### PR TITLE
feat: ContractVersion

### DIFF
--- a/__tests__/cairo1.test.ts
+++ b/__tests__/cairo1.test.ts
@@ -60,6 +60,11 @@ describeIfDevnet('Cairo 1 Devnet', () => {
       expect(cairo1Contract).toBeInstanceOf(Contract);
     });
 
+    test('getCairoVersion', async () => {
+      const version1 = await cairo1Contract.getVersion();
+      expect(version1).toEqual({ cairo: '1', compiler: '1' });
+    });
+
     test('ContractFactory on Cairo1', async () => {
       const c1CFactory = new ContractFactory({
         compiledContract: compiledHelloSierra,

--- a/__tests__/cairo1v2.test.ts
+++ b/__tests__/cairo1v2.test.ts
@@ -41,7 +41,7 @@ const { uint256, tuple, isCairo1Abi } = cairo;
 const { toHex } = num;
 const { starknetKeccak } = selector;
 
-describe('Cairo 1 Devnet', () => {
+describe('Cairo 1', () => {
   const provider = getTestProvider();
   const account = getTestAccount(provider);
   describe('API &  Contract interactions', () => {
@@ -70,6 +70,14 @@ describe('Cairo 1 Devnet', () => {
       expect(dd.deploy).toMatchSchemaRef('DeployContractUDCResponse');
       expect(cairo1Contract).toBeInstanceOf(Contract);
       expect(cairo210Contract).toBeInstanceOf(Contract);
+    });
+
+    test('getCairoVersion', async () => {
+      const version1 = await cairo1Contract.getVersion();
+      expect(version1).toEqual({ cairo: '1', compiler: '2' });
+
+      const version210 = await cairo210Contract.getVersion();
+      expect(version210).toEqual({ cairo: '1', compiler: '2' });
     });
 
     xtest('validate TS for redeclare - skip testing', async () => {

--- a/__tests__/contract.test.ts
+++ b/__tests__/contract.test.ts
@@ -59,6 +59,11 @@ describe('contract module', () => {
         );
       });
 
+      test('getCairoVersion', async () => {
+        const version = await erc20Contract.getVersion();
+        expect(version).toEqual({ cairo: '0', compiler: '0' });
+      });
+
       test('isCairo1', async () => {
         const isContractCairo1: boolean = erc20Contract.isCairo1();
         expect(isContractCairo1).toBe(false);

--- a/__tests__/defaultProvider.test.ts
+++ b/__tests__/defaultProvider.test.ts
@@ -44,6 +44,11 @@ describe('defaultProvider', () => {
       expect(exampleTransactionHash).toBeTruthy();
     });
 
+    test('getContractVersion', async () => {
+      const version = await testProvider.getContractVersion(erc20ContractAddress);
+      expect(version).toEqual({ cairo: '0', compiler: '0' });
+    });
+
     describe('getBlock', () => {
       test('getBlock(blockIdentifier=latest)', async () => {
         expect(exampleBlock).not.toBeNull();

--- a/__tests__/defaultProvider.test.ts
+++ b/__tests__/defaultProvider.test.ts
@@ -45,8 +45,9 @@ describe('defaultProvider', () => {
     });
 
     test('getContractVersion', async () => {
-      const version = await testProvider.getContractVersion(erc20ContractAddress);
-      expect(version).toEqual({ cairo: '0', compiler: '0' });
+      const expected = { cairo: '0', compiler: '0' };
+      expect(await testProvider.getContractVersion(erc20ContractAddress)).toEqual(expected);
+      expect(await testProvider.getContractVersion(undefined, erc20ClassHash)).toEqual(expected);
     });
 
     describe('getBlock', () => {

--- a/src/contract/default.ts
+++ b/src/contract/default.ts
@@ -342,6 +342,10 @@ export class Contract implements ContractInterface {
     return cairo.isCairo1Abi(this.abi);
   }
 
+  public async getVersion() {
+    return this.providerOrAccount.getContractVersion(this.address);
+  }
+
   public typed<TAbi extends AbiKanabi>(tAbi: TAbi): TypedContract<TAbi> {
     return this as TypedContract<typeof tAbi>;
   }

--- a/src/contract/interface.ts
+++ b/src/contract/interface.ts
@@ -9,6 +9,7 @@ import {
   BlockIdentifier,
   CallOptions,
   ContractFunction,
+  ContractVersion,
   EstimateFeeResponse,
   GetTransactionReceiptResponse,
   Invocation,
@@ -131,6 +132,12 @@ export abstract class ContractInterface {
    * ```
    */
   public abstract isCairo1(): boolean;
+
+  /**
+   * Gets contract's version (cairo version & compiler version)
+   * @returns ContractVersion
+   */
+  public abstract getVersion(): Promise<ContractVersion>;
 
   public abstract typed<TAbi extends AbiKanabi>(tAbi: TAbi): TypedContract<TAbi>;
 }

--- a/src/provider/default.ts
+++ b/src/provider/default.ts
@@ -6,6 +6,7 @@ import {
   Call,
   CallContractResponse,
   ContractClassResponse,
+  ContractVersion,
   DeclareContractResponse,
   DeclareContractTransaction,
   DeployAccountContractTransaction,
@@ -224,10 +225,21 @@ export class Provider implements ProviderInterface {
   }
 
   public async getContractVersion(
+    contractAddress: string,
+    classHash?: undefined,
+    options?: getContractVersionOptions
+  ): Promise<ContractVersion>;
+  public async getContractVersion(
+    contractAddress: undefined,
+    classHash: string,
+    options?: getContractVersionOptions
+  ): Promise<ContractVersion>;
+
+  public async getContractVersion(
     contractAddress?: string,
     classHash?: string,
     options?: getContractVersionOptions
   ) {
-    return this.provider.getContractVersion(contractAddress, classHash, options);
+    return this.provider.getContractVersion(contractAddress as any, classHash as any, options);
   }
 }

--- a/src/provider/default.ts
+++ b/src/provider/default.ts
@@ -223,7 +223,11 @@ export class Provider implements ProviderInterface {
     return getAddressFromStarkName(this, name, StarknetIdContract);
   }
 
-  public async getContractVersion(contractAddress: string, options?: getContractVersionOptions) {
-    return this.provider.getContractVersion(contractAddress, options);
+  public async getContractVersion(
+    contractAddress?: string,
+    classHash?: string,
+    options?: getContractVersionOptions
+  ) {
+    return this.provider.getContractVersion(contractAddress, classHash, options);
   }
 }

--- a/src/provider/default.ts
+++ b/src/provider/default.ts
@@ -26,6 +26,7 @@ import {
   SimulateTransactionResponse,
   StateUpdateResponse,
   Storage,
+  getContractVersionOptions,
   getEstimateFeeBulkOptions,
   getSimulateTransactionOptions,
   waitForTransactionOptions,
@@ -220,5 +221,9 @@ export class Provider implements ProviderInterface {
 
   public async getAddressFromStarkName(name: string, StarknetIdContract?: string): Promise<string> {
     return getAddressFromStarkName(this, name, StarknetIdContract);
+  }
+
+  public async getContractVersion(contractAddress: string, options?: getContractVersionOptions) {
+    return this.provider.getContractVersion(contractAddress, options);
   }
 }

--- a/src/provider/interface.ts
+++ b/src/provider/interface.ts
@@ -6,6 +6,7 @@ import type {
   Call,
   CallContractResponse,
   ContractClassResponse,
+  ContractVersion,
   DeclareContractResponse,
   DeclareContractTransaction,
   DeployAccountContractPayload,
@@ -24,6 +25,7 @@ import type {
   SimulateTransactionResponse,
   StateUpdateResponse,
   Storage,
+  getContractVersionOptions,
   getEstimateFeeBulkOptions,
   getSimulateTransactionOptions,
   waitForTransactionOptions,
@@ -330,4 +332,16 @@ export abstract class ProviderInterface {
    * @returns StateUpdateResponse
    */
   public abstract getStateUpdate(blockIdentifier?: BlockIdentifier): Promise<StateUpdateResponse>;
+
+  /**
+   * Gets the contract version from the provided address
+   * @param contractAddress string
+   * @param options - getContractVersionOptions
+   *   - (optional) compiler - (default true) extract compiler version using type tactic from abi
+   *   - (optional) blockIdentifier - block identifier
+   */
+  public abstract getContractVersion(
+    contractAddress: string,
+    options?: getContractVersionOptions
+  ): Promise<ContractVersion>;
 }

--- a/src/provider/interface.ts
+++ b/src/provider/interface.ts
@@ -335,13 +335,15 @@ export abstract class ProviderInterface {
 
   /**
    * Gets the contract version from the provided address
-   * @param contractAddress string
+   * @param contractAddress required if no classHash
+   * @param classHash required if no contractAddress
    * @param options - getContractVersionOptions
    *   - (optional) compiler - (default true) extract compiler version using type tactic from abi
    *   - (optional) blockIdentifier - block identifier
    */
   public abstract getContractVersion(
-    contractAddress: string,
+    contractAddress?: string,
+    classHash?: string,
     options?: getContractVersionOptions
   ): Promise<ContractVersion>;
 }

--- a/src/provider/interface.ts
+++ b/src/provider/interface.ts
@@ -335,15 +335,29 @@ export abstract class ProviderInterface {
 
   /**
    * Gets the contract version from the provided address
-   * @param contractAddress required if no classHash
-   * @param classHash required if no contractAddress
+   * @param contractAddress string
+   * @param classHash undefined
    * @param options - getContractVersionOptions
    *   - (optional) compiler - (default true) extract compiler version using type tactic from abi
    *   - (optional) blockIdentifier - block identifier
    */
   public abstract getContractVersion(
-    contractAddress?: string,
-    classHash?: string,
+    contractAddress: string,
+    classHash?: undefined,
+    options?: getContractVersionOptions
+  ): Promise<ContractVersion>;
+
+  /**
+   * Gets the contract version from the provided address
+   * @param contractAddress undefined
+   * @param classHash
+   * @param options - getContractVersionOptions
+   *   - (optional) compiler - (default true) extract compiler version using type tactic from abi
+   *   - (optional) blockIdentifier - block identifier
+   */
+  public abstract getContractVersion(
+    contractAddress: undefined,
+    classHash: string,
     options?: getContractVersionOptions
   ): Promise<ContractVersion>;
 }

--- a/src/provider/rpc.ts
+++ b/src/provider/rpc.ts
@@ -12,6 +12,7 @@ import {
   Call,
   CallContractResponse,
   ContractClassResponse,
+  ContractVersion,
   DeclareContractResponse,
   DeclareContractTransaction,
   DeployAccountContractTransaction,
@@ -256,14 +257,14 @@ export class RpcProvider implements ProviderInterface {
   public async getContractVersion(
     contractAddress: string,
     { blockIdentifier = this.blockIdentifier, compiler = true }: getContractVersionOptions
-  ) {
+  ): Promise<ContractVersion> {
     const contractClass = await this.getClassAt(contractAddress, blockIdentifier);
     if (isSierra(contractClass)) {
       if (compiler) {
         const abiTest = getAbiContractVersion(contractClass.abi);
         return { cairo: '1', compiler: abiTest.compiler };
       }
-      return { cairo: '1', compiler: 'unknown' };
+      return { cairo: '1', compiler: undefined };
     }
     return { cairo: '0', compiler: '0' };
   }

--- a/src/provider/rpc.ts
+++ b/src/provider/rpc.ts
@@ -256,9 +256,18 @@ export class RpcProvider implements ProviderInterface {
 
   public async getContractVersion(
     contractAddress: string,
+    classHash: string,
     { blockIdentifier = this.blockIdentifier, compiler = true }: getContractVersionOptions
   ): Promise<ContractVersion> {
-    const contractClass = await this.getClassAt(contractAddress, blockIdentifier);
+    let contractClass;
+    if (contractAddress) {
+      contractClass = await this.getClassAt(contractAddress, blockIdentifier);
+    } else if (classHash) {
+      contractClass = await this.getClass(classHash, blockIdentifier);
+    } else {
+      throw Error('getContractVersion require contractAddress or classHash');
+    }
+
     if (isSierra(contractClass)) {
       if (compiler) {
         const abiTest = getAbiContractVersion(contractClass.abi);

--- a/src/provider/rpc.ts
+++ b/src/provider/rpc.ts
@@ -255,6 +255,17 @@ export class RpcProvider implements ProviderInterface {
   }
 
   public async getContractVersion(
+    contractAddress: string,
+    classHash?: undefined,
+    options?: getContractVersionOptions
+  ): Promise<ContractVersion>;
+  public async getContractVersion(
+    contractAddress: undefined,
+    classHash: string,
+    options?: getContractVersionOptions
+  ): Promise<ContractVersion>;
+
+  public async getContractVersion(
     contractAddress?: string,
     classHash?: string,
     { blockIdentifier = this.blockIdentifier, compiler = true }: getContractVersionOptions = {}

--- a/src/provider/sequencer.ts
+++ b/src/provider/sequencer.ts
@@ -346,13 +346,22 @@ export class SequencerProvider implements ProviderInterface {
   }
 
   public async getContractVersion(
-    contractAddress: string,
+    contractAddress?: string,
+    classHash?: string,
     { blockIdentifier, compiler }: getContractVersionOptions = {
       blockIdentifier: this.blockIdentifier,
       compiler: true,
     }
   ): Promise<ContractVersion> {
-    const contractClass = await this.getClassAt(contractAddress, blockIdentifier);
+    let contractClass;
+    if (contractAddress) {
+      contractClass = await this.getClassAt(contractAddress, blockIdentifier);
+    } else if (classHash) {
+      contractClass = await this.getClassByHash(classHash, blockIdentifier);
+    } else {
+      throw Error('getContractVersion require contractAddress or classHash');
+    }
+
     if (isSierra(contractClass)) {
       if (compiler) {
         const abiTest = getAbiContractVersion(contractClass.abi);

--- a/src/provider/sequencer.ts
+++ b/src/provider/sequencer.ts
@@ -346,6 +346,17 @@ export class SequencerProvider implements ProviderInterface {
   }
 
   public async getContractVersion(
+    contractAddress: string,
+    classHash?: undefined,
+    options?: getContractVersionOptions
+  ): Promise<ContractVersion>;
+  public async getContractVersion(
+    contractAddress: undefined,
+    classHash: string,
+    options?: getContractVersionOptions
+  ): Promise<ContractVersion>;
+
+  public async getContractVersion(
     contractAddress?: string,
     classHash?: string,
     { blockIdentifier = this.blockIdentifier, compiler = true }: getContractVersionOptions = {}

--- a/src/provider/sequencer.ts
+++ b/src/provider/sequencer.ts
@@ -349,7 +349,6 @@ export class SequencerProvider implements ProviderInterface {
     contractAddress?: string,
     classHash?: string,
     { blockIdentifier = this.blockIdentifier, compiler = true }: getContractVersionOptions = {}
-    }
   ): Promise<ContractVersion> {
     let contractClass;
     if (contractAddress) {

--- a/src/provider/sequencer.ts
+++ b/src/provider/sequencer.ts
@@ -12,6 +12,7 @@ import {
   CallContractResponse,
   CallL1Handler,
   ContractClassResponse,
+  ContractVersion,
   DeclareContractResponse,
   DeclareContractTransaction,
   DeployAccountContractTransaction,
@@ -350,14 +351,14 @@ export class SequencerProvider implements ProviderInterface {
       blockIdentifier: this.blockIdentifier,
       compiler: true,
     }
-  ) {
+  ): Promise<ContractVersion> {
     const contractClass = await this.getClassAt(contractAddress, blockIdentifier);
     if (isSierra(contractClass)) {
       if (compiler) {
         const abiTest = getAbiContractVersion(contractClass.abi);
         return { cairo: '1', compiler: abiTest.compiler };
       }
-      return { cairo: '1', compiler: 'unknown' };
+      return { cairo: '1', compiler: undefined };
     }
     return { cairo: '0', compiler: '0' };
   }

--- a/src/types/lib/index.ts
+++ b/src/types/lib/index.ts
@@ -230,6 +230,11 @@ export type getSimulateTransactionOptions = {
   skipFeeCharge?: boolean;
 };
 
+export type getContractVersionOptions = {
+  blockIdentifier?: BlockIdentifier;
+  compiler?: boolean;
+};
+
 export type getEstimateFeeBulkOptions = {
   blockIdentifier?: BlockIdentifier;
   skipValidate?: boolean;
@@ -240,5 +245,15 @@ export interface CallStruct {
   selector: string;
   calldata: string[];
 }
+
+/**
+ * Represent Contract version
+ * cairo: version of the cairo language
+ * compiler: version of the cairo compiler used to compile the contract
+ */
+export type ContractVersion = {
+  cairo: string | 'unknown';
+  compiler: string | 'unknown';
+};
 
 export * from './contract';

--- a/src/types/lib/index.ts
+++ b/src/types/lib/index.ts
@@ -105,7 +105,8 @@ export type Invocation = CallDetails & { signature?: Signature };
 
 export type Call = CallDetails & { entrypoint: string };
 
-export type CairoVersion = '0' | '1';
+export type CairoVersion = '0' | '1' | undefined;
+export type CompilerVersion = '0' | '1' | '2' | undefined;
 
 export type InvocationsDetails = {
   nonce?: BigNumberish;
@@ -252,8 +253,8 @@ export interface CallStruct {
  * compiler: version of the cairo compiler used to compile the contract
  */
 export type ContractVersion = {
-  cairo: string | 'unknown';
-  compiler: string | 'unknown';
+  cairo: CairoVersion;
+  compiler: CompilerVersion;
 };
 
 export * from './contract';

--- a/src/utils/calldata/cairo.ts
+++ b/src/utils/calldata/cairo.ts
@@ -1,4 +1,13 @@
-import { Abi, AbiEnums, AbiStructs, BigNumberish, Litteral, Uint, Uint256 } from '../../types';
+import {
+  Abi,
+  AbiEnums,
+  AbiStructs,
+  BigNumberish,
+  ContractVersion,
+  Litteral,
+  Uint,
+  Uint256,
+} from '../../types';
 import { isBigInt, isHex, isStringWholeNumber } from '../num';
 import { encodeShortString, isShortString, isText } from '../shortString';
 import { UINT_128_MAX, isUint256 } from '../uint256';
@@ -57,6 +66,33 @@ export function isCairo1Abi(abi: Abi): boolean {
     return isCairo1Type(firstFunction.outputs[0].type);
   }
   throw new Error(`Error in ABI. No input/output in function ${firstFunction.name}`);
+}
+
+/**
+ * Return ContractVersion (Abi version) based on Abi
+ * or undefined for unknown version
+ * @param abi
+ * @returns string
+ */
+export function getAbiContractVersion(abi: Abi): ContractVersion {
+  // determine by interface for "Cairo 1.2"
+  if (abi.find((it) => it.type === 'interface')) {
+    return { cairo: '1', compiler: '2' };
+  }
+
+  // determine by function io types "Cairo 1.1" or "Cairo 0.0"
+  // find first function with inputs or outputs
+  const testFunction = abi.find(
+    (it) => it.type === 'function' && (it.inputs.length || it.outputs.length)
+  );
+  if (!testFunction) {
+    return { cairo: 'unknown', compiler: 'unknown' };
+  }
+  const io = testFunction.inputs.length ? testFunction.inputs : testFunction.outputs;
+  if (isCairo1Type(io[0].type)) {
+    return { cairo: '1', compiler: '1' };
+  }
+  return { cairo: '0', compiler: '0' };
 }
 
 /**

--- a/src/utils/calldata/cairo.ts
+++ b/src/utils/calldata/cairo.ts
@@ -86,7 +86,7 @@ export function getAbiContractVersion(abi: Abi): ContractVersion {
     (it) => it.type === 'function' && (it.inputs.length || it.outputs.length)
   );
   if (!testFunction) {
-    return { cairo: 'unknown', compiler: 'unknown' };
+    return { cairo: undefined, compiler: undefined };
   }
   const io = testFunction.inputs.length ? testFunction.inputs : testFunction.outputs;
   if (isCairo1Type(io[0].type)) {

--- a/src/utils/calldata/cairo.ts
+++ b/src/utils/calldata/cairo.ts
@@ -51,21 +51,11 @@ export const getArrayType = (type: string) => {
  * ```
  */
 export function isCairo1Abi(abi: Abi): boolean {
-  const firstFunction = abi.find((entry) => entry.type === 'function');
-  if (!firstFunction) {
-    if (abi.find((it) => it.type === 'interface')) {
-      // Expected in Cairo1 version 2
-      return true;
-    }
-    throw new Error(`Error in ABI. No function in ABI.`);
+  const { cairo } = getAbiContractVersion(abi);
+  if (cairo === undefined) {
+    throw Error('Unable to determine Cairo version');
   }
-  if (firstFunction.inputs.length) {
-    return isCairo1Type(firstFunction.inputs[0].type);
-  }
-  if (firstFunction.outputs.length) {
-    return isCairo1Type(firstFunction.outputs[0].type);
-  }
-  throw new Error(`Error in ABI. No input/output in function ${firstFunction.name}`);
+  return cairo === '1';
 }
 
 /**


### PR DESCRIPTION
## Motivation and Resolution
Account cairoVersion default ~~0~~ -> undefined
Default cairoVersion will be undefined and Account will 'auto-detect' and set it on the first request.
This is backward compatible and less prone to bugs due to an incorrect Cairo version on the account.
The drawback is only one API Call for the first time setting it.
If the Cairo version is explicitly defined by the user, there are no changes.

New methods:
Account ``getCairoVersion()`` - return Cairo version for the Account
Account ``getCairoVersion(classHash)`` - return Cairo version for the Account by classHash
Provider ``getContractVersion(contractAddress)``- return Cairo and compiler version
Provider ``getContractVersion(undefined, classHash)``- return Cairo and compiler version by classHash
Contract ``getVersion()`` - return Contract's Cairo and compiler version, 
Utils cairo getAbiContractVersion(abi: Abi) - return Cairo and compiler version based on Abi

fix #759
Resolve general Contract versioning detecting (Contract Interaction)
Remove the necessity for Account default cairoVersion

## Usage related changes
New methods Interface update
New types ``ContractVersion`` & ``getContractVersionOptions``

## Development related changes
Inside Account don't use cairoVersion use getCairoVersion() instead

## Checklist:

- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Linked the issues which this PR resolves
- [ ] Documented the changes in code (API docs will be generated automatically)
- [x] Updated the tests
- [x] All tests are passing
