### PR TITLE
refactor: parse int as number or big int

### DIFF
--- a/src/utils/json.ts
+++ b/src/utils/json.ts
@@ -6,9 +6,17 @@ import * as json from 'lossless-json';
  * Convert string to number or bigint based on size
  */
 const parseIntAsNumberOrBigInt = (x: string) => {
-  if (!json.isInteger(x)) return parseFloat(x);
+  if (!Number.isInteger(Number(x))) {
+    return parseFloat(x);
+  }
+
   const v = parseInt(x, 10);
-  return Number.isSafeInteger(v) ? v : BigInt(x);
+
+  if (Number.isSafeInteger(v)) {
+    return v;
+  }
+
+  return BigInt(x);
 };
 
 /**


### PR DESCRIPTION

## Development related changes

1.Use Number.isInteger to check if the input can be parsed as an integer, and if not, we parse it as a float.
2.Use Number(x) to convert the string to a number for checking integer type.
3.Split the condition and result into separate lines for improved readability.
4.Use Number.isSafeInteger to check if the parsed integer is within the safe integer range.
4.If it's a safe integer, we return it as a regular number; otherwise, we return it as a BigInt.

## Checklist:

- [ ] Performed a self-review of the code
- [ ] Rebased to the last commit of the target branch (or merged it into my branch)
- [ ] Linked the issues which this PR resolves
- [ ] Documented the changes in code (API docs will be generated automatically)
- [ ] Updated the tests
- [ ] All tests are passing
