### PR TITLE
Deprecations & Default RPC Provider

### DIFF
--- a/__tests__/fixtures.ts
+++ b/__tests__/fixtures.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
-import { Account, ProviderInterface, RpcProvider, SequencerProvider, json } from '../src';
+import { Account, ProviderInterface, RpcProvider, json } from '../src';
 import {
   CompiledSierra,
   CompiledSierraCasm,
@@ -47,10 +47,7 @@ export const compiledC210 = readContractSierra('cairo/cairo210/cairo210.sierra')
 export const compiledC210Casm = readContractSierraCasm('cairo/cairo210/cairo210');
 
 export const getTestProvider = (): ProviderInterface => {
-  const provider = process.env.TEST_RPC_URL
-    ? new RpcProvider({ nodeUrl: process.env.TEST_RPC_URL })
-    : new SequencerProvider({ baseUrl: process.env.TEST_PROVIDER_BASE_URL || '' });
-
+  const provider = new RpcProvider({ nodeUrl: process.env.TEST_RPC_URL });
   if (process.env.IS_LOCALHOST_DEVNET) {
     // accelerate the tests when running locally
     const originalWaitForTransaction = provider.waitForTransaction.bind(provider);

--- a/__tests__/fixtures.ts
+++ b/__tests__/fixtures.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
-import { Account, ProviderInterface, RpcProvider, json } from '../src';
+import { Account, ProviderInterface, RpcProvider, SequencerProvider, json } from '../src';
 import {
   CompiledSierra,
   CompiledSierraCasm,
@@ -47,7 +47,10 @@ export const compiledC210 = readContractSierra('cairo/cairo210/cairo210.sierra')
 export const compiledC210Casm = readContractSierraCasm('cairo/cairo210/cairo210');
 
 export const getTestProvider = (): ProviderInterface => {
-  const provider = new RpcProvider({ nodeUrl: process.env.TEST_RPC_URL });
+  const provider = process.env.TEST_RPC_URL
+    ? new RpcProvider({ nodeUrl: process.env.TEST_RPC_URL })
+    : new SequencerProvider({ baseUrl: process.env.TEST_PROVIDER_BASE_URL || '' });
+
   if (process.env.IS_LOCALHOST_DEVNET) {
     // accelerate the tests when running locally
     const originalWaitForTransaction = provider.waitForTransaction.bind(provider);

--- a/__tests__/jestGlobalSetup.ts
+++ b/__tests__/jestGlobalSetup.ts
@@ -5,6 +5,7 @@
  * ref: order of execution jestGlobalSetup.ts -> jest.setup.ts -> fixtures.ts
  */
 
+import { getDefaultNodeUrl } from '../src';
 import { BaseUrl } from '../src/constants';
 
 type DevnetStrategy = {
@@ -155,16 +156,15 @@ const verifySetup = (final?: boolean) => {
     if (final) throw new Error('TEST_ACCOUNT_PRIVATE_KEY env is not provided');
     else warnings.push('TEST_ACCOUNT_PRIVATE_KEY env is not provided!');
   }
-  if (!process.env.TEST_PROVIDER_BASE_URL && !process.env.TEST_RPC_URL) {
-    if (final) throw new Error('One of TEST_PROVIDER_BASE_URL or TEST_RPC_URL env is not provided');
-    else warnings.push('TEST_PROVIDER_BASE_URL or TEST_RPC_URL env is not provided!');
+  if (!process.env.TEST_RPC_URL) {
+    process.env.TEST_RPC_URL = getDefaultNodeUrl();
+    console.warn('TEST_RPC_URL env is not provided');
   }
 
   if (warnings.length > 0) {
     console.log('\x1b[33m', warnings.join('\n'), '\x1b[0m');
     delete process.env.TEST_ACCOUNT_ADDRESS;
     delete process.env.TEST_ACCOUNT_PRIVATE_KEY;
-    delete process.env.TEST_PROVIDER_BASE_URL;
     return false;
   }
 
@@ -213,7 +213,7 @@ const executeStrategy = async () => {
     return true;
   }
 
-  // 2. Try to detect setup
+  // 2. Try to detect devnet setup
   console.log('Basic test parameters are missing, Auto Setup Started');
   const devnetStrategy = await localDevnetDetectionStrategy();
   if (devnetStrategy.isDevnet) {
@@ -242,6 +242,4 @@ const executeStrategy = async () => {
 export default async (_globalConfig: any, _projectConfig: any) => {
   const isSet = await executeStrategy();
   if (!isSet) console.error('Test Setup Environment is NOT Ready');
-  // SET GLOBALS
-  process.env.GS_DEFAULT_TEST_PROVIDER_URL = GS_DEFAULT_TEST_PROVIDER_URL;
 };

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -48,11 +48,11 @@ export const UDC = {
 export const RPC_GOERLI_NODES = [
   'https://starknet-testnet.public.blastapi.io/rpc/v0.5',
   'https://rpc.starknet-testnet.lava.build/rpc/v0.5',
-  // 'http://limited-rpc.nethermind.io/goerli-juno/v0_5',
+  'https://limited-rpc.nethermind.io/goerli-juno/v0_5',
 ];
 
 export const RPC_MAINNET_NODES = [
   'https://starknet-mainnet.public.blastapi.io',
   'https://rpc.starknet.lava.build',
-  // 'http://limited-rpc.nethermind.io/mainnet-juno/v0_5',
+  'https://limited-rpc.nethermind.io/mainnet-juno/v0_5',
 ];

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -47,12 +47,10 @@ export const UDC = {
 
 export const RPC_GOERLI_NODES = [
   'https://starknet-testnet.public.blastapi.io/rpc/v0.5',
-  'https://rpc.starknet-testnet.lava.build/rpc/v0.5',
   'https://limited-rpc.nethermind.io/goerli-juno/v0_5',
 ];
 
 export const RPC_MAINNET_NODES = [
   'https://starknet-mainnet.public.blastapi.io/rpc/v0.5',
-  'https://rpc.starknet.lava.build/rpc/v0.5',
   'https://limited-rpc.nethermind.io/mainnet-juno/v0_5',
 ];

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -46,13 +46,13 @@ export const UDC = {
 };
 
 export const RPC_GOERLI_NODES = [
-  'https://starknet-testnet.public.blastapi.io',
-  'https://rpc.starknet-testnet.lava.build',
-  'http://limited-rpc.nethermind.io/goerli-juno',
+  'https://starknet-testnet.public.blastapi.io/rpc/v0.5',
+  'https://rpc.starknet-testnet.lava.build/rpc/v0.5',
+  // 'http://limited-rpc.nethermind.io/goerli-juno/v0_5',
 ];
 
 export const RPC_MAINNET_NODES = [
   'https://starknet-mainnet.public.blastapi.io',
   'https://rpc.starknet.lava.build',
-  'http://limited-rpc.nethermind.io/mainnet-juno/',
+  // 'http://limited-rpc.nethermind.io/mainnet-juno/v0_5',
 ];

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -52,7 +52,7 @@ export const RPC_GOERLI_NODES = [
 ];
 
 export const RPC_MAINNET_NODES = [
-  'https://starknet-mainnet.public.blastapi.io',
-  'https://rpc.starknet.lava.build',
+  'https://starknet-mainnet.public.blastapi.io/rpc/v0.5',
+  'https://rpc.starknet.lava.build/rpc/v0.5',
   'https://limited-rpc.nethermind.io/mainnet-juno/v0_5',
 ];

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -44,3 +44,15 @@ export const UDC = {
   ADDRESS: '0x041a78e741e5af2fec34b695679bc6891742439f7afb8484ecd7766661ad02bf',
   ENTRYPOINT: 'deployContract',
 };
+
+export const RPC_GOERLI_NODES = [
+  'https://starknet-testnet.public.blastapi.io',
+  'https://rpc.starknet-testnet.lava.build',
+  'http://limited-rpc.nethermind.io/goerli-juno',
+];
+
+export const RPC_MAINNET_NODES = [
+  'https://starknet-mainnet.public.blastapi.io',
+  'https://rpc.starknet.lava.build',
+  'http://limited-rpc.nethermind.io/mainnet-juno/',
+];

--- a/src/provider/default.ts
+++ b/src/provider/default.ts
@@ -23,7 +23,6 @@ import {
   Nonce,
   ProviderOptions,
   RpcProviderOptions,
-  SequencerProviderOptions,
   SimulateTransactionResponse,
   StateUpdateResponse,
   Storage,
@@ -34,7 +33,6 @@ import {
 } from '../types';
 import { ProviderInterface } from './interface';
 import { RpcProvider } from './rpc';
-import { SequencerProvider } from './sequencer';
 import { getAddressFromStarkName, getStarkName } from './starknetId';
 
 export class Provider implements ProviderInterface {
@@ -44,21 +42,15 @@ export class Provider implements ProviderInterface {
     if (providerOrOptions instanceof Provider) {
       // providerOrOptions is Provider
       this.provider = providerOrOptions.provider;
-    } else if (
-      providerOrOptions instanceof RpcProvider ||
-      providerOrOptions instanceof SequencerProvider
-    ) {
+    } else if (providerOrOptions instanceof RpcProvider) {
       // providerOrOptions is SequencerProvider or RpcProvider
       this.provider = <ProviderInterface>providerOrOptions;
     } else if (providerOrOptions && 'rpc' in providerOrOptions) {
       // providerOrOptions is rpc option
       this.provider = new RpcProvider(<RpcProviderOptions>providerOrOptions.rpc);
-    } else if (providerOrOptions && 'sequencer' in providerOrOptions) {
-      // providerOrOptions is sequencer option
-      this.provider = new SequencerProvider(<SequencerProviderOptions>providerOrOptions.sequencer);
     } else {
       // providerOrOptions is none, create SequencerProvider as default
-      this.provider = new SequencerProvider();
+      this.provider = new RpcProvider();
     }
   }
 

--- a/src/provider/default.ts
+++ b/src/provider/default.ts
@@ -43,13 +43,13 @@ export class Provider implements ProviderInterface {
       // providerOrOptions is Provider
       this.provider = providerOrOptions.provider;
     } else if (providerOrOptions instanceof RpcProvider) {
-      // providerOrOptions is SequencerProvider or RpcProvider
+      // providerOrOptions is RpcProvider
       this.provider = <ProviderInterface>providerOrOptions;
     } else if (providerOrOptions && 'rpc' in providerOrOptions) {
       // providerOrOptions is rpc option
       this.provider = new RpcProvider(<RpcProviderOptions>providerOrOptions.rpc);
     } else {
-      // providerOrOptions is none, create SequencerProvider as default
+      // providerOrOptions is none, create RpcProvider as default
       this.provider = new RpcProvider();
     }
   }

--- a/src/provider/default.ts
+++ b/src/provider/default.ts
@@ -23,6 +23,7 @@ import {
   Nonce,
   ProviderOptions,
   RpcProviderOptions,
+  SequencerProviderOptions,
   SimulateTransactionResponse,
   StateUpdateResponse,
   Storage,
@@ -33,8 +34,12 @@ import {
 } from '../types';
 import { ProviderInterface } from './interface';
 import { RpcProvider } from './rpc';
+import { SequencerProvider } from './sequencer';
 import { getAddressFromStarkName, getStarkName } from './starknetId';
 
+/**
+ * @deprecated Use RpcProvider instead. Common Provider will be removed with Sequencer provider.
+ */
 export class Provider implements ProviderInterface {
   private provider!: ProviderInterface;
 
@@ -42,14 +47,20 @@ export class Provider implements ProviderInterface {
     if (providerOrOptions instanceof Provider) {
       // providerOrOptions is Provider
       this.provider = providerOrOptions.provider;
-    } else if (providerOrOptions instanceof RpcProvider) {
-      // providerOrOptions is RpcProvider
+    } else if (
+      providerOrOptions instanceof RpcProvider ||
+      providerOrOptions instanceof SequencerProvider
+    ) {
+      // providerOrOptions is SequencerProvider or RpcProvider
       this.provider = <ProviderInterface>providerOrOptions;
     } else if (providerOrOptions && 'rpc' in providerOrOptions) {
       // providerOrOptions is rpc option
       this.provider = new RpcProvider(<RpcProviderOptions>providerOrOptions.rpc);
+    } else if (providerOrOptions && 'sequencer' in providerOrOptions) {
+      // providerOrOptions is sequencer option
+      this.provider = new SequencerProvider(<SequencerProviderOptions>providerOrOptions.sequencer);
     } else {
-      // providerOrOptions is none, create RpcProvider as default
+      // providerOrOptions is none, create SequencerProvider as default
       this.provider = new RpcProvider();
     }
   }

--- a/src/provider/rpc.ts
+++ b/src/provider/rpc.ts
@@ -43,13 +43,14 @@ import { ProviderInterface } from './interface';
 import { getAddressFromStarkName, getStarkName } from './starknetId';
 import { Block } from './utils';
 
-const getDefaultNodeUrl = (networkName?: NetworkName): string => {
+export const getDefaultNodeUrl = (networkName?: NetworkName): string => {
   // eslint-disable-next-line no-console
   console.warn('Using default public node url, please provide nodeUrl in provider options!');
-  const randIdx = Math.floor(Math.random() * 3);
   if (networkName && NetworkName.SN_MAIN === networkName) {
+    const randIdx = Math.floor(Math.random() * RPC_MAINNET_NODES.length);
     return RPC_MAINNET_NODES[randIdx];
   }
+  const randIdx = Math.floor(Math.random() * RPC_GOERLI_NODES.length);
   return RPC_GOERLI_NODES[randIdx];
 };
 

--- a/src/provider/rpc.ts
+++ b/src/provider/rpc.ts
@@ -46,12 +46,9 @@ import { Block } from './utils';
 export const getDefaultNodeUrl = (networkName?: NetworkName): string => {
   // eslint-disable-next-line no-console
   console.warn('Using default public node url, please provide nodeUrl in provider options!');
-  if (networkName && NetworkName.SN_MAIN === networkName) {
-    const randIdx = Math.floor(Math.random() * RPC_MAINNET_NODES.length);
-    return RPC_MAINNET_NODES[randIdx];
-  }
-  const randIdx = Math.floor(Math.random() * RPC_GOERLI_NODES.length);
-  return RPC_GOERLI_NODES[randIdx];
+  const nodes = networkName === NetworkName.SN_MAIN ? RPC_MAINNET_NODES : RPC_GOERLI_NODES;
+  const randIdx = Math.floor(Math.random() * nodes.length);
+  return nodes[randIdx];
 };
 
 const defaultOptions = {
@@ -75,14 +72,14 @@ export class RpcProvider implements ProviderInterface {
 
   constructor(optionsOrProvider?: RpcProviderOptions) {
     const { nodeUrl, retries, headers, blockIdentifier, chainId } = optionsOrProvider || {};
-    if ((<any>Object).values(NetworkName).includes(nodeUrl)) {
+    if (Object.values(NetworkName).includes(nodeUrl as NetworkName)) {
       // Network name provided for nodeUrl
       this.nodeUrl = getDefaultNodeUrl(nodeUrl as NetworkName);
     } else if (nodeUrl) {
       // NodeUrl provided
       this.nodeUrl = nodeUrl;
     } else {
-      // non provided fallback to default testnet
+      // none provided fallback to default testnet
       this.nodeUrl = getDefaultNodeUrl();
     }
     this.retries = retries || defaultOptions.retries;

--- a/src/types/provider/configuration.ts
+++ b/src/types/provider/configuration.ts
@@ -7,7 +7,7 @@ export interface ProviderOptions {
 }
 
 export type RpcProviderOptions = {
-  nodeUrl: string;
+  nodeUrl: string | NetworkName;
   retries?: number;
   headers?: object;
   blockIdentifier?: BlockIdentifier;

--- a/src/types/provider/configuration.ts
+++ b/src/types/provider/configuration.ts
@@ -7,7 +7,7 @@ export interface ProviderOptions {
 }
 
 export type RpcProviderOptions = {
-  nodeUrl: string | NetworkName;
+  nodeUrl?: string | NetworkName;
   retries?: number;
   headers?: object;
   blockIdentifier?: BlockIdentifier;


### PR DESCRIPTION
## Motivation and Resolution
fix https://github.com/starknet-io/starknet.js/issues/803
- [x] Set default provider to RPC Provider
- [x] Update RPC Provider with option 'empty nodeUrl' - will use random public goerli nodeUrl from the known nodes
- [x] Update RPC Provider with option 'NetworkName for nodeUrl' - provide NetworkName and random public nodeUrl will be used for specific network
- [x] Updated test setup for default RPC Provider and new options

### RPC version (if applicable)
0.5

## Usage related changes
mentioned

## Checklist:

- [ ] Performed a self-review of the code
- [ ] Rebased to the last commit of the target branch (or merged it into my branch)
- [ ] Linked the issues which this PR resolves
- [ ] Documented the changes in code (API docs will be generated automatically)
- [ ] Updated the tests
- [ ] All tests are passing
