### PR TITLE
docs: Update broken links in intro docs.

### DIFF
--- a/www/docs/guides/L1message.md
+++ b/www/docs/guides/L1message.md
@@ -7,7 +7,7 @@ sidebar_position: 13
 You can exchange messages between L1 & L2 networks:
 
 - L2 Starknet mainnet ↔️ L1 Ethereum.
-- L2 Starknet testnet 1 & 2 ↔️ L1 Goerli ETH testnet.
+- L2 Starknet testnet ↔️ L1 Goerli ETH testnet.
 - L2 local Starknet devnet ↔️ L1 local ETH testnet (Ganache, ...).
 
 You can find an explanation of the global mechanism [here](https://docs.starknet.io/documentation/architecture_and_concepts/L1-L2_Communication/messaging-mechanism/).
@@ -36,7 +36,7 @@ You have to pay in the L1 an extra fee when invoking `sendMessageToL2` (of cours
 
 ```typescript
 import { SequencerProvider } from "starknet";
-const provider = new SequencerProvider({ baseUrl: constants.BaseUrl.SN_GOERLI }); // for testnet 1
+const provider = new SequencerProvider({ baseUrl: constants.BaseUrl.SN_GOERLI }); // for testnet
 
 const responseEstimateMessageFee = await provider.estimateMessageFee({
     from_address: L1address,

--- a/www/docs/guides/connect_account.md
+++ b/www/docs/guides/connect_account.md
@@ -68,7 +68,7 @@ import * as dotenv from "dotenv";
 dotenv.config();
 
 // initialize provider
-const provider = new Provider({ sequencer: { network: constants.NetworkName.SN_GOERLI2  } });
+const provider = new Provider({ sequencer: { network: constants.NetworkName.SN_GOERLI  } });
 // initialize existing account
 const privateKey = process.env.OZ_NEW_ACCOUNT_PRIVKEY;
 const accountAddress = "0x051158d244c7636dde39ec822873b29e6c9a758c6a9812d005b6287564908667";

--- a/www/docs/guides/connect_network.md
+++ b/www/docs/guides/connect_network.md
@@ -18,14 +18,13 @@ import {Provider} from 'starknet';
 const provider = new Provider({ sequencer: { network: constants.NetworkName.SN_MAIN } })
 ```
 
-## Connect your DAPP to Starknet testnet 1 & 2
+## Connect your DAPP to Starknet testnet
 
 ```typescript
-const provider = new Provider({ sequencer: { network: constants.NetworkName.SN_GOERLI } }) // for testnet 1
-const provider = new Provider({ sequencer: { network: constants.NetworkName.SN_GOERLI2 } })  // for testnet 2
+const provider = new Provider({ sequencer: { network: constants.NetworkName.SN_GOERLI } }) // for testnet
 ```
 
-## Connect your DAPP to Starknet-devnet
+## Connect your DAPP to Starknet devnet
 
 ```typescript
 const provider = new Provider({ sequencer: { baseUrl:"http://127.0.0.1:5050"} });
@@ -110,7 +109,7 @@ For example, if you want to estimate the fee of an L1 ➡️ L2 message, you nee
 
 ```typescript
 import { SequencerProvider, constants } from "starknet";
-const provider = new SequencerProvider({ baseUrl: constants.BaseUrl.SN_GOERLI2 }); // for testnet 2
+const provider = new SequencerProvider({ baseUrl: constants.BaseUrl.SN_GOERLI }); // for testnet
 const responseEstimateMessageFee = await provider.estimateMessageFee(.....)
 ```
 

--- a/www/docs/guides/create_account.md
+++ b/www/docs/guides/create_account.md
@@ -20,7 +20,7 @@ Creating an account is a bit tricky; you have several steps:
 
 > Level: easy.
 
-Here, we will create a wallet with the Open Zeppelin smart contract v0.5.1. The contract class is already implemented in both Testnet 1 & 2.  
+Here, we will create a wallet with the Open Zeppelin smart contract v0.5.1. The contract class is already implemented in Testnet.  
 This contract is coded in Cairo 0, so it will not survive the upcoming re-genesis of Starknet.
 
 ```typescript
@@ -97,7 +97,7 @@ const OZaccount = new Account(provider, OZcontractAddress, privateKey, "1");
 
 > Level: medium.
 
-Here, we will create a wallet with the Argent smart contract v0.2.3. This case is more complicated because we will have the account behind a proxy contract (this way, the wallet contract can be updated). The contract classes of both contracts are already implemented in both Testnet 1 & 2.
+Here, we will create a wallet with the Argent smart contract v0.2.3. This case is more complicated because we will have the account behind a proxy contract (this way, the wallet contract can be updated). The contract classes of both contracts are already implemented in Testnet.
 
 > If necessary OZ contracts can also be created with a proxy.
 

--- a/www/docs/guides/intro.md
+++ b/www/docs/guides/intro.md
@@ -65,9 +65,9 @@ Additional helpful resources can also be found at <ins>[OpenZeppelin](https://do
 
 ## Full example with account & erc20 deployments
 
-Please take a look at our workshop using OpenZeppelin contracts <ins>[here](https://github.com/starknet-io/starknet.js-workshop)</ins>.
+Please take a look at our workshop using OpenZeppelin contracts <ins>[here](https://github.com/0xs34n/starknet.js-workshop)</ins>.
 
-Example with the Argent contract <ins>[here](https://github.com/starknet-io/starknet.js-account)</ins>.
+Example with the Argent contract <ins>[here](https://github.com/0xs34n/starknet.js-account)</ins>.
 
 ## Contracts used in the guides
 

--- a/www/docs/guides/intro.md
+++ b/www/docs/guides/intro.md
@@ -20,13 +20,14 @@ npm install starknet@next
 
 ### With Devnet
 
-The example devnet version is `0.5.3`.
+- Sequencer Devnet [docs](https://0xspaceshard.github.io/starknet-devnet/docs/intro)
+- RPC Devnet [repo](https://github.com/0xSpaceShard/starknet-devnet-rs)
 
-Get devnet with docker:
+Get the Sequencer Devnet with Docker:
 
 ```bash
-docker pull shardlabs/starknet-devnet:0.5.3
-docker run -p 5050:5050 shardlabs/starknet-devnet:0.5.3 --seed 0
+docker pull shardlabs/starknet-devnet:latest
+docker run -p 5050:5050 shardlabs/starknet-devnet:latest --seed 0
 ```
 
 Open a new console tab, go to your starknet.js directory, and run:
@@ -63,12 +64,12 @@ Please check the Starknet documentation <ins>[here](https://docs.starknet.io/doc
 
 Additional helpful resources can also be found at <ins>[OpenZeppelin](https://docs.openzeppelin.com/contracts-cairo/0.6.1/)</ins> documentation site.
 
-## Full example with account & erc20 deployments
+## Interacting with contracts and accounts
 
-Please take a look at our workshop using OpenZeppelin contracts <ins>[here](https://github.com/0xs34n/starknet.js-workshop)</ins>.
+For a basic overview on how to interact with contracts and accounts continue following this guide.
 
-Example with the Argent contract <ins>[here](https://github.com/0xs34n/starknet.js-account)</ins>.
+For some more extensive examples visit PhilippeR26's <ins>[workshop](https://github.com/PhilippeR26/starknet.js-workshop-typescript)</ins>.
 
 ## Contracts used in the guides
 
-You can find the compiled contracts used in these guides in `compiled_contracts` directory.
+You can find the compiled contracts used in these guides in the <ins>[compiled_contracts](https://github.com/starknet-io/starknet.js/tree/develop/www/docs/guides/compiled_contracts)</ins> directory.

--- a/www/docs/guides/signature.md
+++ b/www/docs/guides/signature.md
@@ -138,7 +138,7 @@ const typedDataValidate: TypedData = {
         domain: {
             name: "myDapp", // put the name of your dapp to ensure that the signatures will not be used by other DAPP
             version: "1",
-            chainId: shortString.encodeShortString("SN_GOERLI"), // shortString of 'SN_GOERLI' (or 'SN_MAIN' or 'SN_GOERLI2'), to be sure that signature can't be used by other network.
+            chainId: shortString.encodeShortString("SN_GOERLI"), // shortString of 'SN_GOERLI' (or 'SN_MAIN'), to be sure that signature can't be used by other network.
         },
         message: {
             id: "0x0000004f000f",

--- a/www/docs/guides/what_s_starknet.js.md
+++ b/www/docs/guides/what_s_starknet.js.md
@@ -15,7 +15,7 @@ Some important topics that have to be understood:
 - You can connect your DAPP to several networks:
 
   - [Starknet mainnet](https://starkscan.co) (Layer 2 of [Ethereum network](https://etherscan.io/) ).
-  - [Starknet testnet 1](https://testnet.starkscan.co/) & [testnet 2](https://testnet-2.starkscan.co/) (Layer 2 of [Goerli network](https://goerli.etherscan.io/) (testnet of Ethereum)).
+  - [Starknet testnet](https://testnet.starkscan.co/) (Layer 2 of [Goerli network](https://goerli.etherscan.io/) (testnet of Ethereum)).
   - [Starknet-devnet](https://shard-labs.github.io/starknet-devnet/docs/intro) (your local Starknet network, for developers).
 
   and also to some more specific solutions:

--- a/www/versioned_docs/version-4.17.1/guides/intro.md
+++ b/www/versioned_docs/version-4.17.1/guides/intro.md
@@ -58,6 +58,6 @@ Get the class hash of a contract: [starkli](https://github.com/xJonathanLEI/star
 
 ## Full example with account & erc20 deployments
 
-Please take a look at our workshop using OpenZeppelin contracts <ins>[here](https://github.com/starknet-io/starknet.js-workshop)</ins>.
+Please take a look at our workshop using OpenZeppelin contracts <ins>[here](https://github.com/0xs34n/starknet.js-workshop)</ins>.
 
-Example with Argent contract <ins>[here](https://github.com/starknet-io/starknet.js-account)</ins>.
+Example with Argent contract <ins>[here](https://github.com/0xs34n/starknet.js-account)</ins>.

--- a/www/versioned_docs/version-4.22.0/guides/intro.md
+++ b/www/versioned_docs/version-4.22.0/guides/intro.md
@@ -67,6 +67,6 @@ Get the class hash of a contract: [starkli](https://github.com/xJonathanLEI/star
 
 ## Full example with account & erc20 deployments
 
-Please take a look at our workshop using OpenZeppelin contracts <ins>[here](https://github.com/starknet-io/starknet.js-workshop)</ins>.
+Please take a look at our workshop using OpenZeppelin contracts <ins>[here](https://github.com/0xs34n/starknet.js-workshop)</ins>.
 
-Example with Argent contract <ins>[here](https://github.com/starknet-io/starknet.js-account)</ins>.
+Example with Argent contract <ins>[here](https://github.com/0xs34n/starknet.js-account)</ins>.

--- a/www/versioned_docs/version-5.14.1/guides/intro.md
+++ b/www/versioned_docs/version-5.14.1/guides/intro.md
@@ -63,12 +63,12 @@ Please check the Starknet documentation <ins>[here](https://www.cairo-lang.org/d
 
 Additional helpful resources can also be found at <ins>[OpenZeppelin](https://docs.openzeppelin.com/contracts-cairo/0.6.1/)</ins> documentation site.
 
-## Full example with account & erc20 deployments
+## Interacting with contracts and accounts
 
-Please take a look at our workshop using OpenZeppelin contracts <ins>[here](https://github.com/0xs34n/starknet.js-workshop)</ins>.
+For a basic overview on how to interact with contracts and accounts continue following this guide.
 
-Example with Argent contract <ins>[here](https://github.com/0xs34n/starknet.js-account)</ins>.
+For some more extensive examples visit PhilippeR26's <ins>[workshop](https://github.com/PhilippeR26/starknet.js-workshop-typescript)</ins>.
 
 ## Contracts used in the guides
 
-You can find the compiled contracts used in these guides in `compiled_contracts` directory.
+You can find the compiled contracts used in these guides in the <ins>[compiled_contracts](https://github.com/starknet-io/starknet.js/tree/develop/www/docs/guides/compiled_contracts)</ins> directory.

--- a/www/versioned_docs/version-5.14.1/guides/intro.md
+++ b/www/versioned_docs/version-5.14.1/guides/intro.md
@@ -65,9 +65,9 @@ Additional helpful resources can also be found at <ins>[OpenZeppelin](https://do
 
 ## Full example with account & erc20 deployments
 
-Please take a look at our workshop using OpenZeppelin contracts <ins>[here](https://github.com/starknet-io/starknet.js-workshop)</ins>.
+Please take a look at our workshop using OpenZeppelin contracts <ins>[here](https://github.com/0xs34n/starknet.js-workshop)</ins>.
 
-Example with Argent contract <ins>[here](https://github.com/starknet-io/starknet.js-account)</ins>.
+Example with Argent contract <ins>[here](https://github.com/0xs34n/starknet.js-account)</ins>.
 
 ## Contracts used in the guides
 

--- a/www/versioned_docs/version-5.19.5/guides/L1message.md
+++ b/www/versioned_docs/version-5.19.5/guides/L1message.md
@@ -7,7 +7,7 @@ sidebar_position: 13
 You can exchange messages between L1 & L2 networks:
 
 - L2 Starknet mainnet ↔️ L1 Ethereum.
-- L2 Starknet testnet 1 & 2 ↔️ L1 Goerli ETH testnet.
+- L2 Starknet testnet ↔️ L1 Goerli ETH testnet.
 - L2 local Starknet devnet ↔️ L1 local ETH testnet (Ganache, ...).
 
 You can find an explanation of the global mechanism [here](https://docs.starknet.io/documentation/architecture_and_concepts/L1-L2_Communication/messaging-mechanism/).
@@ -36,7 +36,7 @@ You have to pay in the L1 an extra fee when invoking `sendMessageToL2` (of cours
 
 ```typescript
 import { SequencerProvider } from "starknet";
-const provider = new SequencerProvider({ baseUrl: constants.BaseUrl.SN_GOERLI }); // for testnet 1
+const provider = new SequencerProvider({ baseUrl: constants.BaseUrl.SN_GOERLI }); // for testnet
 
 const responseEstimateMessageFee = await provider.estimateMessageFee({
     from_address: L1address,

--- a/www/versioned_docs/version-5.19.5/guides/connect_account.md
+++ b/www/versioned_docs/version-5.19.5/guides/connect_account.md
@@ -68,7 +68,7 @@ import * as dotenv from "dotenv";
 dotenv.config();
 
 // initialize provider
-const provider = new Provider({ sequencer: { network: constants.NetworkName.SN_GOERLI2  } });
+const provider = new Provider({ sequencer: { network: constants.NetworkName.SN_GOERLI  } });
 // initialize existing account
 const privateKey = process.env.OZ_NEW_ACCOUNT_PRIVKEY;
 const accountAddress = "0x051158d244c7636dde39ec822873b29e6c9a758c6a9812d005b6287564908667";

--- a/www/versioned_docs/version-5.19.5/guides/connect_network.md
+++ b/www/versioned_docs/version-5.19.5/guides/connect_network.md
@@ -18,14 +18,13 @@ import {Provider} from 'starknet';
 const provider = new Provider({ sequencer: { network: constants.NetworkName.SN_MAIN } })
 ```
 
-## Connect your DAPP to Starknet testnet 1 & 2
+## Connect your DAPP to Starknet testnet
 
 ```typescript
-const provider = new Provider({ sequencer: { network: constants.NetworkName.SN_GOERLI } }) // for testnet 1
-const provider = new Provider({ sequencer: { network: constants.NetworkName.SN_GOERLI2 } })  // for testnet 2
+const provider = new Provider({ sequencer: { network: constants.NetworkName.SN_GOERLI } }) // for testnet
 ```
 
-## Connect your DAPP to Starknet-devnet
+## Connect your DAPP to Starknet devnet
 
 ```typescript
 const provider = new Provider({ sequencer: { baseUrl:"http://127.0.0.1:5050"} });
@@ -72,7 +71,7 @@ For example, if you want to estimate the fee of an L1 ➡️ L2 message, you nee
 
 ```typescript
 import { SequencerProvider, constants } from "starknet";
-const provider = new SequencerProvider({ baseUrl: constants.BaseUrl.SN_GOERLI2 }); // for testnet 2
+const provider = new SequencerProvider({ baseUrl: constants.BaseUrl.SN_GOERLI }); // for testnet
 const responseEstimateMessageFee = await provider.estimateMessageFee(.....)
 ```
 

--- a/www/versioned_docs/version-5.19.5/guides/create_account.md
+++ b/www/versioned_docs/version-5.19.5/guides/create_account.md
@@ -20,7 +20,7 @@ Creating an account is a bit tricky; you have several steps:
 
 > Level: easy.
 
-Here, we will create a wallet with the Open Zeppelin smart contract v0.5.1. The contract class is already implemented in both Testnet 1 & 2.  
+Here, we will create a wallet with the Open Zeppelin smart contract v0.5.1. The contract class is already implemented in Testnet.  
 This contract is coded in Cairo 0, so it will not survive the upcoming re-genesis of Starknet.
 
 ```typescript
@@ -97,7 +97,7 @@ const OZaccount = new Account(provider, OZcontractAddress, privateKey, "1");
 
 > Level: medium.
 
-Here, we will create a wallet with the Argent smart contract v0.2.3. This case is more complicated because we will have the account behind a proxy contract (this way, the wallet contract can be updated). The contract classes of both contracts are already implemented in both Testnet 1 & 2.
+Here, we will create a wallet with the Argent smart contract v0.2.3. This case is more complicated because we will have the account behind a proxy contract (this way, the wallet contract can be updated). The contract classes of both contracts are already implemented in Testnet.
 
 > If necessary OZ contracts can also be created with a proxy.
 

--- a/www/versioned_docs/version-5.19.5/guides/interact.md
+++ b/www/versioned_docs/version-5.19.5/guides/interact.md
@@ -9,19 +9,16 @@ Once your provider, contract, and account are connected, you can interact with t
 - you can read the memory of the contract, without fees.
 - you can write to memory, but you have to pay fees.
   - On Mainnet, you have to pay fees with a bridged ETH token.
-  - On Testnet 1 & 2, you have to pay with a bridged Goerli ETH token.
+  - On Testnet, you have to pay with a bridged Goerli ETH token.
   - On devnet, you have to pay with a dummy ETH token.
 
 Your account should be funded enough to pay fees (0.01 ETH should be enough to start).
 
 ![](./pictures/Interact_contract.png)
 
-Here we will interact with a `test.cairo` contract (Cairo 0), already deployed in Testnet 1 and Testnet 2, at addresses:
+Here we will interact with a `test.cairo` contract (Cairo 0), already deployed on Testnet at the address:
 
-- testnet1: [0x5f7cd1fd465baff2ba9d2d1501ad0a2eb5337d9a885be319366b5205a414fdd](https://testnet.starkscan.co/contract/0x5f7cd1fd465baff2ba9d2d1501ad0a2eb5337d9a885be319366b5205a414fdd#read-contract).
-- testnet2: [0x2367db6b0df07033d196dcd25961109d8fbc86227158343149742284c7582e](https://testnet-2.starkscan.co/contract/0x002367db6b0df07033d196dcd25961109d8fbc86227158343149742284c7582e#read-contract).
-
-We will use Testnet1, so you need a funded wallet in this network.
+- [0x5f7cd1fd465baff2ba9d2d1501ad0a2eb5337d9a885be319366b5205a414fdd](https://testnet.starkscan.co/contract/0x5f7cd1fd465baff2ba9d2d1501ad0a2eb5337d9a885be319366b5205a414fdd#read-contract).
 
 This contract contains a storage variable called `balance`.
 

--- a/www/versioned_docs/version-5.19.5/guides/intro.md
+++ b/www/versioned_docs/version-5.19.5/guides/intro.md
@@ -20,13 +20,14 @@ npm install starknet@next
 
 ### With Devnet
 
-The example devnet version is `0.5.3`.
+- Sequencer Devnet [docs](https://0xspaceshard.github.io/starknet-devnet/docs/intro)
+- RPC Devnet [repo](https://github.com/0xSpaceShard/starknet-devnet-rs)
 
-Get devnet with docker:
+Get the Sequencer Devnet with Docker:
 
 ```bash
-docker pull shardlabs/starknet-devnet:0.5.3
-docker run -p 5050:5050 shardlabs/starknet-devnet:0.5.3 --seed 0
+docker pull shardlabs/starknet-devnet:latest
+docker run -p 5050:5050 shardlabs/starknet-devnet:latest --seed 0
 ```
 
 Open a new console tab, go to your starknet.js directory, and run:
@@ -63,12 +64,12 @@ Please check the Starknet documentation <ins>[here](https://www.cairo-lang.org/d
 
 Additional helpful resources can also be found at <ins>[OpenZeppelin](https://docs.openzeppelin.com/contracts-cairo/0.6.1/)</ins> documentation site.
 
-## Full example with account & erc20 deployments
+## Interacting with contracts and accounts
 
-Please take a look at our workshop using OpenZeppelin contracts <ins>[here](https://github.com/0xs34n/starknet.js-workshop)</ins>.
+For a basic overview on how to interact with contracts and accounts continue following this guide.
 
-Example with the Argent contract <ins>[here](https://github.com/0xs34n/starknet.js-account)</ins>.
+For some more extensive examples visit PhilippeR26's <ins>[workshop](https://github.com/PhilippeR26/starknet.js-workshop-typescript)</ins>.
 
 ## Contracts used in the guides
 
-You can find the compiled contracts used in these guides in `compiled_contracts` directory.
+You can find the compiled contracts used in these guides in the <ins>[compiled_contracts](https://github.com/starknet-io/starknet.js/tree/develop/www/docs/guides/compiled_contracts)</ins> directory.

--- a/www/versioned_docs/version-5.19.5/guides/intro.md
+++ b/www/versioned_docs/version-5.19.5/guides/intro.md
@@ -65,9 +65,9 @@ Additional helpful resources can also be found at <ins>[OpenZeppelin](https://do
 
 ## Full example with account & erc20 deployments
 
-Please take a look at our workshop using OpenZeppelin contracts <ins>[here](https://github.com/starknet-io/starknet.js-workshop)</ins>.
+Please take a look at our workshop using OpenZeppelin contracts <ins>[here](https://github.com/0xs34n/starknet.js-workshop)</ins>.
 
-Example with the Argent contract <ins>[here](https://github.com/starknet-io/starknet.js-account)</ins>.
+Example with the Argent contract <ins>[here](https://github.com/0xs34n/starknet.js-account)</ins>.
 
 ## Contracts used in the guides
 

--- a/www/versioned_docs/version-5.19.5/guides/migrate.md
+++ b/www/versioned_docs/version-5.19.5/guides/migrate.md
@@ -153,10 +153,10 @@ Constants for `Provider` initialization have been updated:
 
 ```typescript
 // v4
-const providerTestnet2 = new Provider({ sequencer: { network: "goerli-alpha-2" } });
+const providerTestnet = new Provider({ sequencer: { network: "goerli-alpha" } });
 
 // v5
- const providerTestnet2 = new Provider({ sequencer: { network: constants.NetworkName.SN_GOERLI2 } }); // or SN_GOERLI or SN_MAIN
+ const providerTestnet = new Provider({ sequencer: { network: constants.NetworkName.SN_GOERLI } }); // or SN_MAIN
 ```
 
 `Provider.chainId()` has been removed, `Provider.getChainId()` should be used.

--- a/www/versioned_docs/version-5.19.5/guides/signature.md
+++ b/www/versioned_docs/version-5.19.5/guides/signature.md
@@ -138,7 +138,7 @@ const typedDataValidate: TypedData = {
         domain: {
             name: "myDapp", // put the name of your dapp to ensure that the signatures will not be used by other DAPP
             version: "1",
-            chainId: shortString.encodeShortString("SN_GOERLI"), // shortString of 'SN_GOERLI' (or 'SN_MAIN' or 'SN_GOERLI2'), to be sure that signature can't be used by other network.
+            chainId: shortString.encodeShortString("SN_GOERLI"), // shortString of 'SN_GOERLI' (or 'SN_MAIN'), to be sure that signature can't be used by other network.
         },
         message: {
             id: "0x0000004f000f",

--- a/www/versioned_docs/version-5.19.5/guides/what_s_starknet.js.md
+++ b/www/versioned_docs/version-5.19.5/guides/what_s_starknet.js.md
@@ -15,7 +15,7 @@ Some important topics that have to be understood:
 - You can connect your DAPP to several networks:
 
   - [Starknet mainnet](https://starkscan.co) (Layer 2 of [Ethereum network](https://etherscan.io/) ).
-  - [Starknet testnet 1](https://testnet.starkscan.co/) & [testnet 2](https://testnet-2.starkscan.co/) (Layer 2 of [Goerli network](https://goerli.etherscan.io/) (testnet of Ethereum)).
+  - [Starknet testnet](https://testnet.starkscan.co/) (Layer 2 of [Goerli network](https://goerli.etherscan.io/) (testnet of Ethereum)).
   - [Starknet-devnet](https://shard-labs.github.io/starknet-devnet/docs/intro) (your local Starknet network, for developers).
 
   and also to some more specific solutions:


### PR DESCRIPTION
## Motivation and Resolution

In a certain code submission, the `0xs34n` field in the link path of the docs was mistakenly replaced with `starknet-io`, but  the repo does not exist in the `starknet-io`.

### RPC version (if applicable)

...

## Usage related changes

<!-- How the changes from this PR affect users. -->


## Development related changes

<!-- How these changes affect the developers of this project - e.g. changes in testing or CI/CD. -->


## Checklist:

- [ ] Performed a self-review of the code
- [ ] Rebased to the last commit of the target branch (or merged it into my branch)
- [ ] Linked the issues which this PR resolves
- [ ] Documented the changes in code (API docs will be generated automatically)
- [ ] Updated the tests
- [ ] All tests are passing
