### PR TITLE
fix: errors when testing in Testnet with a Cairo 1 account

### DIFF
--- a/__tests__/cairo1.test.ts
+++ b/__tests__/cairo1.test.ts
@@ -538,7 +538,7 @@ describeIfDevnet('Cairo 1 Devnet', () => {
         entrypoint: 'transfer',
         calldata: {
           recipient: toBeAccountAddress,
-          amount: uint256(1_000_000_000_000_000),
+          amount: uint256(5 * 10 ** 15),
         },
       });
       await account.waitForTransaction(transaction_hash);

--- a/__tests__/cairo1v2.test.ts
+++ b/__tests__/cairo1v2.test.ts
@@ -719,7 +719,7 @@ describe('Cairo 1', () => {
         entrypoint: 'transfer',
         calldata: {
           recipient: toBeAccountAddress,
-          amount: uint256(1_000_000_000_000_000),
+          amount: uint256(5 * 10 ** 15),
         },
       });
       await account.waitForTransaction(transaction_hash);

--- a/src/utils/transaction.ts
+++ b/src/utils/transaction.ts
@@ -75,7 +75,7 @@ export const fromCallsToExecuteCalldata_cairo1 = (calls: Call[]) => {
     contractAddress: call.contractAddress,
     entrypoint: call.entrypoint,
     calldata:
-      Array.isArray(call.calldata) && '__compiled' in call.calldata
+      Array.isArray(call.calldata) && '__compiled__' in call.calldata
         ? call.calldata // Calldata type
         : CallData.compile(call.calldata as RawArgs), // RawArgsObject | RawArgsArray type
   }));

--- a/src/utils/transaction.ts
+++ b/src/utils/transaction.ts
@@ -1,4 +1,12 @@
-import { BigNumberish, CairoVersion, Call, CallStruct, Calldata, ParsedStruct } from '../types';
+import {
+  BigNumberish,
+  CairoVersion,
+  Call,
+  CallStruct,
+  Calldata,
+  ParsedStruct,
+  RawArgs,
+} from '../types';
 import { CallData } from './calldata';
 import { getSelectorFromName } from './hash';
 import { toBigInt } from './num';
@@ -66,7 +74,10 @@ export const fromCallsToExecuteCalldata_cairo1 = (calls: Call[]) => {
   const orderCalls = calls.map((call) => ({
     contractAddress: call.contractAddress,
     entrypoint: call.entrypoint,
-    calldata: call.calldata,
+    calldata:
+      Array.isArray(call.calldata) && '__compiled' in call.calldata
+        ? call.calldata // Calldata type
+        : CallData.compile(call.calldata as RawArgs), // RawArgsObject | RawArgsArray type
   }));
 
   return CallData.compile({ orderCalls });


### PR DESCRIPTION
## Motivation and Resolution
As no Devnet is currently supporting rpc0.5.0, I tried to use a local Pathfinder node (Testnet) with a Cairo1 account (ArgentX).
Several problems have been discovered and solved (see hereunder).

### RPC version (if applicable)

## Usage related changes

- If you try `myAccount.execute()` with a Cairo 1 account, it works fine only if you use the type `Calldata`. With `RawArgs` type, an error occurs. It's now solved. (2 people reported this problem in Discord, but I thought they have made errors in the creation of their calldata...).

## Development related changes
- Problem of `myAccount.execute()` solved in `src/utils/transaction.ts`.
- In account.test.ts, several `declare()` have been replaced by `declareIfNot()`.
- Funding of new accounts has been reduced to minimize the gETH needs.
- Simulate or estimateFee for Declare are failing if this class is already declared (it's the case in Testnet). These 2 tests are executed only in Devnet.

## Checklist:

- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Updated the tests
- [x] All tests are passing
