### PR TITLE
fix: correct syncing type

### DIFF
--- a/src/types/api/rpcspec/nonspec.ts
+++ b/src/types/api/rpcspec/nonspec.ts
@@ -58,7 +58,7 @@ export type StateUpdate = STATE_UPDATE | PENDING_STATE_UPDATE;
 // response starknet_traceBlockTransactions
 export type BlockTransactionsTraces = { transaction_hash: FELT; trace_root: TRANSACTION_TRACE }[];
 // response starknet_syncing
-export type Syncing = 'false' | SYNC_STATUS;
+export type Syncing = false | SYNC_STATUS;
 // response starknet_getEvents
 export type Events = EVENTS_CHUNK;
 // response starknet_addInvokeTransaction

--- a/src/types/api/rpcspec/nonspec.ts
+++ b/src/types/api/rpcspec/nonspec.ts
@@ -58,7 +58,7 @@ export type StateUpdate = STATE_UPDATE | PENDING_STATE_UPDATE;
 // response starknet_traceBlockTransactions
 export type BlockTransactionsTraces = { transaction_hash: FELT; trace_root: TRANSACTION_TRACE }[];
 // response starknet_syncing
-export type Syncing = boolean | SYNC_STATUS;
+export type Syncing = 'false' | SYNC_STATUS;
 // response starknet_getEvents
 export type Events = EVENTS_CHUNK;
 // response starknet_addInvokeTransaction


### PR DESCRIPTION
## Motivation and Resolution

Syncing was incorrectly typed it should be `false` or `SYNC_STATUS`. Ref: https://github.com/starkware-libs/starknet-specs/blob/aae966a5067e139d2b1050c2d11d47a6b41d47c9/api/starknet_api_openrpc.json#L745


## Usage related changes

- Should remove unnecessary checks

## Checklist:

- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [ ] Linked the issues which this PR resolves
- [ ] Documented the changes in code (API docs will be generated automatically)
- [ ] Updated the tests
- [x] All tests are passing
