### PR TITLE
fix(Calldata.compile): do not split long `entrypoint` names before ca…

### DIFF
--- a/src/utils/calldata/index.ts
+++ b/src/utils/calldata/index.ts
@@ -164,8 +164,8 @@ export class CallData {
         const oe = Array.isArray(o) ? [o.length.toString(), ...o] : o;
         return Object.entries(oe).flatMap(([k, v]) => {
           let value = v;
-          if (isLongText(value)) value = splitLongString(value);
           if (k === 'entrypoint') value = getSelectorFromName(value);
+          else if (isLongText(value)) value = splitLongString(value);
           const kk = Array.isArray(oe) && k === '0' ? '$$len' : k;
           if (isBigInt(value)) return [[`${prefix}${kk}`, felt(value)]];
           if (Object(value) === value) {


### PR DESCRIPTION
…lling `getSelectorFromName`

Since `getSelectorFromName` uses keccak on its input, we don't need to split the given text value, as there are practically no limits on the input it can handle

## Motivation and Resolution

...

### RPC version (if applicable)

...

## Usage related changes

<!-- How the changes from this PR affect users. -->

- Change 1.
- ...

## Development related changes

<!-- How these changes affect the developers of this project - e.g. changes in testing or CI/CD. -->

- Change 1.
- ...

## Checklist:

- [ ] Performed a self-review of the code
- [ ] Rebased to the last commit of the target branch (or merged it into my branch)
- [ ] Linked the issues which this PR resolves
- [ ] Documented the changes in code (API docs will be generated automatically)
- [ ] Updated the tests
- [ ] All tests are passing
