### PR TITLE
docs: use only RpcProvider

### DIFF
--- a/www/docs/guides/compiled_contracts/deployBraavos.ts
+++ b/www/docs/guides/compiled_contracts/deployBraavos.ts
@@ -11,8 +11,8 @@ import {
   DeployContractResponse,
   EstimateFeeDetails,
   InvocationsSignerDetails,
-  Provider,
   RawCalldata,
+  RpcProvider,
   constants,
   ec,
   hash,
@@ -116,7 +116,7 @@ async function buildBraavosAccountDeployPayload(
 
 export async function estimateBraavosAccountDeployFee(
   privateKeyBraavos: BigNumberish,
-  provider: Provider,
+  provider: RpcProvider,
   { blockIdentifier, skipValidate }: EstimateFeeDetails = {}
 ): Promise<bigint> {
   const version = hash.feeTransactionVersion;
@@ -159,7 +159,7 @@ export async function estimateBraavosAccountDeployFee(
 
 export async function deployBraavosAccount(
   privateKeyBraavos: BigNumberish,
-  provider: Provider,
+  provider: RpcProvider,
   max_fee?: BigNumberish
 ): Promise<DeployContractResponse> {
   const nonce = constants.ZERO;

--- a/www/docs/guides/connect_account.md
+++ b/www/docs/guides/connect_account.md
@@ -68,7 +68,7 @@ import * as dotenv from "dotenv";
 dotenv.config();
 
 // initialize provider
-const provider = new RpcProvider({ nodeUrl: "https://starknet-testnet.public.blastapi.io/rpc/v0.5" });
+const provider = new RpcProvider({ nodeUrl: `${myNodeUrl}` });
 // initialize existing account
 const privateKey = process.env.OZ_NEW_ACCOUNT_PRIVKEY;
 const accountAddress = "0x051158d244c7636dde39ec822873b29e6c9a758c6a9812d005b6287564908667";

--- a/www/docs/guides/connect_account.md
+++ b/www/docs/guides/connect_account.md
@@ -12,33 +12,33 @@ You need 2 pieces of data:
 - the private key of this account
 
 ```typescript
-import { Account, Provider } from "starknet";
+import { Account, RpcProvider } from "starknet";
 ```
 
-## Connect to a pre-deployed account in Starknet-devnet
+## Connect to a pre-deployed account in Starknet-devnet-rs
 
-When you launch starknet-devnet, 10 accounts are pre-deployed with 100 dummy ETH in each.
+When you launch starknet-devnet-rs, 10 accounts are pre-deployed with 100 dummy ETH in each.
 
 Addresses and private keys are displayed on the console at initialization.
 
-> This data will change at each launch, so to freeze them, launch with: `starknet-devnet --seed 0`.
+> This data will change at each launch, so to freeze them, launch with: `cargo run --release -- --seed 0`.
 
 The result for `account #0`:
 
-```bash
-Address: 0x7e00d496e324876bbc8531f2d9a82bf154d1a04a50218ee74cdd372f75a551a
-Public key: 0x7e52885445756b313ea16849145363ccb73fb4ab0440dbac333cf9d13de82b9
-Private key: 0xe3e70682c2094cac629f6fbed82c07cd
+```text
+Address    : 0x64b48806902a367c8598f4f95c305e8c1a1acba5f082d294a43793113115691
+Private key: 0x71d7bb07b9a64f6f78ac4c816aff4da9
+Public key : 0x7e52885445756b313ea16849145363ccb73fb4ab0440dbac333cf9d13de82b9
 ```
 
 Then you can use this code:
 
 ```typescript
 // initialize provider
-const provider = new Provider({ sequencer: { baseUrl:"http://127.0.0.1:5050"  } });
+const provider = new RpcProvider({ nodeUrl: "http://127.0.0.1:5050/rpc" });
 // initialize existing pre-deployed account 0 of Devnet
-const privateKey = "0xe3e70682c2094cac629f6fbed82c07cd";
-const accountAddress = "0x7e00d496e324876bbc8531f2d9a82bf154d1a04a50218ee74cdd372f75a551a";
+const privateKey = "0x71d7bb07b9a64f6f78ac4c816aff4da9";
+const accountAddress = "0x64b48806902a367c8598f4f95c305e8c1a1acba5f082d294a43793113115691";
 
 const account = new Account(provider, accountAddress, privateKey);
 ```
@@ -68,7 +68,7 @@ import * as dotenv from "dotenv";
 dotenv.config();
 
 // initialize provider
-const provider = new Provider({ sequencer: { network: constants.NetworkName.SN_GOERLI  } });
+const provider = new RpcProvider({ nodeUrl: "https://starknet-testnet.public.blastapi.io/rpc/v0.5" });
 // initialize existing account
 const privateKey = process.env.OZ_NEW_ACCOUNT_PRIVKEY;
 const accountAddress = "0x051158d244c7636dde39ec822873b29e6c9a758c6a9812d005b6287564908667";

--- a/www/docs/guides/connect_contract.md
+++ b/www/docs/guides/connect_contract.md
@@ -11,7 +11,7 @@ You need 2 pieces of data:
 - the address of the contract
 - the ABI file of the contract (or the compiled/compressed contract file, that includes the abi)
 
-> If you don't have the abi file, the `provider.getClassAt()` and `provider.getClassByHash()` commands will recover the compressed contract file. As these methods generate a significant workload to the sequencer/node, it's recommended to store the result in your computer, to be able to reuse it later without using the provider each time:
+> If you don't have the abi file, the `provider.getClassAt()` and `provider.getClassByHash()` commands will recover the compressed contract file. As these methods generate a significant workload for the sequencer/node, it's recommended to store the result on your computer to be able to reuse it later without using the provider each time:
 
 ```typescript
 import fs from "fs";

--- a/www/docs/guides/connect_contract.md
+++ b/www/docs/guides/connect_contract.md
@@ -11,10 +11,11 @@ You need 2 pieces of data:
 - the address of the contract
 - the ABI file of the contract (or the compiled/compressed contract file, that includes the abi)
 
-> If you don't have the abi file, the `provider.getClassAt()` and `provider.getClassByHash()` commands will recover the compressed contract file. As these methods generate a significant workload to the sequencer/node, it's recommended to store the result in your computer, to be able to reuse it later without using the provider:
+> If you don't have the abi file, the `provider.getClassAt()` and `provider.getClassByHash()` commands will recover the compressed contract file. As these methods generate a significant workload to the sequencer/node, it's recommended to store the result in your computer, to be able to reuse it later without using each time the provider:
 
 ```typescript
 import fs from "fs";
+
 const compressedContract = await provider.getClassAt(addrContract);
 fs.writeFileSync('./myAbi.json', json.stringify( compressedContract.abi, undefined, 2));
 ```
@@ -24,7 +25,7 @@ fs.writeFileSync('./myAbi.json', json.stringify( compressedContract.abi, undefin
 ## Get the abi from a compiled/compressed file
 
 ```typescript
-import { Provider, Contract, json } from "starknet";
+import { RpcProvider, Contract, json } from "starknet";
 ```
 
 If you have the compiled/compressed file of the contract, use this code to recover all data, including the ABI:
@@ -39,7 +40,7 @@ const compiledContract = json.parse(fs.readFileSync("./compiledContracts/test.js
 
 ```typescript
 // initialize provider
-const provider = new Provider({ sequencer: { network: constants.NetworkName.SN_GOERLI } });
+const provider = new RpcProvider({ nodeUrl: "https://limited-rpc.nethermind.io/goerli-juno" });
 
 // initialize deployed contract
 const testAddress = "0x7667469b8e93faa642573078b6bf8c790d3a6184b2a1bb39c5c923a732862e1";

--- a/www/docs/guides/connect_contract.md
+++ b/www/docs/guides/connect_contract.md
@@ -11,7 +11,7 @@ You need 2 pieces of data:
 - the address of the contract
 - the ABI file of the contract (or the compiled/compressed contract file, that includes the abi)
 
-> If you don't have the abi file, the `provider.getClassAt()` and `provider.getClassByHash()` commands will recover the compressed contract file. As these methods generate a significant workload to the sequencer/node, it's recommended to store the result in your computer, to be able to reuse it later without using each time the provider:
+> If you don't have the abi file, the `provider.getClassAt()` and `provider.getClassByHash()` commands will recover the compressed contract file. As these methods generate a significant workload to the sequencer/node, it's recommended to store the result in your computer, to be able to reuse it later without using the provider each time:
 
 ```typescript
 import fs from "fs";

--- a/www/docs/guides/connect_contract.md
+++ b/www/docs/guides/connect_contract.md
@@ -40,7 +40,7 @@ const compiledContract = json.parse(fs.readFileSync("./compiledContracts/test.js
 
 ```typescript
 // initialize provider
-const provider = new RpcProvider({ nodeUrl: "https://limited-rpc.nethermind.io/goerli-juno" });
+const provider = new RpcProvider({ nodeUrl: `${myNodeUrl}` });
 
 // initialize deployed contract
 const testAddress = "0x7667469b8e93faa642573078b6bf8c790d3a6184b2a1bb39c5c923a732862e1";

--- a/www/docs/guides/connect_network.md
+++ b/www/docs/guides/connect_network.md
@@ -6,35 +6,71 @@ sidebar_position: 3
 
 The first thing to do is to define with which network you want to interact.
 
-With the RpcProvider object, you define the Starknet Rpc node to use.
+Then you need to select a node. A node is a safe way to connect with the Starknet blockchain. You can use :
 
-> Many nodes providers are available. You have hereunder some examples.
+- a node proposed by a node provider, that can be free or not ; it can have limitations or not ; it can have a WebSocket access or not.
+  > RPC node providers are for example Infura, Alchemy, Blast, Nethermind, Lava, Chainstack...
+- your own node, located in your local computer or in your local network.
+  > you can spin up your own node with Pathfinder, Juno, Papyrus, Deoxys, ...
+- a local development node, that simulates a Starknet network. Useful for devs to perform quick tests without spending precious fee token.
+  > Main development devnets are Starknet-devnet-rs, Madara, ...
+
+With the RpcProvider object, you define the Starknet Rpc node to use.
 
 ```typescript
 import {RpcProvider} from 'starknet';
 ```
 
-## Connect your DAPP to Starknet mainnet
+## Connect your DAPP to a RPC node provider
+
+### Default Rpc node
+
+If you don't want to use a specific node, or to handle an API key, you can use by default :
 
 ```typescript
-const provider = new RpcProvider({ nodeUrl: "https://json-rpc.starknet-mainnet.public.lavanet.xyz" });
+const myProvider = new RpcProvider({ nodeUrl: constants.NetworkName.SN_GOERLI });
+const myProvider = new RpcProvider({ nodeUrl: constants.NetworkName.SN_MAIN });
+// or
+const myProvider = new RpcProvider(); // Goerli
 ```
 
-## Connect your DAPP to Starknet testnet
+> when using this syntax, a random public node will be selected.
+
+Using a specific nodeUrl is the better approach, as a such node will have less limitations and will be less crowded.
+
+Some example of RpcProvider instantiation to connect to RPC node providers:
+
+### Mainnet
 
 ```typescript
-const provider = new RpcProvider({ nodeUrl: "https://limited-rpc.nethermind.io/goerli-juno" }); // for testnet
+// Infura node rpc for Mainnet:
+const providerInfuraMainnet = new RpcProvider({ nodeUrl: 'https://starknet-mainnet.infura.io/v3/' + infuraKey });
+// Blast node rpc for Mainnet:
+const providerBlastMainnet = new RpcProvider({ nodeUrl: 'https://starknet-mainnet.blastapi.io/' + blastKey + "/rpc/v0.5" });
+// Lava node rpc for Mainnet:
+const providerMainnetLava = new RpcProvider({ nodeUrl: "https://g.w.lavanet.xyz:443/gateway/strk/rpc-http/" + lavaMainnetKey });
+// Alchemy node rpc for Mainnet:
+const providerAlchemyMainnet = new RpcProvider({ nodeUrl: 'https://starknet-mainnet.g.alchemy.com/starknet/version/rpc/v0.5/' + alchemyKey });
+// Public Nethermind node rpc 0.5.1 for Mainnet :
+const providerMainnetNethermindPublic = new RpcProvider({ nodeUrl: "https://free-rpc.nethermind.io/mainnet-juno/v0_5" });
 ```
 
-## Connect your DAPP to Starknet-devnet-rs
+> Take care to safely manage your API key. It's a confidential item!
+
+### Testnet
 
 ```typescript
-const provider = new RpcProvider({ nodeUrl: "http://127.0.0.1:5050/rpc" });
+// Infura node rpc for Testnet:
+const providerInfuraTestnet = new RpcProvider({ nodeUrl: 'https://starknet-goerli.infura.io/v3/' + infuraKey });
+// Blast node rpc for Testnet:
+const providerBlastTestnet = new RpcProvider({ nodeUrl: 'https://starknet-testnet.blastapi.io/' + blastKey + "/rpc/v0.5" });
+// Alchemy node rpc for Testnet:
+const providerAlchemyTestnet = new RpcProvider({ nodeUrl: 'https://starknet-goerli.g.alchemy.com/starknet/version/rpc/v0.5/' + alchemyKey });
+// Public Nethermind node rpc for Testnet :
+const providerTestnetNethermindPublic = new RpcProvider({ nodeUrl: "https://free-rpc.nethermind.io/testnet-juno/v0_5" });
 ```
 
-> If you have customized host and port during starknet-devnet initialization, adapt in accordance to your script.
-
-## Connect your DAPP to a Starknet node
+## Connect to your own node
 
 ### Pathfinder
 
@@ -59,36 +95,14 @@ Initialize the provider with:
 const provider = new RpcProvider({ nodeUrl: 'http://127.0.0.1:6060/v0_5' });
 ```
 
-### Other node clients
+> if Juno is running in a separate computer in your local network, don't forget to add the option `--http-host 0.0.0.0` when launching Juno.
 
-Other examples (some need a secret key):
+## Devnet
 
-**Mainnet:**
-
-```typescript
-// Infura node rpc for Mainnet:
-const providerInfuraMainnet = new RpcProvider({ nodeUrl: 'https://starknet-mainnet.infura.io/v3/' + infuraKey });
-// Blast node rpc for Mainnet:
-const providerBlastMainnet = new RpcProvider({ nodeUrl: 'https://starknet-mainnet.blastapi.io/' + blastKey + "/rpc/v0.5" });
-// Lava node rpc for Mainnet:
-const providerMainnetLava = new RpcProvider({ nodeUrl: "https://g.w.lavanet.xyz:443/gateway/strk/rpc-http/" + lavaMainnetKey });
-// Alchemy node rpc for Mainnet:
-const providerAlchemyMainnet = new RpcProvider({ nodeUrl: 'https://starknet-mainnet.g.alchemy.com/starknet/version/rpc/v0.5/' + alchemyKey });
-// Public Nethermind node rpc 0.5.1 for Mainnet :
-const providerMainnetNethermindPublic = new RpcProvider({ nodeUrl: "https://limited-rpc.nethermind.io/mainnet-juno/v0_5" });
-```
-
-**Testnet:**
+Example of a connection to a local development node, with Starknet-devnet-rs:
 
 ```typescript
-// Infura node rpc for Testnet:
-const providerInfuraTestnet = new RpcProvider({ nodeUrl: 'https://starknet-goerli.infura.io/v3/' + infuraKey });
-// Blast node rpc for Testnet:
-const providerBlastTestnet = new RpcProvider({ nodeUrl: 'https://starknet-testnet.blastapi.io/' + blastKey + "/rpc/v0.5" });
-// Alchemy node rpc for Testnet:
-const providerAlchemyTestnet = new RpcProvider({ nodeUrl: 'https://starknet-goerli.g.alchemy.com/starknet/version/rpc/v0.5/' + alchemyKey });
-// Public Nethermind node rpc for Testnet :
-const providerTestnetNethermindPublic = new RpcProvider({ nodeUrl: "https://limited-rpc.nethermind.io/goerli-juno" });
+const provider = new RpcProvider({ nodeUrl: "http://127.0.0.1:5050/rpc" });
 ```
 
-RPC providers are for example Infura, Alchemy, Chainstack... Or you can spin up your own Pathfinder node!
+> If you have customized host and port during starknet-devnet initialization, adapt in accordance to your script.

--- a/www/docs/guides/connect_network.md
+++ b/www/docs/guides/connect_network.md
@@ -38,7 +38,7 @@ const myProvider = new RpcProvider(); // Goerli
 
 Using a specific nodeUrl is the better approach, as such a node will have less limitations and will be less crowded.
 
-Some example of RpcProvider instantiation to connect to RPC node providers:
+Some examples of RpcProvider instantiation to connect to RPC node providers:
 
 ### Mainnet
 

--- a/www/docs/guides/connect_network.md
+++ b/www/docs/guides/connect_network.md
@@ -2,49 +2,37 @@
 sidebar_position: 3
 ---
 
-# Provider object 🔌 connect to the network
+# RpcProvider object 🔌 connect to the network
 
 The first thing to do is to define with which network you want to interact.
 
-With the Provider object, you define which network to use.
+With the RpcProvider object, you define the Starknet Rpc node to use.
+
+> Many nodes providers are available. You have hereunder some examples.
 
 ```typescript
-import {Provider} from 'starknet';
+import {RpcProvider} from 'starknet';
 ```
 
 ## Connect your DAPP to Starknet mainnet
 
 ```typescript
-const provider = new Provider({ sequencer: { network: constants.NetworkName.SN_MAIN } })
+const provider = new RpcProvider({ nodeUrl: "https://json-rpc.starknet-mainnet.public.lavanet.xyz" });
 ```
 
 ## Connect your DAPP to Starknet testnet
 
 ```typescript
-const provider = new Provider({ sequencer: { network: constants.NetworkName.SN_GOERLI } }) // for testnet
+const provider = new RpcProvider({ nodeUrl: "https://limited-rpc.nethermind.io/goerli-juno" }); // for testnet
 ```
 
-## Connect your DAPP to Starknet devnet
+## Connect your DAPP to Starknet-devnet-rs
 
 ```typescript
-const provider = new Provider({ sequencer: { baseUrl:"http://127.0.0.1:5050"} });
+const provider = new RpcProvider({ nodeUrl: "http://127.0.0.1:5050/rpc" });
 ```
 
 > If you have customized host and port during starknet-devnet initialization, adapt in accordance to your script.
-
-## Connect your DAPP to a private Starknet network
-
-If necessary you can have full control of the network access (for example, for your company's private test network):
-
-```typescript
-const provider = new Provider({
-  sequencer: {
-    baseUrl: 'https://mynetwork.mycompany.io',
-    feederGatewayUrl: 'feeder_gateway',
-    gatewayUrl: 'gateway',
-  }
-})
-```
 
 ## Connect your DAPP to a Starknet node
 
@@ -53,14 +41,14 @@ const provider = new Provider({
 For a local [Pathfinder](https://github.com/eqlabs/pathfinder) node:
 
 ```typescript
-const provider = new Provider({ rpc: { nodeUrl: '127.0.0.1:9545/rpc/v0.4' } })
+const provider = new RpcProvider({ nodeUrl: '127.0.0.1:9545/rpc/v0.5' });
 ```
 
 Your node can be located in your local network (example: pathfinder node running on a computer on your network, launched with this additional option: `--http-rpc 0.0.0.0:9545`).
 You can connect with:
 
 ```typescript
-const provider = new Provider({ rpc: { nodeUrl: '192.168.1.99:9545/rpc/v0.4' } })
+const provider = new RpcProvider({ nodeUrl: '192.168.1.99:9545/rpc/v0.5' })
 ```
 
 ### Juno
@@ -68,7 +56,7 @@ const provider = new Provider({ rpc: { nodeUrl: '192.168.1.99:9545/rpc/v0.4' } }
 Initialize the provider with:
 
 ```typescript
-const provider = new RpcProvider({ nodeUrl: 'http://127.0.0.1:6060' });
+const provider = new RpcProvider({ nodeUrl: 'http://127.0.0.1:6060/v0_5' });
 ```
 
 ### Other node clients
@@ -81,11 +69,13 @@ Other examples (some need a secret key):
 // Infura node rpc for Mainnet:
 const providerInfuraMainnet = new RpcProvider({ nodeUrl: 'https://starknet-mainnet.infura.io/v3/' + infuraKey });
 // Blast node rpc for Mainnet:
-const providerBlastMainnet = new RpcProvider({ nodeUrl: 'https://starknet-mainnet.blastapi.io/' + blastKey + "/rpc/v0.4" });
+const providerBlastMainnet = new RpcProvider({ nodeUrl: 'https://starknet-mainnet.blastapi.io/' + blastKey + "/rpc/v0.5" });
 // Lava node rpc for Mainnet:
 const providerMainnetLava = new RpcProvider({ nodeUrl: "https://g.w.lavanet.xyz:443/gateway/strk/rpc-http/" + lavaMainnetKey });
 // Alchemy node rpc for Mainnet:
-const providerAlchemyMainnet = new RpcProvider({ nodeUrl: 'https://starknet-mainnet.g.alchemy.com/v2/' + alchemyKey });
+const providerAlchemyMainnet = new RpcProvider({ nodeUrl: 'https://starknet-mainnet.g.alchemy.com/starknet/version/rpc/v0.5/' + alchemyKey });
+// Public Nethermind node rpc 0.5.1 for Mainnet :
+const providerMainnetNethermindPublic = new RpcProvider({ nodeUrl: "https://limited-rpc.nethermind.io/mainnet-juno/v0_5" });
 ```
 
 **Testnet:**
@@ -94,39 +84,11 @@ const providerAlchemyMainnet = new RpcProvider({ nodeUrl: 'https://starknet-main
 // Infura node rpc for Testnet:
 const providerInfuraTestnet = new RpcProvider({ nodeUrl: 'https://starknet-goerli.infura.io/v3/' + infuraKey });
 // Blast node rpc for Testnet:
-const providerBlastTestnet = new RpcProvider({ nodeUrl: 'https://starknet-testnet.blastapi.io/' + blastKey + "/rpc/v0.4" });
+const providerBlastTestnet = new RpcProvider({ nodeUrl: 'https://starknet-testnet.blastapi.io/' + blastKey + "/rpc/v0.5" });
 // Alchemy node rpc for Testnet:
-const providerAlchemyTestnet = new RpcProvider({ nodeUrl: 'https://starknet-goerli.g.alchemy.com/v2/' + alchemyKey });
-```
-
-## Specific methods
-
-Some methods are available only if connected to a sequencer, and some others are available only if connected to a node (using RPC).
-
-### Specific sequencer methods
-
-For example, if you want to estimate the fee of an L1 ➡️ L2 message, you need to use a method that is available only in the sequencer. The class `SequencerProvider` is available for this case:
-
-```typescript
-import { SequencerProvider, constants } from "starknet";
-const provider = new SequencerProvider({ baseUrl: constants.BaseUrl.SN_GOERLI }); // for testnet
-const responseEstimateMessageFee = await provider.estimateMessageFee(.....)
-```
-
-### Specific RPC methods
-
-For example, if you want to read the list of pending transactions, you need to use a method available from an RPC node. The class `RpcProvider` is available for this case:
-
-```typescript
-import { RpcProvider } from "starknet";
-const providerRPC = new RpcProvider({ nodeUrl: "http://192.168.1.99:9545/rpc/v0.4" }); // for a pathfinder node located in a PC in the local network
-const pendingTx = await providerRPC.getPendingTransactions();
+const providerAlchemyTestnet = new RpcProvider({ nodeUrl: 'https://starknet-goerli.g.alchemy.com/starknet/version/rpc/v0.5/' + alchemyKey });
+// Public Nethermind node rpc for Testnet :
+const providerTestnetNethermindPublic = new RpcProvider({ nodeUrl: "https://limited-rpc.nethermind.io/goerli-juno" });
 ```
 
 RPC providers are for example Infura, Alchemy, Chainstack... Or you can spin up your own Pathfinder node!
-
-For example, to connect to Alchemy with your personal API key:
-
-```typescript
-const providerRPC = new RpcProvider({ nodeUrl: 'https://starknet-mainnet.g.alchemy.com/v2/' + alchemyKey});
-```

--- a/www/docs/guides/connect_network.md
+++ b/www/docs/guides/connect_network.md
@@ -6,11 +6,11 @@ sidebar_position: 3
 
 The first thing to do is to define with which network you want to interact.
 
-Then you need to select a node. A node is a safe way to connect with the Starknet blockchain. You can use :
+Then you need to select a node. A node is a safe way to connect with the Starknet blockchain. You can use:
 
-- a node proposed by a node provider, that can be free or not ; it can have limitations or not ; it can have a WebSocket access or not.
+- a node supplied by a node provider - it can be free or not; it can have limitations or not; it can have WebSocket support or not.
   > RPC node providers are for example Infura, Alchemy, Blast, Nethermind, Lava, Chainstack...
-- your own node, located in your local computer or in your local network.
+- your own node, located on your local computer or in your local network.
   > you can spin up your own node with Pathfinder, Juno, Papyrus, Deoxys, ...
 - a local development node, that simulates a Starknet network. Useful for devs to perform quick tests without spending precious fee token.
   > Main development devnets are Starknet-devnet-rs, Madara, ...
@@ -21,11 +21,11 @@ With the RpcProvider object, you define the Starknet Rpc node to use.
 import {RpcProvider} from 'starknet';
 ```
 
-## Connect your DAPP to a RPC node provider
+## Connect your DAPP to an RPC node provider
 
 ### Default Rpc node
 
-If you don't want to use a specific node, or to handle an API key, you can use by default :
+If you don't want to use a specific node, or to handle an API key, you can use by default:
 
 ```typescript
 const myProvider = new RpcProvider({ nodeUrl: constants.NetworkName.SN_GOERLI });
@@ -36,7 +36,7 @@ const myProvider = new RpcProvider(); // Goerli
 
 > when using this syntax, a random public node will be selected.
 
-Using a specific nodeUrl is the better approach, as such a node will have less limitations and will be less crowded.
+Using a specific nodeUrl is the better approach, as such a node will have fewer limitations and will be less crowded.
 
 Some examples of RpcProvider instantiation to connect to RPC node providers:
 
@@ -51,7 +51,7 @@ const providerBlastMainnet = new RpcProvider({ nodeUrl: 'https://starknet-mainne
 const providerMainnetLava = new RpcProvider({ nodeUrl: "https://g.w.lavanet.xyz:443/gateway/strk/rpc-http/" + lavaMainnetKey });
 // Alchemy node rpc for Mainnet:
 const providerAlchemyMainnet = new RpcProvider({ nodeUrl: 'https://starknet-mainnet.g.alchemy.com/starknet/version/rpc/v0.5/' + alchemyKey });
-// Public Nethermind node rpc 0.5.1 for Mainnet :
+// Public Nethermind node rpc 0.5.1 for Mainnet:
 const providerMainnetNethermindPublic = new RpcProvider({ nodeUrl: "https://free-rpc.nethermind.io/mainnet-juno/v0_5" });
 ```
 
@@ -66,7 +66,7 @@ const providerInfuraTestnet = new RpcProvider({ nodeUrl: 'https://starknet-goerl
 const providerBlastTestnet = new RpcProvider({ nodeUrl: 'https://starknet-testnet.blastapi.io/' + blastKey + "/rpc/v0.5" });
 // Alchemy node rpc for Testnet:
 const providerAlchemyTestnet = new RpcProvider({ nodeUrl: 'https://starknet-goerli.g.alchemy.com/starknet/version/rpc/v0.5/' + alchemyKey });
-// Public Nethermind node rpc for Testnet :
+// Public Nethermind node rpc for Testnet:
 const providerTestnetNethermindPublic = new RpcProvider({ nodeUrl: "https://free-rpc.nethermind.io/testnet-juno/v0_5" });
 ```
 
@@ -80,7 +80,7 @@ For a local [Pathfinder](https://github.com/eqlabs/pathfinder) node:
 const provider = new RpcProvider({ nodeUrl: '127.0.0.1:9545/rpc/v0.5' });
 ```
 
-Your node can be located in your local network (example: pathfinder node running on a computer on your network, launched with this additional option: `--http-rpc 0.0.0.0:9545`).
+Your node can be located in your local network (example: Pathfinder node running on a computer in your network, launched with this additional option: `--http-rpc 0.0.0.0:9545`).
 You can connect with:
 
 ```typescript
@@ -89,13 +89,13 @@ const provider = new RpcProvider({ nodeUrl: '192.168.1.99:9545/rpc/v0.5' })
 
 ### Juno
 
-Initialize the provider with:
+For a local [Juno](https://github.com/NethermindEth/juno) node initialize the provider with:
 
 ```typescript
 const provider = new RpcProvider({ nodeUrl: 'http://127.0.0.1:6060/v0_5' });
 ```
 
-> if Juno is running in a separate computer in your local network, don't forget to add the option `--http-host 0.0.0.0` when launching Juno.
+> If Juno is running on a separate computer in your local network, don't forget to add the option `--http-host 0.0.0.0` when launching Juno.
 
 ## Devnet
 

--- a/www/docs/guides/connect_network.md
+++ b/www/docs/guides/connect_network.md
@@ -36,7 +36,7 @@ const myProvider = new RpcProvider(); // Goerli
 
 > when using this syntax, a random public node will be selected.
 
-Using a specific nodeUrl is the better approach, as a such node will have less limitations and will be less crowded.
+Using a specific nodeUrl is the better approach, as such a node will have less limitations and will be less crowded.
 
 Some example of RpcProvider instantiation to connect to RPC node providers:
 

--- a/www/docs/guides/create_account.md
+++ b/www/docs/guides/create_account.md
@@ -24,14 +24,14 @@ Here, we will create a wallet with the Open Zeppelin smart contract v0.5.1. The 
 This contract is coded in Cairo 0, so it will not survive the upcoming re-genesis of Starknet.
 
 ```typescript
-import { Account, constants, ec, json, stark, Provider, hash, CallData } from "starknet";
+import { Account, constants, ec, json, stark, RpcProvider, hash, CallData } from "starknet";
 ```
 
 ### compute address
 
 ```typescript
 // connect provider
-const provider = new Provider({ sequencer: { network: constants.NetworkName.SN_GOERLI } });
+const provider = new RpcProvider({ nodeUrl: "https://limited-rpc.nethermind.io/goerli-juno" });
 
 // new Open Zeppelin account v0.5.1
 // Generate public and private key pair.
@@ -85,14 +85,6 @@ await provider.waitForTransaction(transaction_hash);
 console.log('✅ New OpenZeppelin account created.\n   address =', contract_address);
 ```
 
-> **IMPORTANT:** If this account is based on a Cairo v2 contract (for example OpenZeppelin account 0.7.0 or later), do not forget to add the parameter "1" after the privateKey parameter:
-
-```typescript
-const OZaccount = new Account(provider, OZcontractAddress, privateKey, "1");
-```
-
-> Take care that this added parameter is a string, NOT a number.
-
 ## Create an Argent account
 
 > Level: medium.
@@ -102,14 +94,14 @@ Here, we will create a wallet with the Argent smart contract v0.2.3. This case i
 > If necessary OZ contracts can also be created with a proxy.
 
 ```typescript
-import { Account, ec, json, stark, Provider, hash, CallData } from "starknet";
+import { Account, ec, json, stark, RpcProvider, hash, CallData } from "starknet";
 ```
 
 ### compute address
 
 ```typescript
 // connect provider
-const provider = new Provider({ sequencer: { network: constants.NetworkName.SN_GOERLI } });
+const provider = new RpcProvider({ nodeUrl: "https://json-rpc.starknet-testnet.public.lavanet.xyz" });
 
 //new Argent X account v0.2.3
 const argentXproxyClassHash = "0x25ec026985a3bf9d0cc1fe17326b245dfdc3ff89b8fde106542a3ea56c5a918";
@@ -172,7 +164,7 @@ starknet-devnet --seed 0 --fork-network alpha-goerli
 Initialization:
 
 ```typescript
-import { Provider, Account, num, stark } from "starknet";
+import { RpcProvider, Account, num, stark } from "starknet";
 import { calculateAddressBraavos,
     deployBraavosAccount,
     estimateBraavosAccountDeployFee
@@ -195,8 +187,8 @@ const privateKeyBraavos = "0x02e8....e12";
 ### Compute address
 
 ```typescript
-// initialize Provider
-const providerDevnet = new Provider({ sequencer: { baseUrl: "http://127.0.0.1:5050" } });
+// initialize provider
+const providerDevnet = new RpcProvider({ baseUrl: "http://127.0.0.1:5050/rpc" });
 // address
 const BraavosProxyAddress = calculateAddressBraavos(privateKeyBraavos);
 console.log('Calculated account address=', BraavosProxyAddress);
@@ -259,14 +251,14 @@ Here is an example of a customized wallet, including super administrator managem
 > launch `starknet-devnet --seed 0` before using this script
 
 ```typescript
-import { Account, ec, json, stark, Provider, hash, CallData } from "starknet";
+import { Account, ec, json, stark, RpcProvider, hash, CallData } from "starknet";
 import fs from "fs";
 import axios from "axios";
 ```
 
 ```typescript
 // connect provider
-const provider = new Provider({ sequencer: { network: "http://127.0.0.1:5050" } });
+const provider = new RpcProvider({ network: "http://127.0.0.1:5050/rpc" });
 
 // initialize existing predeployed account 0 of Devnet
 const privateKey0 = "0xe3e70682c2094cac629f6fbed82c07cd";

--- a/www/docs/guides/create_account.md
+++ b/www/docs/guides/create_account.md
@@ -31,7 +31,7 @@ import { Account, constants, ec, json, stark, RpcProvider, hash, CallData } from
 
 ```typescript
 // connect provider
-const provider = new RpcProvider({ nodeUrl: "https://limited-rpc.nethermind.io/goerli-juno" });
+const provider = new RpcProvider({ nodeUrl: `${myNodeUrl}` });
 
 // new Open Zeppelin account v0.5.1
 // Generate public and private key pair.
@@ -101,7 +101,7 @@ import { Account, ec, json, stark, RpcProvider, hash, CallData } from "starknet"
 
 ```typescript
 // connect provider
-const provider = new RpcProvider({ nodeUrl: "https://json-rpc.starknet-testnet.public.lavanet.xyz" });
+const provider = new RpcProvider({ nodeUrl: `${myNodeUrl}` });
 
 //new Argent X account v0.2.3
 const argentXproxyClassHash = "0x25ec026985a3bf9d0cc1fe17326b245dfdc3ff89b8fde106542a3ea56c5a918";
@@ -188,7 +188,7 @@ const privateKeyBraavos = "0x02e8....e12";
 
 ```typescript
 // initialize provider
-const providerDevnet = new RpcProvider({ baseUrl: "http://127.0.0.1:5050/rpc" });
+const providerDevnet = new RpcProvider({ nodeUrl: `${myNodeUrl}` });
 // address
 const BraavosProxyAddress = calculateAddressBraavos(privateKeyBraavos);
 console.log('Calculated account address=', BraavosProxyAddress);

--- a/www/docs/guides/create_contract.md
+++ b/www/docs/guides/create_contract.md
@@ -27,7 +27,7 @@ Other users of the network can use your declared contract. It means that if some
 Example: if you want an ERC20 contract, and somebody has already declared an ERC20 contract that conforms to your needs, you have just to deploy a new instance of this contract class.
 
 ```typescript
-import { Provider, Account, Contract, json, stark, uint256, shortString } from "starknet";
+import { RpcProvider, Account, Contract, json, stark, uint256, shortString } from "starknet";
 ```
 
 ## `declareAndDeploy()` your new contract
@@ -38,7 +38,7 @@ Here, to declare & deploy a `Test.cairo` smart contract, in devnet:
 
 ```typescript
 // connect provider
-const provider = new Provider({ sequencer: { baseUrl: "http://127.0.0.1:5050" } });
+const provider = new RpcProvider({ baseUrl: "http://127.0.0.1:5050/rpc" });
 // connect your account. To adapt to your own account:
 const privateKey0 = process.env.OZ_ACCOUNT_PRIVATE_KEY;
 const account0Address: string = "0x123....789";
@@ -62,7 +62,7 @@ If the contract class is already declared, it's faster and cheaper: just use `de
 
 ```typescript
 // connect provider
-const provider = new Provider({ sequencer: { baseUrl: "http://127.0.0.1:5050" } });
+const provider = new RpcProvider({ sequencer: { baseUrl: "http://127.0.0.1:5050/rpc" } });
 // connect your account. To adapt to your own account:
 const privateKey0 = process.env.OZ_ACCOUNT_PRIVATE_KEY;
 const account0Address: string = "0x123....789";
@@ -162,7 +162,7 @@ If you want only declare a new Contract Class, use `declare()`.
 
 ```typescript
 // connect provider
-const provider = new Provider({ sequencer: { baseUrl: "http://127.0.0.1:5050" } });
+const provider = new RpcProvider({ baseUrl: "http://127.0.0.1:5050/rpc" });
 // connect your account. To adapt to your own account:
 const privateKey0 = process.env.OZ_ACCOUNT_PRIVATE_KEY;
 const account0Address: string = "0x123....789";

--- a/www/docs/guides/create_contract.md
+++ b/www/docs/guides/create_contract.md
@@ -62,7 +62,7 @@ If the contract class is already declared, it's faster and cheaper: just use `de
 
 ```typescript
 // connect provider
-const provider = new RpcProvider({ sequencer: { baseUrl: "http://127.0.0.1:5050/rpc" } });
+const provider = new RpcProvider({ baseUrl: "http://127.0.0.1:5050/rpc" });
 // connect your account. To adapt to your own account:
 const privateKey0 = process.env.OZ_ACCOUNT_PRIVATE_KEY;
 const account0Address: string = "0x123....789";

--- a/www/docs/guides/events.md
+++ b/www/docs/guides/events.md
@@ -118,7 +118,7 @@ Easier to read and process, isn't it?
 
 If you don't have the transaction Hash of the contract execution that created the event, it will be necessary to search inside the blocks of the Starknet blockchain.
 
-In this example, if you want to read the events recorded in the last 10 blocks, you need to use a method available from a RPC node. The class `RpcProvider` is available for this case:
+In this example, if you want to read the events recorded in the last 10 blocks, you need to use a method available from an RPC node. The class `RpcProvider` is available for this case:
 
 ```typescript
 import { RpcProvider } from "starknet";

--- a/www/docs/guides/events.md
+++ b/www/docs/guides/events.md
@@ -122,7 +122,7 @@ In this example, if you want to read the events recorded in the last 10 blocks, 
 
 ```typescript
 import { RpcProvider } from "starknet";
-const provider = new RpcProvider({ nodeUrl: 'https://starknet-goerli.infura.io/v3/' + infuraKey }); // for an Infura node on Testnet
+const provider = new RpcProvider({ nodeUrl: `${myNodeUrl}` });
 const lastBlock = await provider.getBlock('latest');
 const keyFilter = [num.toHex(hash.starknetKeccak("EventPanic")), "0x8"]
 const eventsList = await provider.getEvents({

--- a/www/docs/guides/events.md
+++ b/www/docs/guides/events.md
@@ -118,14 +118,14 @@ Easier to read and process, isn't it?
 
 If you don't have the transaction Hash of the contract execution that created the event, it will be necessary to search inside the blocks of the Starknet blockchain.
 
-In this example, if you want to read the events recorded in the last 10 blocks, you need to use a method available only from an RPC node. The class `RpcProvider` is available for this case:
+In this example, if you want to read the events recorded in the last 10 blocks, you need to use a method available from a RPC node. The class `RpcProvider` is available for this case:
 
 ```typescript
 import { RpcProvider } from "starknet";
-const providerRPC = new RpcProvider({ nodeUrl: "{ nodeUrl: 'https://starknet-goerli.infura.io/v3/' + infuraKey }" }); // for an Infura node on Testnet
-const lastBlock = await providerRPC.getBlock('latest');
+const provider = new RpcProvider({ nodeUrl: 'https://starknet-goerli.infura.io/v3/' + infuraKey }); // for an Infura node on Testnet
+const lastBlock = await provider.getBlock('latest');
 const keyFilter = [num.toHex(hash.starknetKeccak("EventPanic")), "0x8"]
-const eventsList = await providerRPC.getEvents({
+const eventsList = await provider.getEvents({
     address: myContractAddress,
     from_block: {block_number: lastBlock.block_number-9},
     to_block: {block_number: lastBlock.block_number},

--- a/www/docs/guides/interact.md
+++ b/www/docs/guides/interact.md
@@ -31,7 +31,7 @@ import { RpcProvider, Contract, Account, ec, json } from "starknet";
 
 ## 🔍 Read from contract memory, with meta-class
 
-To read the balance, you need to connect a RpcProvider and a Contract.  
+To read the balance, you need to connect an RpcProvider and a Contract.  
 You have to call Starknet, with the use of the meta-class method: `contract.function_name(params)` (here `params` is not necessary, because there are no parameters for the `get_balance` function).
 
 ```typescript

--- a/www/docs/guides/interact.md
+++ b/www/docs/guides/interact.md
@@ -36,7 +36,7 @@ You have to call Starknet, with the use of the meta-class method: `contract.func
 
 ```typescript
 //initialize provider
-const provider = new RpcProvider({ nodeUrl: "https://limited-rpc.nethermind.io/goerli-juno" });
+const provider = new RpcProvider({ nodeUrl: `${myNodeUrl}` });
 // Connect the deployed Test contract in Testnet
 const testAddress = "0x5f7cd1fd465baff2ba9d2d1501ad0a2eb5337d9a885be319366b5205a414fdd";
 
@@ -63,7 +63,7 @@ Here is an example of how to increase and check the balance:
 
 ```typescript
 //initialize provider
-const provider = new RpcProvider({ nodeUrl: "https://starknet-testnet.public.blastapi.io/rpc/v0.5" });
+const provider = new RpcProvider({ nodeUrl: `${myNodeUrl}` });
 // connect your account. To adapt to your own account:
 const privateKey0 = process.env.OZ_ACCOUNT_PRIVATE_KEY;
 const account0Address = "0x123....789";

--- a/www/docs/guides/interact.md
+++ b/www/docs/guides/interact.md
@@ -26,17 +26,17 @@ This contract contains a storage variable called `balance`.
 - Balance can be modified with the `@external function: increase_balance(amount1: felt, amount2: felt)`
 
 ```typescript
-import { Provider, Contract, Account, ec, json } from "starknet";
+import { RpcProvider, Contract, Account, ec, json } from "starknet";
 ```
 
 ## 🔍 Read from contract memory, with meta-class
 
-To read the balance, you need to connect a Provider and a Contract.  
+To read the balance, you need to connect a RpcProvider and a Contract.  
 You have to call Starknet, with the use of the meta-class method: `contract.function_name(params)` (here `params` is not necessary, because there are no parameters for the `get_balance` function).
 
 ```typescript
-//initialize Provider
-const provider = new Provider({ sequencer: { network: constants.NetworkName.SN_GOERLI } });
+//initialize provider
+const provider = new RpcProvider({ nodeUrl: "https://limited-rpc.nethermind.io/goerli-juno" });
 // Connect the deployed Test contract in Testnet
 const testAddress = "0x5f7cd1fd465baff2ba9d2d1501ad0a2eb5337d9a885be319366b5205a414fdd";
 
@@ -62,8 +62,8 @@ You have to invoke Starknet, with the use of the meta-class method: `contract.fu
 Here is an example of how to increase and check the balance:
 
 ```typescript
-//initialize Provider
-const provider = new Provider({ sequencer: { network: constants.NetworkName.SN_GOERLI } });
+//initialize provider
+const provider = new RpcProvider({ nodeUrl: "https://starknet-testnet.public.blastapi.io/rpc/v0.5" });
 // connect your account. To adapt to your own account:
 const privateKey0 = process.env.OZ_ACCOUNT_PRIVATE_KEY;
 const account0Address = "0x123....789";

--- a/www/docs/guides/intro.md
+++ b/www/docs/guides/intro.md
@@ -20,32 +20,15 @@ npm install starknet@next
 
 ### With Devnet
 
-- Sequencer Devnet [docs](https://0xspaceshard.github.io/starknet-devnet/docs/intro)
 - RPC Devnet [repo](https://github.com/0xSpaceShard/starknet-devnet-rs)
 
-Get the Sequencer Devnet with Docker:
-
-```bash
-docker pull shardlabs/starknet-devnet:latest
-docker run -p 5050:5050 shardlabs/starknet-devnet:latest --seed 0
-```
+Launch the development net.
 
 Open a new console tab, go to your starknet.js directory, and run:
 
 ```bash
 npm run test # all tests
 npm run test ./__tests__/contract.test.ts # just one test suite
-```
-
-By default, `defaultProvider` tests will be run through the `Sequencer`.
-
-If you want to run `defaultProvider` through the `RPC` run:
-
-```bash
-export TEST_RPC_URL = "http://127.0.0.1:5050/rpc"
-
-# only RPC related tests:
-npm run test ./__tests__/rpcProvider.test.ts
 ```
 
 ## Running docs locally

--- a/www/docs/guides/migrate.md
+++ b/www/docs/guides/migrate.md
@@ -149,17 +149,17 @@ Returned values from a Cairo 0 contract are identical, but returned values from 
 
 ## Provider
 
-Constants for `Provider` initialization have been updated:
+Constants for `Provider` initialization have been updated. Only `RpcProvider` is now authorized:
 
 ```typescript
 // v4
 const providerTestnet = new Provider({ sequencer: { network: "goerli-alpha" } });
 
 // v5
- const providerTestnet = new Provider({ sequencer: { network: constants.NetworkName.SN_GOERLI } }); // or SN_MAIN
+ const providerTestnet = new RpcProvider({ nodeUrl: "https://limited-rpc.nethermind.io/goerli-juno" });
 ```
 
-`Provider.chainId()` has been removed, `Provider.getChainId()` should be used.
+`Provider.chainId()` has been removed, `RpcProvider.getChainId()` should be used.
 
 ```typescript
 // v4

--- a/www/docs/guides/migrate.md
+++ b/www/docs/guides/migrate.md
@@ -156,7 +156,7 @@ Constants for `Provider` initialization have been updated. Only `RpcProvider` is
 const providerTestnet = new Provider({ sequencer: { network: "goerli-alpha" } });
 
 // v5
- const providerTestnet = new RpcProvider({ nodeUrl: "https://limited-rpc.nethermind.io/goerli-juno" });
+ const providerTestnet = new RpcProvider({ nodeUrl: `${myNodeUrl}` });
 ```
 
 `Provider.chainId()` has been removed, `RpcProvider.getChainId()` should be used.

--- a/www/docs/guides/signature.md
+++ b/www/docs/guides/signature.md
@@ -58,7 +58,7 @@ console.log("Result (boolean) =", result1);
 Read the Public Key of the account:
 
 ```typescript
-const provider = new Provider({ sequencer: { baseUrl: "http://127.0.0.1:5050" } }); //devnet
+const provider = new RpcProvider({ nodeUrl: "http://127.0.0.1:5050/rpc" }); //devnet
 const compiledAccount = json.parse(fs.readFileSync("./compiled_contracts/Account_0_5_1.json").toString("ascii"));
 const accountAddress ="0x...."; // account of sender
 const contractAccount = new Contract(compiledAccount.abi, accountAddress, provider);
@@ -78,7 +78,7 @@ console.log("Result (boolean)=", isFullPubKeyRelatedToAccount);
 The sender can provide an account address, despite a full public key.
 
 ```typescript
-const provider = new Provider({ sequencer: { baseUrl: "http://127.0.0.1:5050" } }); //devnet
+const provider = new RpcProvider({ nodeUrl: "http://127.0.0.1:5050/rpc" }); //devnet
 const compiledAccount = json.parse(fs.readFileSync("./compiled_contracts/Account_0_5_1.json").toString("ascii"));
 
 const accountAddress ="0x..."; // account of sender

--- a/www/docs/guides/use_ERC20.md
+++ b/www/docs/guides/use_ERC20.md
@@ -43,7 +43,7 @@ First, let's initialize an account:
 
 ```typescript
 // initialize provider
-const provider = new Provider({ sequencer: { baseUrl:"http://127.0.0.1:5050"  } });
+const provider = new RpcProvider({ nodeUrl: "http://127.0.0.1:5050/rpc" });
 // initialize existing pre-deployed account 0 of Devnet
 const privateKey = "0xe3e70682c2094cac629f6fbed82c07cd";
 const accountAddress = "0x7e00d496e324876bbc8531f2d9a82bf154d1a04a50218ee74cdd372f75a551a";

--- a/www/docs/guides/what_s_starknet.js.md
+++ b/www/docs/guides/what_s_starknet.js.md
@@ -25,7 +25,7 @@ Some important topics that have to be understood:
 
 > Understand what is Starknet and how it works is necessary. Then, you can learn how to interact with it using Starknet.js. So, at this stage, you should be aware of the content of the [Starknet official doc](https://docs.starknet.io/documentation/) and [the Starknet Book](https://book.starknet.io/).
 
-- Only the `Provider` object is talking directly to the network - your DAPP will talk mainly to `Account` and `Contract` objects. You will define with the `Provider` with which network you want to work. You can ask the Provider for some low-level data of the network (block, timestamp, ...).
+- Only the `RpcProvider` object is talking directly to the network - your DAPP will talk mainly to `Account` and `Contract` objects. You will define with the `RpcProvider` with which network you want to work. You can ask the provider for some low-level data of the network (block, timestamp, ...).
 - `Signer` and `Utils` objects contain many useful functions for interaction with Starknet.js.
 - The `Contract` object is mainly used to read the memory of a blockchain contract.
 - The `Account` object is the most useful:

--- a/www/docs/guides/what_s_starknet.js.md
+++ b/www/docs/guides/what_s_starknet.js.md
@@ -23,9 +23,9 @@ Some important topics that have to be understood:
   - private customized version of Starknet.
   - local Starknet node (connected to mainnet or testnet).
 
-> Understand what is Starknet and how it works is necessary. Then, you can learn how to interact with it using Starknet.js. So, at this stage, you should be aware of the content of the [Starknet official doc](https://docs.starknet.io/documentation/) and [the Starknet Book](https://book.starknet.io/).
+> Understanding what Starknet is and how it works is necessary. Then, you can learn how to interact with it using Starknet.js. So, at this stage, you should be aware of the content of the [Starknet official doc](https://docs.starknet.io/documentation/) and [the Starknet Book](https://book.starknet.io/).
 
-- Only the `RpcProvider` object is talking directly to the network - your DAPP will talk mainly to `Account` and `Contract` objects. You will define with the `RpcProvider` with which network you want to work. You can ask the provider for some low-level data of the network (block, timestamp, ...).
+- Only the `RpcProvider` object communicates directly with the network; your DAPP will mainly interact with `Account` and `Contract` objects. You will define with the `RpcProvider` with which network you want to work. You can use the provider to access some low-level data from the network (block, timestamp, ...).
 - `Signer` and `Utils` objects contain many useful functions for interaction with Starknet.js.
 - The `Contract` object is mainly used to read the memory of a blockchain contract.
 - The `Account` object is the most useful:


### PR DESCRIPTION
## Motivation and Resolution

Following removal of Starknet sequencers, users shall only use `RpcSequencer`.
The guides are here updated in accordance.
It's also the opportunity to migrate in the guides from Pythonic Devnet to Starknet-devnet-rs.



## Usage related changes
N/A

## Development related changes
N/A

## Checklist:

- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] All tests are passing
