### PR TITLE
Aggregate typo changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ If you consider to contribute to this project please read [CONTRIBUTING.md](http
 
 Special thanks to all the [contributors](https://github.com/starknet-io/starknet.js/graphs/contributors), especially to:
 
-- Sean ([@0xs34n](https://github.com/0xs34n)), the original creator of Straknet.js!
+- Sean ([@0xs34n](https://github.com/0xs34n)), the original creator of Starknet.js!
 
 - Janek ([@janek26](https://github.com/janek26)) and Dhruv ([@dhruvkelawala](https://github.com/dhruvkelawala)) from [Argent](https://github.com/argentlabs)
 

--- a/__mocks__/cairo/helloCairo2/hellocairo
+++ b/__mocks__/cairo/helloCairo2/hellocairo
@@ -478,7 +478,7 @@ mod HelloStarknet {
             }
         }
 
-        // return Option<litteral>
+        // return Option<literal>
         fn option_u8_output(self: @ContractState, val1: u8) -> Option<u8> {
             if val1 < 100 {
                 return Option::None(());

--- a/__tests__/cairo1v2.test.ts
+++ b/__tests__/cairo1v2.test.ts
@@ -141,7 +141,7 @@ describe('Cairo 1', () => {
       expect(balance).toBe(200n);
     });
 
-    test('Cairo 1 Contract Interaction - uint 8, 16, 32, 64, 128, litterals', async () => {
+    test('Cairo 1 Contract Interaction - uint 8, 16, 32, 64, 128, literals', async () => {
       const tx = await cairo1Contract.increase_balance_u8(255n);
       await account.waitForTransaction(tx.transaction_hash);
       const balance = await cairo1Contract.get_balance_u8();

--- a/__tests__/contract.test.ts
+++ b/__tests__/contract.test.ts
@@ -443,7 +443,7 @@ describe('Complex interaction', () => {
     expect(json.stringify(compiled)).toBe(reference);
     expect(json.stringify(doubleCompiled)).toBe(reference);
 
-    // mix of complex and litteral
+    // mix of complex and literal
     const mySetArgs = {
       validators: [234, 235],
       powers: { a1: 562, a2: 567 },

--- a/src/account/interface.ts
+++ b/src/account/interface.ts
@@ -262,7 +262,7 @@ export abstract class AccountInterface extends ProviderInterface {
 
   /**
    * Sign an JSON object for off-chain usage with the starknet private key and return the signature
-   * This adds a message prefix so it cant be interchanged with transactions
+   * This adds a message prefix so it can't be interchanged with transactions
    *
    * @param json - JSON object to be signed
    * @returns the signature of the JSON object
@@ -271,8 +271,8 @@ export abstract class AccountInterface extends ProviderInterface {
   public abstract signMessage(typedData: TypedData): Promise<Signature>;
 
   /**
-   * Hash a JSON object with pederson hash and return the hash
-   * This adds a message prefix so it cant be interchanged with transactions
+   * Hash a JSON object with Pedersen hash and return the hash
+   * This adds a message prefix so it can't be interchanged with transactions
    *
    * @param json - JSON object to be hashed
    * @returns the hash of the JSON object

--- a/src/account/interface.ts
+++ b/src/account/interface.ts
@@ -261,7 +261,7 @@ export abstract class AccountInterface extends ProviderInterface {
   ): Promise<DeployContractResponse>;
 
   /**
-   * Sign an JSON object for off-chain usage with the starknet private key and return the signature
+   * Signs a JSON object for off-chain usage with the Starknet private key and returns the signature
    * This adds a message prefix so it can't be interchanged with transactions
    *
    * @param json - JSON object to be signed
@@ -322,7 +322,7 @@ export abstract class AccountInterface extends ProviderInterface {
   ): Promise<bigint>;
 
   /**
-   * Simulates an array of transaction and returns an array of transaction trace and estimated fee.
+   * Simulates an array of transactions and returns an array of transaction trace and estimated fee.
    *
    * @param invocations Invocations containing:
    * - type - transaction type: DECLARE, (multi)DEPLOY, DEPLOY_ACCOUNT, (multi)INVOKE_FUNCTION

--- a/src/contract/contractFactory.ts
+++ b/src/contract/contractFactory.ts
@@ -110,5 +110,5 @@ export class ContractFactory {
     return new Contract(this.abi, address, this.account);
   }
 
-  // ethers.js' getDeployTransaction cant be supported as it requires the account or signer to return a signed transaction which is not possible with the current implementation
+  // ethers.js' getDeployTransaction can't be supported as it requires the account or signer to return a signed transaction which is not possible with the current implementation
 }

--- a/src/provider/interface.ts
+++ b/src/provider/interface.ts
@@ -158,7 +158,7 @@ export abstract class ProviderInterface {
 
   /**
    * Invokes a function on starknet
-   * @deprecated This method wont be supported as soon as fees are mandatory. Should not be used outside of Account class
+   * @deprecated This method won't be supported as soon as fees are mandatory. Should not be used outside of Account class
    *
    * @param invocation the invocation object containing:
    * - contractAddress - the address of the contract

--- a/src/provider/sequencer.ts
+++ b/src/provider/sequencer.ts
@@ -370,7 +370,7 @@ export class SequencerProvider implements ProviderInterface {
     } else if (classHash) {
       contractClass = await this.getClassByHash(classHash, blockIdentifier);
     } else {
-      throw Error('getContractVersion require contractAddress or classHash');
+      throw Error('getContractVersion requires contractAddress or classHash');
     }
 
     if (isSierra(contractClass)) {

--- a/src/provider/sequencer.ts
+++ b/src/provider/sequencer.ts
@@ -196,7 +196,7 @@ export class SequencerProvider implements ProviderInterface {
         : [undefined, Sequencer.Endpoints[T]['REQUEST']]
       : Sequencer.Endpoints[T]['REQUEST'] extends never
       ? [Sequencer.Endpoints[T]['QUERY']] // when no request is needed, we can omit the request parameter
-      : [Sequencer.Endpoints[T]['QUERY'], Sequencer.Endpoints[T]['REQUEST']] // when both query and request are needed, we cant omit anything
+      : [Sequencer.Endpoints[T]['QUERY'], Sequencer.Endpoints[T]['REQUEST']] // when both query and request are needed, we can't omit anything
   ): Promise<Sequencer.Endpoints[T]['RESPONSE']> {
     const baseUrl = this.getFetchUrl(endpoint);
     const method = this.getFetchMethod(endpoint);

--- a/src/types/calldata.ts
+++ b/src/types/calldata.ts
@@ -13,7 +13,7 @@ export enum Uint {
   u256 = 'core::integer::u256', // This one is struct
 }
 
-export enum Litteral {
+export enum Literal {
   ClassHash = 'core::starknet::class_hash::ClassHash',
   ContractAddress = 'core::starknet::contract_address::ContractAddress',
 }

--- a/src/types/lib/contract/legacy.ts
+++ b/src/types/lib/contract/legacy.ts
@@ -11,7 +11,7 @@ export type LegacyContractClass = {
 };
 
 /**
- * format produced after compile .cairo to .json
+ * format produced after compiling .cairo to .json
  */
 export type LegacyCompiledContract = Omit<LegacyContractClass, 'program'> & {
   program: Program;

--- a/src/utils/calldata/cairo.ts
+++ b/src/utils/calldata/cairo.ts
@@ -4,7 +4,7 @@ import {
   AbiStructs,
   BigNumberish,
   ContractVersion,
-  Litteral,
+  Literal,
   Uint,
   Uint256,
 } from '../../types';
@@ -26,7 +26,7 @@ export const isTypeEnum = (type: string, enums: AbiEnums) => type in enums;
 export const isTypeOption = (type: string) => type.startsWith('core::option::Option::');
 export const isTypeResult = (type: string) => type.startsWith('core::result::Result::');
 export const isTypeUint = (type: string) => Object.values(Uint).includes(type as Uint);
-export const isTypeLitteral = (type: string) => Object.values(Litteral).includes(type as Litteral);
+export const isTypeLiteral = (type: string) => Object.values(Literal).includes(type as Literal);
 export const isTypeUint256 = (type: string) => type === 'core::integer::u256';
 export const isTypeBool = (type: string) => type === 'core::bool';
 export const isTypeContractAddress = (type: string) =>

--- a/src/utils/calldata/enum/CairoCustomEnum.ts
+++ b/src/utils/calldata/enum/CairoCustomEnum.ts
@@ -29,7 +29,7 @@ export class CairoCustomEnum {
   constructor(enumContent: CairoEnumRaw) {
     const variantsList = Object.values(enumContent);
     if (variantsList.length === 0) {
-      throw new Error('This Enum must have a least 1 variant');
+      throw new Error('This Enum must have at least 1 variant');
     }
     const nbActiveVariants = variantsList.filter(
       (content) => typeof content !== 'undefined'

--- a/src/utils/calldata/propertyOrder.ts
+++ b/src/utils/calldata/propertyOrder.ts
@@ -63,7 +63,7 @@ export default function orderPropsByAbi(
       // eslint-disable-next-line @typescript-eslint/no-use-before-define
       return orderStruct(unorderedItem, abiOfStruct);
     }
-    // litterals
+    // literals
     return unorderedItem;
   };
 

--- a/src/utils/calldata/validate.ts
+++ b/src/utils/calldata/validate.ts
@@ -8,7 +8,7 @@ import {
   AbiStructs,
   BigNumberish,
   FunctionAbi,
-  Litteral,
+  Literal,
   Uint,
 } from '../../types';
 import assert from '../assert';
@@ -22,7 +22,7 @@ import {
   isTypeBool,
   isTypeEnum,
   isTypeFelt,
-  isTypeLitteral,
+  isTypeLiteral,
   isTypeOption,
   isTypeResult,
   isTypeStruct,
@@ -105,7 +105,7 @@ const validateUint = (parameter: any, input: AbiEntry) => {
       );
       break;
 
-    case Litteral.ClassHash:
+    case Literal.ClassHash:
       assert(
         // from : https://github.com/starkware-libs/starknet-specs/blob/29bab650be6b1847c92d4461d4c33008b5e50b1a/api/starknet_api_openrpc.json#L1670
         param >= 0n && param <= 2n ** 252n - 1n,
@@ -113,7 +113,7 @@ const validateUint = (parameter: any, input: AbiEntry) => {
       );
       break;
 
-    case Litteral.ContractAddress:
+    case Literal.ContractAddress:
       assert(
         // from : https://github.com/starkware-libs/starknet-specs/blob/29bab650be6b1847c92d4461d4c33008b5e50b1a/api/starknet_api_openrpc.json#L1245
         param >= 0n && param <= 2n ** 252n - 1n,
@@ -235,7 +235,7 @@ const validateArray = (parameter: any, input: AbiEntry, structs: AbiStructs, enu
     case isTypeEnum(baseType, enums):
       parameter.forEach((it: any) => validateEnum(it, { name: input.name, type: baseType }));
       break;
-    case isTypeUint(baseType) || isTypeLitteral(baseType):
+    case isTypeUint(baseType) || isTypeLiteral(baseType):
       parameter.forEach((param: BigNumberish) => validateUint(param, input));
       break;
     case isTypeBool(baseType):
@@ -263,7 +263,7 @@ export default function validateFields(
       case isTypeFelt(input.type):
         validateFelt(parameter, input);
         break;
-      case isTypeUint(input.type) || isTypeLitteral(input.type):
+      case isTypeUint(input.type) || isTypeLiteral(input.type):
         validateUint(parameter, input);
         break;
       case isTypeBool(input.type):

--- a/www/docs/guides/connect_contract.md
+++ b/www/docs/guides/connect_contract.md
@@ -53,6 +53,6 @@ const myTestContract = new Contract(compiledTest.abi, testAddress, provider);
 
 ## Typechecking and autocompletion
 
-If you want to have typechecking and autocompletion for your contracts functions calls and catch typing errors early, you can use Abiwan! 
+If you want to have typechecking and autocompletion for your contracts functions calls and catch typing errors early, you can use Abiwan!
 
 See [this guide](./automatic_cairo_ABI_parsing.md) for more details.

--- a/www/docs/guides/create_account.md
+++ b/www/docs/guides/create_account.md
@@ -110,7 +110,7 @@ const argentXaccountClassHash = "0x033434ad846cdd5f23eb73ff09fe6fddd568284a0fb7d
 // Generate public and private key pair.
 const privateKeyAX = stark.randomAddress();
 console.log('AX_ACCOUNT_PRIVATE_KEY=', privateKeyAX);
-const starkKeyPubAX = ec.starkCurve.getStarkKey(privateKey);
+const starkKeyPubAX = ec.starkCurve.getStarkKey(privateKeyAX);
 console.log('AX_ACCOUNT_PUBLIC_KEY=', starkKeyPubAX);
 
 // Calculate future address of the ArgentX account

--- a/www/docs/guides/estimate_fees.md
+++ b/www/docs/guides/estimate_fees.md
@@ -43,7 +43,7 @@ To estimate the cost to deploy an account in the network:
 
 ```typescript
 const { suggestedMaxFee: estimatedFee1 } = await account0.estimateAccountDeployFee({
-	classHash: OZaccountClashHass,
+	classHash: OZaccountClassHash,
 	constructorCalldata: OZaccountConstructorCallData,
 	contractAddress: OZcontractAddress
 });

--- a/www/versioned_docs/version-5.14.1/API/classes/Account.md
+++ b/www/versioned_docs/version-5.14.1/API/classes/Account.md
@@ -574,7 +574,7 @@ a confirmation of sending a transaction on the starknet contract
 ▸ **signMessage**(`typedData`): `Promise`<[`Signature`](../namespaces/types.md#signature)\>
 
 Sign an JSON object for off-chain usage with the starknet private key and return the signature
-This adds a message prefix so it cant be interchanged with transactions
+This adds a message prefix so it can't be interchanged with transactions
 
 **`Throws`**
 
@@ -606,8 +606,8 @@ the signature of the JSON object
 
 ▸ **hashMessage**(`typedData`): `Promise`<`string`\>
 
-Hash a JSON object with pederson hash and return the hash
-This adds a message prefix so it cant be interchanged with transactions
+Hash a JSON object with Pedersen hash and return the hash
+This adds a message prefix so it can't be interchanged with transactions
 
 **`Throws`**
 
@@ -1307,7 +1307,7 @@ Invokes a function on starknet
 
 **`Deprecated`**
 
-This method wont be supported as soon as fees are mandatory. Should not be used outside of Account class
+This method won't be supported as soon as fees are mandatory. Should not be used outside of Account class
 
 #### Parameters
 

--- a/www/versioned_docs/version-5.14.1/API/classes/AccountInterface.md
+++ b/www/versioned_docs/version-5.14.1/API/classes/AccountInterface.md
@@ -363,7 +363,7 @@ a confirmation of sending a transaction on the starknet contract
 ▸ `Abstract` **signMessage**(`typedData`): `Promise`<[`Signature`](../namespaces/types.md#signature)\>
 
 Sign an JSON object for off-chain usage with the starknet private key and return the signature
-This adds a message prefix so it cant be interchanged with transactions
+This adds a message prefix so it can't be interchanged with transactions
 
 **`Throws`**
 
@@ -391,8 +391,8 @@ the signature of the JSON object
 
 ▸ `Abstract` **hashMessage**(`typedData`): `Promise`<`string`\>
 
-Hash a JSON object with pederson hash and return the hash
-This adds a message prefix so it cant be interchanged with transactions
+Hash a JSON object with Pedersen hash and return the hash
+This adds a message prefix so it can't be interchanged with transactions
 
 **`Throws`**
 
@@ -898,7 +898,7 @@ Invokes a function on starknet
 
 **`Deprecated`**
 
-This method wont be supported as soon as fees are mandatory. Should not be used outside of Account class
+This method won't be supported as soon as fees are mandatory. Should not be used outside of Account class
 
 #### Parameters
 

--- a/www/versioned_docs/version-5.14.1/API/classes/Provider.md
+++ b/www/versioned_docs/version-5.14.1/API/classes/Provider.md
@@ -426,7 +426,7 @@ Invokes a function on starknet
 
 **`Deprecated`**
 
-This method wont be supported as soon as fees are mandatory. Should not be used outside of Account class
+This method won't be supported as soon as fees are mandatory. Should not be used outside of Account class
 
 #### Parameters
 

--- a/www/versioned_docs/version-5.14.1/API/classes/ProviderInterface.md
+++ b/www/versioned_docs/version-5.14.1/API/classes/ProviderInterface.md
@@ -324,7 +324,7 @@ Invokes a function on starknet
 
 **`Deprecated`**
 
-This method wont be supported as soon as fees are mandatory. Should not be used outside of Account class
+This method won't be supported as soon as fees are mandatory. Should not be used outside of Account class
 
 #### Parameters
 

--- a/www/versioned_docs/version-5.14.1/API/classes/RpcProvider.md
+++ b/www/versioned_docs/version-5.14.1/API/classes/RpcProvider.md
@@ -827,7 +827,7 @@ Invokes a function on starknet
 
 **`Deprecated`**
 
-This method wont be supported as soon as fees are mandatory. Should not be used outside of Account class
+This method won't be supported as soon as fees are mandatory. Should not be used outside of Account class
 
 #### Parameters
 

--- a/www/versioned_docs/version-5.14.1/API/classes/SequencerProvider.md
+++ b/www/versioned_docs/version-5.14.1/API/classes/SequencerProvider.md
@@ -579,7 +579,7 @@ Invokes a function on starknet
 
 **`Deprecated`**
 
-This method wont be supported as soon as fees are mandatory. Should not be used outside of Account class
+This method won't be supported as soon as fees are mandatory. Should not be used outside of Account class
 
 #### Parameters
 

--- a/www/versioned_docs/version-5.14.1/API/classes/Signer.md
+++ b/www/versioned_docs/version-5.14.1/API/classes/Signer.md
@@ -65,7 +65,7 @@ public key of signer as hex string with 0x prefix
 ▸ **signMessage**(`typedData`, `accountAddress`): `Promise`<[`Signature`](../namespaces/types.md#signature)\>
 
 Sign an JSON object for off-chain usage with the starknet private key and return the signature
-This adds a message prefix so it cant be interchanged with transactions
+This adds a message prefix so it can't be interchanged with transactions
 
 **`Throws`**
 

--- a/www/versioned_docs/version-5.14.1/API/classes/SignerInterface.md
+++ b/www/versioned_docs/version-5.14.1/API/classes/SignerInterface.md
@@ -41,7 +41,7 @@ public key of signer as hex string with 0x prefix
 ▸ `Abstract` **signMessage**(`typedData`, `accountAddress`): `Promise`<[`Signature`](../namespaces/types.md#signature)\>
 
 Sign an JSON object for off-chain usage with the starknet private key and return the signature
-This adds a message prefix so it cant be interchanged with transactions
+This adds a message prefix so it can't be interchanged with transactions
 
 **`Throws`**
 

--- a/www/versioned_docs/version-5.14.1/guides/Old_API_doc/account.md
+++ b/www/versioned_docs/version-5.14.1/guides/Old_API_doc/account.md
@@ -460,7 +460,7 @@ The _transactionsDetail_ object may include any of:
 
 account.**signMessage**(typedData) => _Promise < Signature >_
 
-Sign an JSON object for off-chain usage with the starknet private key and return the signature. This adds a message prefix so it cant be interchanged with transactions.
+Sign an JSON object for off-chain usage with the starknet private key and return the signature. This adds a message prefix so it can't be interchanged with transactions.
 
 _typedData_ - JSON object to be signed
 
@@ -476,7 +476,7 @@ string[];
 
 account.**hashMessage**(typedData) => _Promise < string >_
 
-Hash a JSON object with pederson hash and return the hash. This adds a message prefix so it cant be interchanged with transactions.
+Hash a JSON object with Pedersen hash and return the hash. This adds a message prefix so it can't be interchanged with transactions.
 
 _typedData_ - JSON object to be signed
 

--- a/www/versioned_docs/version-5.14.1/guides/create_account.md
+++ b/www/versioned_docs/version-5.14.1/guides/create_account.md
@@ -110,7 +110,7 @@ const argentXaccountClassHash = "0x033434ad846cdd5f23eb73ff09fe6fddd568284a0fb7d
 // Generate public and private key pair.
 const privateKeyAX = stark.randomAddress();
 console.log('AX_ACCOUNT_PRIVATE_KEY=', privateKeyAX);
-const starkKeyPubAX = ec.starkCurve.getStarkKey(privateKey);
+const starkKeyPubAX = ec.starkCurve.getStarkKey(privateKeyAX);
 console.log('AX_ACCOUNT_PUBLIC_KEY=', starkKeyPubAX);
 
 // Calculate future address of the ArgentX account

--- a/www/versioned_docs/version-5.14.1/guides/estimate_fees.md
+++ b/www/versioned_docs/version-5.14.1/guides/estimate_fees.md
@@ -39,7 +39,7 @@ To estimate the cost to deploy an account in the network:
 
 ```typescript
 const { suggestedMaxFee: estimatedFee1 } = await account0.estimateAccountDeployFee({
-	classHash: OZaccountClashHass,
+	classHash: OZaccountClassHash,
 	constructorCalldata: OZaccountConstructorCallData,
 	contractAddress: OZcontractAddress
 });

--- a/www/versioned_docs/version-5.19.5/API/classes/Account.md
+++ b/www/versioned_docs/version-5.19.5/API/classes/Account.md
@@ -574,7 +574,7 @@ a confirmation of sending a transaction on the starknet contract
 ▸ **signMessage**(`typedData`): `Promise`<[`Signature`](../namespaces/types.md#signature)\>
 
 Sign an JSON object for off-chain usage with the starknet private key and return the signature
-This adds a message prefix so it cant be interchanged with transactions
+This adds a message prefix so it can't be interchanged with transactions
 
 **`Throws`**
 
@@ -606,8 +606,8 @@ the signature of the JSON object
 
 ▸ **hashMessage**(`typedData`): `Promise`<`string`\>
 
-Hash a JSON object with pederson hash and return the hash
-This adds a message prefix so it cant be interchanged with transactions
+Hash a JSON object with Pedersen hash and return the hash
+This adds a message prefix so it can't be interchanged with transactions
 
 **`Throws`**
 
@@ -1307,7 +1307,7 @@ Invokes a function on starknet
 
 **`Deprecated`**
 
-This method wont be supported as soon as fees are mandatory. Should not be used outside of Account class
+This method won't be supported as soon as fees are mandatory. Should not be used outside of Account class
 
 #### Parameters
 

--- a/www/versioned_docs/version-5.19.5/API/classes/AccountInterface.md
+++ b/www/versioned_docs/version-5.19.5/API/classes/AccountInterface.md
@@ -363,7 +363,7 @@ a confirmation of sending a transaction on the starknet contract
 ▸ `Abstract` **signMessage**(`typedData`): `Promise`<[`Signature`](../namespaces/types.md#signature)\>
 
 Sign an JSON object for off-chain usage with the starknet private key and return the signature
-This adds a message prefix so it cant be interchanged with transactions
+This adds a message prefix so it can't be interchanged with transactions
 
 **`Throws`**
 
@@ -391,8 +391,8 @@ the signature of the JSON object
 
 ▸ `Abstract` **hashMessage**(`typedData`): `Promise`<`string`\>
 
-Hash a JSON object with pederson hash and return the hash
-This adds a message prefix so it cant be interchanged with transactions
+Hash a JSON object with Pedersen hash and return the hash
+This adds a message prefix so it can't be interchanged with transactions
 
 **`Throws`**
 
@@ -898,7 +898,7 @@ Invokes a function on starknet
 
 **`Deprecated`**
 
-This method wont be supported as soon as fees are mandatory. Should not be used outside of Account class
+This method won't be supported as soon as fees are mandatory. Should not be used outside of Account class
 
 #### Parameters
 

--- a/www/versioned_docs/version-5.19.5/API/classes/Provider.md
+++ b/www/versioned_docs/version-5.19.5/API/classes/Provider.md
@@ -426,7 +426,7 @@ Invokes a function on starknet
 
 **`Deprecated`**
 
-This method wont be supported as soon as fees are mandatory. Should not be used outside of Account class
+This method won't be supported as soon as fees are mandatory. Should not be used outside of Account class
 
 #### Parameters
 

--- a/www/versioned_docs/version-5.19.5/API/classes/ProviderInterface.md
+++ b/www/versioned_docs/version-5.19.5/API/classes/ProviderInterface.md
@@ -324,7 +324,7 @@ Invokes a function on starknet
 
 **`Deprecated`**
 
-This method wont be supported as soon as fees are mandatory. Should not be used outside of Account class
+This method won't be supported as soon as fees are mandatory. Should not be used outside of Account class
 
 #### Parameters
 

--- a/www/versioned_docs/version-5.19.5/API/classes/RpcProvider.md
+++ b/www/versioned_docs/version-5.19.5/API/classes/RpcProvider.md
@@ -827,7 +827,7 @@ Invokes a function on starknet
 
 **`Deprecated`**
 
-This method wont be supported as soon as fees are mandatory. Should not be used outside of Account class
+This method won't be supported as soon as fees are mandatory. Should not be used outside of Account class
 
 #### Parameters
 

--- a/www/versioned_docs/version-5.19.5/API/classes/SequencerProvider.md
+++ b/www/versioned_docs/version-5.19.5/API/classes/SequencerProvider.md
@@ -579,7 +579,7 @@ Invokes a function on starknet
 
 **`Deprecated`**
 
-This method wont be supported as soon as fees are mandatory. Should not be used outside of Account class
+This method won't be supported as soon as fees are mandatory. Should not be used outside of Account class
 
 #### Parameters
 

--- a/www/versioned_docs/version-5.19.5/API/classes/Signer.md
+++ b/www/versioned_docs/version-5.19.5/API/classes/Signer.md
@@ -65,7 +65,7 @@ public key of signer as hex string with 0x prefix
 ▸ **signMessage**(`typedData`, `accountAddress`): `Promise`<[`Signature`](../namespaces/types.md#signature)\>
 
 Sign an JSON object for off-chain usage with the starknet private key and return the signature
-This adds a message prefix so it cant be interchanged with transactions
+This adds a message prefix so it can't be interchanged with transactions
 
 **`Throws`**
 

--- a/www/versioned_docs/version-5.19.5/API/classes/SignerInterface.md
+++ b/www/versioned_docs/version-5.19.5/API/classes/SignerInterface.md
@@ -41,7 +41,7 @@ public key of signer as hex string with 0x prefix
 ▸ `Abstract` **signMessage**(`typedData`, `accountAddress`): `Promise`<[`Signature`](../namespaces/types.md#signature)\>
 
 Sign an JSON object for off-chain usage with the starknet private key and return the signature
-This adds a message prefix so it cant be interchanged with transactions
+This adds a message prefix so it can't be interchanged with transactions
 
 **`Throws`**
 

--- a/www/versioned_docs/version-5.19.5/guides/Old_API_doc/account.md
+++ b/www/versioned_docs/version-5.19.5/guides/Old_API_doc/account.md
@@ -460,7 +460,7 @@ The _transactionsDetail_ object may include any of:
 
 account.**signMessage**(typedData) => _Promise < Signature >_
 
-Sign an JSON object for off-chain usage with the starknet private key and return the signature. This adds a message prefix so it cant be interchanged with transactions.
+Sign an JSON object for off-chain usage with the starknet private key and return the signature. This adds a message prefix so it can't be interchanged with transactions.
 
 _typedData_ - JSON object to be signed
 
@@ -476,7 +476,7 @@ string[];
 
 account.**hashMessage**(typedData) => _Promise < string >_
 
-Hash a JSON object with pederson hash and return the hash. This adds a message prefix so it cant be interchanged with transactions.
+Hash a JSON object with Pedersen hash and return the hash. This adds a message prefix so it can't be interchanged with transactions.
 
 _typedData_ - JSON object to be signed
 

--- a/www/versioned_docs/version-5.19.5/guides/create_account.md
+++ b/www/versioned_docs/version-5.19.5/guides/create_account.md
@@ -118,7 +118,7 @@ const argentXaccountClassHash = "0x033434ad846cdd5f23eb73ff09fe6fddd568284a0fb7d
 // Generate public and private key pair.
 const privateKeyAX = stark.randomAddress();
 console.log('AX_ACCOUNT_PRIVATE_KEY=', privateKeyAX);
-const starkKeyPubAX = ec.starkCurve.getStarkKey(privateKey);
+const starkKeyPubAX = ec.starkCurve.getStarkKey(privateKeyAX);
 console.log('AX_ACCOUNT_PUBLIC_KEY=', starkKeyPubAX);
 
 // Calculate future address of the ArgentX account

--- a/www/versioned_docs/version-5.19.5/guides/estimate_fees.md
+++ b/www/versioned_docs/version-5.19.5/guides/estimate_fees.md
@@ -39,7 +39,7 @@ To estimate the cost to deploy an account in the network:
 
 ```typescript
 const { suggestedMaxFee: estimatedFee1 } = await account0.estimateAccountDeployFee({
-	classHash: OZaccountClashHass,
+	classHash: OZaccountClassHash,
 	constructorCalldata: OZaccountConstructorCallData,
 	contractAddress: OZcontractAddress
 });

--- a/www/versioned_docs/version-5.24.3/API/classes/Account.md
+++ b/www/versioned_docs/version-5.24.3/API/classes/Account.md
@@ -598,7 +598,7 @@ a confirmation of sending a transaction on the starknet contract
 ▸ **signMessage**(`typedData`): `Promise`<[`Signature`](../namespaces/types.md#signature)\>
 
 Sign an JSON object for off-chain usage with the starknet private key and return the signature
-This adds a message prefix so it cant be interchanged with transactions
+This adds a message prefix so it can't be interchanged with transactions
 
 **`Throws`**
 
@@ -630,8 +630,8 @@ the signature of the JSON object
 
 ▸ **hashMessage**(`typedData`): `Promise`<`string`\>
 
-Hash a JSON object with pederson hash and return the hash
-This adds a message prefix so it cant be interchanged with transactions
+Hash a JSON object with Pedersen hash and return the hash
+This adds a message prefix so it can't be interchanged with transactions
 
 **`Throws`**
 
@@ -1331,7 +1331,7 @@ Invokes a function on starknet
 
 **`Deprecated`**
 
-This method wont be supported as soon as fees are mandatory. Should not be used outside of Account class
+This method won't be supported as soon as fees are mandatory. Should not be used outside of Account class
 
 #### Parameters
 

--- a/www/versioned_docs/version-5.24.3/API/classes/AccountInterface.md
+++ b/www/versioned_docs/version-5.24.3/API/classes/AccountInterface.md
@@ -363,7 +363,7 @@ a confirmation of sending a transaction on the starknet contract
 ▸ `Abstract` **signMessage**(`typedData`): `Promise`<[`Signature`](../namespaces/types.md#signature)\>
 
 Sign an JSON object for off-chain usage with the starknet private key and return the signature
-This adds a message prefix so it cant be interchanged with transactions
+This adds a message prefix so it can't be interchanged with transactions
 
 **`Throws`**
 
@@ -391,8 +391,8 @@ the signature of the JSON object
 
 ▸ `Abstract` **hashMessage**(`typedData`): `Promise`<`string`\>
 
-Hash a JSON object with pederson hash and return the hash
-This adds a message prefix so it cant be interchanged with transactions
+Hash a JSON object with Pedersen hash and return the hash
+This adds a message prefix so it can't be interchanged with transactions
 
 **`Throws`**
 
@@ -898,7 +898,7 @@ Invokes a function on starknet
 
 **`Deprecated`**
 
-This method wont be supported as soon as fees are mandatory. Should not be used outside of Account class
+This method won't be supported as soon as fees are mandatory. Should not be used outside of Account class
 
 #### Parameters
 

--- a/www/versioned_docs/version-5.24.3/API/classes/Provider.md
+++ b/www/versioned_docs/version-5.24.3/API/classes/Provider.md
@@ -430,7 +430,7 @@ Invokes a function on starknet
 
 **`Deprecated`**
 
-This method wont be supported as soon as fees are mandatory. Should not be used outside of Account class
+This method won't be supported as soon as fees are mandatory. Should not be used outside of Account class
 
 #### Parameters
 

--- a/www/versioned_docs/version-5.24.3/API/classes/ProviderInterface.md
+++ b/www/versioned_docs/version-5.24.3/API/classes/ProviderInterface.md
@@ -324,7 +324,7 @@ Invokes a function on starknet
 
 **`Deprecated`**
 
-This method wont be supported as soon as fees are mandatory. Should not be used outside of Account class
+This method won't be supported as soon as fees are mandatory. Should not be used outside of Account class
 
 #### Parameters
 

--- a/www/versioned_docs/version-5.24.3/API/classes/RpcProvider.md
+++ b/www/versioned_docs/version-5.24.3/API/classes/RpcProvider.md
@@ -1154,7 +1154,7 @@ Invokes a function on starknet
 
 **`Deprecated`**
 
-This method wont be supported as soon as fees are mandatory. Should not be used outside of Account class
+This method won't be supported as soon as fees are mandatory. Should not be used outside of Account class
 
 #### Parameters
 

--- a/www/versioned_docs/version-5.24.3/API/classes/SequencerProvider.md
+++ b/www/versioned_docs/version-5.24.3/API/classes/SequencerProvider.md
@@ -636,7 +636,7 @@ Invokes a function on starknet
 
 **`Deprecated`**
 
-This method wont be supported as soon as fees are mandatory. Should not be used outside of Account class
+This method won't be supported as soon as fees are mandatory. Should not be used outside of Account class
 
 #### Parameters
 

--- a/www/versioned_docs/version-5.24.3/API/classes/Signer.md
+++ b/www/versioned_docs/version-5.24.3/API/classes/Signer.md
@@ -65,7 +65,7 @@ public key of signer as hex string with 0x prefix
 ▸ **signMessage**(`typedData`, `accountAddress`): `Promise`<[`Signature`](../namespaces/types.md#signature)\>
 
 Sign an JSON object for off-chain usage with the starknet private key and return the signature
-This adds a message prefix so it cant be interchanged with transactions
+This adds a message prefix so it can't be interchanged with transactions
 
 **`Throws`**
 

--- a/www/versioned_docs/version-5.24.3/API/classes/SignerInterface.md
+++ b/www/versioned_docs/version-5.24.3/API/classes/SignerInterface.md
@@ -41,7 +41,7 @@ public key of signer as hex string with 0x prefix
 ▸ `Abstract` **signMessage**(`typedData`, `accountAddress`): `Promise`<[`Signature`](../namespaces/types.md#signature)\>
 
 Sign an JSON object for off-chain usage with the starknet private key and return the signature
-This adds a message prefix so it cant be interchanged with transactions
+This adds a message prefix so it can't be interchanged with transactions
 
 **`Throws`**
 

--- a/www/versioned_docs/version-5.24.3/guides/create_account.md
+++ b/www/versioned_docs/version-5.24.3/guides/create_account.md
@@ -118,7 +118,7 @@ const argentXaccountClassHash = "0x033434ad846cdd5f23eb73ff09fe6fddd568284a0fb7d
 // Generate public and private key pair.
 const privateKeyAX = stark.randomAddress();
 console.log('AX_ACCOUNT_PRIVATE_KEY=', privateKeyAX);
-const starkKeyPubAX = ec.starkCurve.getStarkKey(privateKey);
+const starkKeyPubAX = ec.starkCurve.getStarkKey(privateKeyAX);
 console.log('AX_ACCOUNT_PUBLIC_KEY=', starkKeyPubAX);
 
 // Calculate future address of the ArgentX account

--- a/www/versioned_docs/version-5.24.3/guides/estimate_fees.md
+++ b/www/versioned_docs/version-5.24.3/guides/estimate_fees.md
@@ -43,7 +43,7 @@ To estimate the cost to deploy an account in the network:
 
 ```typescript
 const { suggestedMaxFee: estimatedFee1 } = await account0.estimateAccountDeployFee({
-	classHash: OZaccountClashHass,
+	classHash: OZaccountClassHash,
 	constructorCalldata: OZaccountConstructorCallData,
 	contractAddress: OZcontractAddress
 });


### PR DESCRIPTION
## Motivation and Resolution

This should be used as the target for typo PRs to avoid cluttering the commit history with typo changes.