### PR TITLE
fix: prioritize error states in waitForTransaction evaluation

### DIFF
--- a/__tests__/fixtures.ts
+++ b/__tests__/fixtures.ts
@@ -54,11 +54,8 @@ export const getTestProvider = (): ProviderInterface => {
   if (process.env.IS_LOCALHOST_DEVNET === 'true') {
     // accelerate the tests when running locally
     const originalWaitForTransaction = provider.waitForTransaction.bind(provider);
-    provider.waitForTransaction = (
-      txHash: string,
-      { retryInterval }: waitForTransactionOptions = {}
-    ) => {
-      return originalWaitForTransaction(txHash, { retryInterval: retryInterval || 1000 });
+    provider.waitForTransaction = (txHash: string, options: waitForTransactionOptions = {}) => {
+      return originalWaitForTransaction(txHash, { retryInterval: 1000, ...options });
     };
   }
 


### PR DESCRIPTION
## Motivation and Resolution

Should make the `waitForTransaction` configuration behave closer to user expectations.

Resolves #859 

## Checklist:

- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Linked the issues which this PR resolves
- [x] Documented the changes in code (API docs will be generated automatically)
- [x] Updated the tests
- [x] All tests are passing
