### PR TITLE
new feature: Ethereum signer

### DIFF
--- a/__tests__/utils/ethSigner.test.ts
+++ b/__tests__/utils/ethSigner.test.ts
@@ -1,0 +1,127 @@
+import typedDataExample from '../../__mocks__/typedDataExample.json';
+import {
+  Call,
+  DeclareSignerDetails,
+  DeployAccountSignerDetails,
+  EthSigner,
+  InvocationsSignerDetails,
+  RPC,
+  constants,
+  eth,
+  num,
+  stark,
+} from '../../src';
+
+describe('Ethereum signatures', () => {
+  describe('privk, pubK', () => {
+    test('Generates random PK', () => {
+      const privK = eth.ethRandomPrivateKey();
+      expect(privK.length).toBe(66);
+      expect(num.isHex(privK)).toBe(true);
+    });
+
+    test('Generates pubKey', async () => {
+      const mySigner = new EthSigner(
+        '0x525bc68475c0955fae83869beec0996114d4bb27b28b781ed2a20ef23121b8de'
+      );
+      expect(await mySigner.getPubKey()).toBe(
+        '0x020178bb97615b49070eefad71cb2f159392274404e41db748d9397147cb25cf59'
+      );
+    });
+  });
+
+  describe('Signatures', () => {
+    test('Message signature', async () => {
+      const myPrivateKey = '0x525bc68475c0955fae83869beec0996114d4bb27b28b781ed2a20ef23121b8de';
+      const myEthSigner = new EthSigner(myPrivateKey);
+      const message = typedDataExample;
+      const sig = await myEthSigner.signMessage(
+        message,
+        '0x65a822fbee1ae79e898688b5a4282dc79e0042cbed12f6169937fddb4c26641'
+      );
+      expect(sig).toMatchObject({
+        r: 46302720252787165203319064060867586811009528414735725622252684979112343882634n,
+        s: 44228007167516598548621407232357037139087111723794788802261070080184864735744n,
+        recovery: 1,
+      });
+    });
+
+    // TODO : To update when a contract account handling ETHEREUM signatures will be available.
+    test('Transaction signature', async () => {
+      const myPrivateKey = '0x525bc68475c0955fae83869beec0996114d4bb27b28b781ed2a20ef23121b8de';
+      const myEthSigner = new EthSigner(myPrivateKey);
+      const myCall: Call = {
+        contractAddress: '0x65a822fbee1ae79e898688b5a4282dc79e0042cbed12f6169937fddb4c26641',
+        entrypoint: 'test',
+        calldata: [1, 2],
+      };
+      const sig = await myEthSigner.signTransaction([myCall], {
+        version: '0x2',
+        walletAddress: '0x64b48806902a367c8598f4f95c305e8c1a1acba5f082d294a43793113115691',
+        cairoVersion: '1',
+        chainId: constants.StarknetChainId.SN_SEPOLIA,
+        nonce: 45,
+        maxFee: 10 ** 15,
+      } as InvocationsSignerDetails);
+      expect(sig).toMatchObject({
+        r: 7985353442887841088086521795914083018399735702575968460096442990678259802335n,
+        s: 54448706138210541940611627632626053501325595041277792020051079616748389329289n,
+        recovery: 0,
+      });
+    });
+
+    test('Deploy account signature', async () => {
+      const myPrivateKey = '0x525bc68475c0955fae83869beec0996114d4bb27b28b781ed2a20ef23121b8de';
+      const myEthSigner = new EthSigner(myPrivateKey);
+      const myDeployAcc: DeployAccountSignerDetails = {
+        version: '0x2',
+        contractAddress: '0x65a822fbee1ae79e898688b5a4282dc79e0042cbed12f6169937fddb4c26641',
+        chainId: constants.StarknetChainId.SN_SEPOLIA,
+        classHash: '0x5f3614e8671257aff9ac38e929c74d65b02d460ae966cd826c9f04a7fa8e0d4',
+        constructorCalldata: [1, 2],
+        addressSalt: 1234,
+        nonce: 45,
+        maxFee: 10 ** 15,
+
+        tip: 0,
+        paymasterData: [],
+        accountDeploymentData: [],
+        nonceDataAvailabilityMode: RPC.EDataAvailabilityMode.L1,
+        feeDataAvailabilityMode: RPC.EDataAvailabilityMode.L1,
+        resourceBounds: stark.estimateFeeToBounds(constants.ZERO),
+      };
+      const sig = await myEthSigner.signDeployAccountTransaction(myDeployAcc);
+      expect(sig).toMatchObject({
+        r: 61114347636551792612206610795983058940674613154346642566929862226007498517027n,
+        s: 38870792724053768239218215863749216579253019684549941316832072720775828116206n,
+        recovery: 1,
+      });
+    });
+
+    test('Declare signature', async () => {
+      const myPrivateKey = '0x525bc68475c0955fae83869beec0996114d4bb27b28b781ed2a20ef23121b8de';
+      const myEthSigner = new EthSigner(myPrivateKey);
+      const myDeclare: DeclareSignerDetails = {
+        version: '0x2',
+        chainId: constants.StarknetChainId.SN_SEPOLIA,
+        senderAddress: '0x65a822fbee1ae79e898688b5a4282dc79e0042cbed12f6169937fddb4c26641',
+        classHash: '0x5f3614e8671257aff9ac38e929c74d65b02d460ae966cd826c9f04a7fa8e0d4',
+        nonce: 45,
+        maxFee: 10 ** 15,
+
+        tip: 0,
+        paymasterData: [],
+        accountDeploymentData: [],
+        nonceDataAvailabilityMode: RPC.EDataAvailabilityMode.L1,
+        feeDataAvailabilityMode: RPC.EDataAvailabilityMode.L1,
+        resourceBounds: stark.estimateFeeToBounds(constants.ZERO),
+      };
+      const sig = await myEthSigner.signDeclareTransaction(myDeclare);
+      expect(sig).toMatchObject({
+        r: 38069596217315916583476609659691868035000959604311196895707605245620900872129n,
+        s: 420191492562045858770062885997406552542950984883779606809355688615026963844n,
+        recovery: 1,
+      });
+    });
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,7 @@ export * as json from './utils/json';
 export * as num from './utils/num';
 export * as transaction from './utils/transaction';
 export * as stark from './utils/stark';
+export * as eth from './utils/eth';
 export * as merkle from './utils/merkle';
 export * as uint256 from './utils/uint256';
 export * as shortString from './utils/shortString';

--- a/src/signer/ethSigner.ts
+++ b/src/signer/ethSigner.ts
@@ -1,0 +1,145 @@
+import { secp256k1 } from '@noble/curves/secp256k1';
+
+import {
+  Call,
+  DeclareSignerDetails,
+  DeployAccountSignerDetails,
+  InvocationsSignerDetails,
+  Signature,
+  TypedData,
+  V2DeclareSignerDetails,
+  V2DeployAccountSignerDetails,
+  V2InvocationsSignerDetails,
+  V3DeclareSignerDetails,
+  V3DeployAccountSignerDetails,
+  V3InvocationsSignerDetails,
+} from '../types';
+import { ETransactionVersion2, ETransactionVersion3 } from '../types/api';
+import { CallData } from '../utils/calldata';
+import { addHexPrefix, buf2hex, removeHexPrefix, sanitizeHex } from '../utils/encode';
+import { ethRandomPrivateKey } from '../utils/eth';
+import {
+  calculateDeclareTransactionHash,
+  calculateDeployAccountTransactionHash,
+  calculateInvokeTransactionHash,
+} from '../utils/hash';
+import { toHex } from '../utils/num';
+import { intDAM } from '../utils/stark';
+import { getExecuteCalldata } from '../utils/transaction';
+import { getMessageHash } from '../utils/typedData';
+import { SignerInterface } from './interface';
+
+/**
+ * Signer for accounts using Ethereum signature
+ */
+export class EthSigner implements SignerInterface {
+  protected pk: string; // hex string without 0x and odd number of characters
+
+  constructor(pk: Uint8Array | string = ethRandomPrivateKey()) {
+    this.pk =
+      pk instanceof Uint8Array
+        ? removeHexPrefix(sanitizeHex(buf2hex(pk)))
+        : removeHexPrefix(sanitizeHex(toHex(pk)));
+  }
+
+  public async getPubKey(): Promise<string> {
+    return addHexPrefix(buf2hex(secp256k1.getPublicKey(this.pk)));
+  }
+
+  public async signMessage(typedData: TypedData, accountAddress: string): Promise<Signature> {
+    const msgHash = getMessageHash(typedData, accountAddress);
+    return secp256k1.sign(removeHexPrefix(sanitizeHex(msgHash)), this.pk);
+  }
+
+  public async signTransaction(
+    transactions: Call[],
+    details: InvocationsSignerDetails
+  ): Promise<Signature> {
+    const compiledCalldata = getExecuteCalldata(transactions, details.cairoVersion);
+    let msgHash;
+
+    // TODO: How to do generic union discriminator for all like this
+    if (Object.values(ETransactionVersion2).includes(details.version as any)) {
+      const det = details as V2InvocationsSignerDetails;
+      msgHash = calculateInvokeTransactionHash({
+        ...det,
+        senderAddress: det.walletAddress,
+        compiledCalldata,
+        version: det.version,
+      });
+    } else if (Object.values(ETransactionVersion3).includes(details.version as any)) {
+      const det = details as V3InvocationsSignerDetails;
+      msgHash = calculateInvokeTransactionHash({
+        ...det,
+        senderAddress: det.walletAddress,
+        compiledCalldata,
+        version: det.version,
+        nonceDataAvailabilityMode: intDAM(det.nonceDataAvailabilityMode),
+        feeDataAvailabilityMode: intDAM(det.feeDataAvailabilityMode),
+      });
+    } else {
+      throw Error('unsupported signTransaction version');
+    }
+
+    return secp256k1.sign(removeHexPrefix(sanitizeHex(msgHash)), this.pk);
+  }
+
+  public async signDeployAccountTransaction(
+    details: DeployAccountSignerDetails
+  ): Promise<Signature> {
+    const compiledConstructorCalldata = CallData.compile(details.constructorCalldata);
+    /*     const version = BigInt(details.version).toString(); */
+    let msgHash;
+
+    if (Object.values(ETransactionVersion2).includes(details.version as any)) {
+      const det = details as V2DeployAccountSignerDetails;
+      msgHash = calculateDeployAccountTransactionHash({
+        ...det,
+        salt: det.addressSalt,
+        constructorCalldata: compiledConstructorCalldata,
+        version: det.version,
+      });
+    } else if (Object.values(ETransactionVersion3).includes(details.version as any)) {
+      const det = details as V3DeployAccountSignerDetails;
+      msgHash = calculateDeployAccountTransactionHash({
+        ...det,
+        salt: det.addressSalt,
+        compiledConstructorCalldata,
+        version: det.version,
+        nonceDataAvailabilityMode: intDAM(det.nonceDataAvailabilityMode),
+        feeDataAvailabilityMode: intDAM(det.feeDataAvailabilityMode),
+      });
+    } else {
+      throw Error('unsupported signDeployAccountTransaction version');
+    }
+
+    return secp256k1.sign(removeHexPrefix(sanitizeHex(msgHash)), this.pk);
+  }
+
+  public async signDeclareTransaction(
+    // contractClass: ContractClass,  // Should be used once class hash is present in ContractClass
+    details: DeclareSignerDetails
+  ): Promise<Signature> {
+    let msgHash;
+
+    if (Object.values(ETransactionVersion2).includes(details.version as any)) {
+      const det = details as V2DeclareSignerDetails;
+      msgHash = calculateDeclareTransactionHash({
+        ...det,
+        version: det.version,
+      });
+    } else if (Object.values(ETransactionVersion3).includes(details.version as any)) {
+      const det = details as V3DeclareSignerDetails;
+      msgHash = calculateDeclareTransactionHash({
+        ...det,
+        version: det.version,
+        nonceDataAvailabilityMode: intDAM(det.nonceDataAvailabilityMode),
+        feeDataAvailabilityMode: intDAM(det.feeDataAvailabilityMode),
+      });
+    } else {
+      throw Error('unsupported signDeclareTransaction version');
+    }
+
+    return secp256k1.sign(removeHexPrefix(sanitizeHex(msgHash)), this.pk);
+  }
+}

--- a/src/signer/index.ts
+++ b/src/signer/index.ts
@@ -1,2 +1,3 @@
 export * from './interface';
 export * from './default';
+export * from './ethSigner';

--- a/src/utils/eth.ts
+++ b/src/utils/eth.ts
@@ -1,0 +1,14 @@
+import { secp256k1 } from '@noble/curves/secp256k1';
+
+import { buf2hex, sanitizeHex } from './encode';
+
+/**
+ * Get random Ethereum private Key.
+ * @returns an Hex string
+ * @example
+ * const myPK: string = randomAddress()
+ * // result = "0xf04e69ac152fba37c02929c2ae78c9a481461dda42dbc6c6e286be6eb2a8ab83"
+ */
+export function ethRandomPrivateKey(): string {
+  return sanitizeHex(buf2hex(secp256k1.utils.randomPrivateKey()));
+}

--- a/www/docs/guides/connect_account.md
+++ b/www/docs/guides/connect_account.md
@@ -77,3 +77,21 @@ const account = new Account(provider, accountAddress, privateKey);
 // add ,"1" after privateKey if this account is not a Cairo 0 contract
 
 ```
+
+## Connect to an account that uses Ethereum signature
+
+As a consequence of account abstraction, you can find accounts that uses Ethereum signature logical.  
+To connect to this type of account:
+
+```typescript
+const myEthPrivateKey = "0x525bc68475c0955fae83869beec0996114d4bb27b28b781ed2a20ef23121b8de";
+const myEthAccountAddress = "0x65a822fbee1ae79e898688b5a4282dc79e0042cbed12f6169937fddb4c26641";
+const myEthSigner = new EthSigner(myEthPrivateKey);
+const myEthAccount = new Account(provider, myEthAccountAddress, myEthSigner)
+```
+
+And if you need a randon Ethereum private key:
+
+```typescript
+const myPrivateKey = eth.ethRandomPrivateKey();
+```


### PR DESCRIPTION
## Motivation and Resolution

Solve issue #888 .




## Usage related changes

```typescript
const myEthPrivateKey = "0x525bc68475c0955fae83869beec0996114d4bb27b28b781ed2a20ef23121b8de";
const myEthAccountAddress = "0x65a822fbee1ae79e898688b5a4282dc79e0042cbed12f6169937fddb4c26641";
const myEthSigner = new EthSigner(myEthPrivateKey);
const myEthAccount = new Account(provider, myEthAccountAddress, myEthSigner)
```

To obtain a randon Ethereum private key:

```typescript
const myPrivateKey = eth.ethRandomPrivateKey();
```


## Development related changes

new EthSigner.ts file, nearly a copy/paste of Signer.ts

Tests will have to be updated once an account contract using ETH signature will be available.

## Checklist:

- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Linked the issues which this PR resolves
- [x] Documented the changes in code (API docs will be generated automatically)
- [x] Updated the tests
- [x] All tests are passing
