### PR TITLE
[Feat]: Abiwan V2 Integration

### DIFF
--- a/__mocks__/hellov2.ts
+++ b/__mocks__/hellov2.ts
@@ -1,0 +1,978 @@
+export const tAbi = [
+  {
+    type: 'impl',
+    name: 'IHelloStarknetImpl',
+    interface_name: 'hello_res_events_newTypes::hello_res_events_newTypes::IHelloStarknet',
+  },
+  {
+    type: 'enum',
+    name: 'core::bool',
+    variants: [
+      {
+        name: 'False',
+        type: '()',
+      },
+      {
+        name: 'True',
+        type: '()',
+      },
+    ],
+  },
+  {
+    type: 'struct',
+    name: 'core::integer::u256',
+    members: [
+      {
+        name: 'low',
+        type: 'core::integer::u128',
+      },
+      {
+        name: 'high',
+        type: 'core::integer::u128',
+      },
+    ],
+  },
+  {
+    type: 'struct',
+    name: 'hello_res_events_newTypes::hello_res_events_newTypes::HelloStarknet::SimpleStruct',
+    members: [
+      {
+        name: 'first',
+        type: 'core::integer::u8',
+      },
+      {
+        name: 'second',
+        type: 'core::integer::u16',
+      },
+    ],
+  },
+  {
+    type: 'struct',
+    name: 'hello_res_events_newTypes::hello_res_events_newTypes::HelloStarknet::NestedStruct',
+    members: [
+      {
+        name: 'simpleStruct',
+        type: 'hello_res_events_newTypes::hello_res_events_newTypes::HelloStarknet::SimpleStruct',
+      },
+      {
+        name: 'simpleArray',
+        type: 'core::array::Array::<core::integer::u8>',
+      },
+    ],
+  },
+  {
+    type: 'struct',
+    name: 'hello_res_events_newTypes::hello_res_events_newTypes::Foo',
+    members: [
+      {
+        name: 'val',
+        type: 'core::felt252',
+      },
+    ],
+  },
+  {
+    type: 'struct',
+    name: 'hello_res_events_newTypes::hello_res_events_newTypes::UserData',
+    members: [
+      {
+        name: 'address',
+        type: 'core::starknet::contract_address::ContractAddress',
+      },
+      {
+        name: 'is_claimed',
+        type: 'core::bool',
+      },
+    ],
+  },
+  {
+    type: 'struct',
+    name: 'hello_res_events_newTypes::hello_res_events_newTypes::Bet',
+    members: [
+      {
+        name: 'name',
+        type: 'core::felt252',
+      },
+      {
+        name: 'description',
+        type: 'core::felt252',
+      },
+      {
+        name: 'expire_date',
+        type: 'core::integer::u64',
+      },
+      {
+        name: 'creation_time',
+        type: 'core::integer::u64',
+      },
+      {
+        name: 'creator',
+        type: 'core::starknet::contract_address::ContractAddress',
+      },
+      {
+        name: 'is_cancelled',
+        type: 'core::bool',
+      },
+      {
+        name: 'is_voted',
+        type: 'core::bool',
+      },
+      {
+        name: 'bettor',
+        type: 'hello_res_events_newTypes::hello_res_events_newTypes::UserData',
+      },
+      {
+        name: 'counter_bettor',
+        type: 'hello_res_events_newTypes::hello_res_events_newTypes::UserData',
+      },
+      {
+        name: 'winner',
+        type: 'core::bool',
+      },
+      {
+        name: 'pool',
+        type: 'core::integer::u256',
+      },
+      {
+        name: 'amount',
+        type: 'core::integer::u256',
+      },
+    ],
+  },
+  {
+    type: 'struct',
+    name: 'hello_res_events_newTypes::hello_res_events_newTypes::Order',
+    members: [
+      {
+        name: 'p1',
+        type: 'core::felt252',
+      },
+      {
+        name: 'p2',
+        type: 'core::integer::u16',
+      },
+    ],
+  },
+  {
+    type: 'enum',
+    name: 'hello_res_events_newTypes::hello_res_events_newTypes::MyEnum',
+    variants: [
+      {
+        name: 'Response',
+        type: 'hello_res_events_newTypes::hello_res_events_newTypes::Order',
+      },
+      {
+        name: 'Warning',
+        type: 'core::felt252',
+      },
+      {
+        name: 'Error',
+        type: 'core::integer::u16',
+      },
+    ],
+  },
+  {
+    type: 'enum',
+    name: 'core::option::Option::<core::integer::u8>',
+    variants: [
+      {
+        name: 'Some',
+        type: 'core::integer::u8',
+      },
+      {
+        name: 'None',
+        type: '()',
+      },
+    ],
+  },
+  {
+    type: 'enum',
+    name: 'core::option::Option::<hello_res_events_newTypes::hello_res_events_newTypes::Order>',
+    variants: [
+      {
+        name: 'Some',
+        type: 'hello_res_events_newTypes::hello_res_events_newTypes::Order',
+      },
+      {
+        name: 'None',
+        type: '()',
+      },
+    ],
+  },
+  {
+    type: 'enum',
+    name: 'core::result::Result::<hello_res_events_newTypes::hello_res_events_newTypes::Order, core::integer::u16>',
+    variants: [
+      {
+        name: 'Ok',
+        type: 'hello_res_events_newTypes::hello_res_events_newTypes::Order',
+      },
+      {
+        name: 'Err',
+        type: 'core::integer::u16',
+      },
+    ],
+  },
+  {
+    type: 'struct',
+    name: 'core::starknet::eth_address::EthAddress',
+    members: [
+      {
+        name: 'address',
+        type: 'core::felt252',
+      },
+    ],
+  },
+  {
+    type: 'struct',
+    name: 'core::array::Span::<core::integer::u16>',
+    members: [
+      {
+        name: 'snapshot',
+        type: '@core::array::Array::<core::integer::u16>',
+      },
+    ],
+  },
+  {
+    type: 'interface',
+    name: 'hello_res_events_newTypes::hello_res_events_newTypes::IHelloStarknet',
+    items: [
+      {
+        type: 'function',
+        name: 'increase_balance',
+        inputs: [
+          {
+            name: 'amount',
+            type: 'core::felt252',
+          },
+        ],
+        outputs: [],
+        state_mutability: 'external',
+      },
+      {
+        type: 'function',
+        name: 'get_balance',
+        inputs: [],
+        outputs: [
+          {
+            type: 'core::felt252',
+          },
+        ],
+        state_mutability: 'view',
+      },
+      {
+        type: 'function',
+        name: 'set_status',
+        inputs: [
+          {
+            name: 'new_status',
+            type: 'core::bool',
+          },
+        ],
+        outputs: [],
+        state_mutability: 'external',
+      },
+      {
+        type: 'function',
+        name: 'get_status',
+        inputs: [],
+        outputs: [
+          {
+            type: 'core::bool',
+          },
+        ],
+        state_mutability: 'view',
+      },
+      {
+        type: 'function',
+        name: 'set_ca',
+        inputs: [
+          {
+            name: 'address',
+            type: 'core::starknet::contract_address::ContractAddress',
+          },
+        ],
+        outputs: [],
+        state_mutability: 'external',
+      },
+      {
+        type: 'function',
+        name: 'get_ca',
+        inputs: [],
+        outputs: [
+          {
+            type: 'core::starknet::contract_address::ContractAddress',
+          },
+        ],
+        state_mutability: 'view',
+      },
+      {
+        type: 'function',
+        name: 'increase_balance_u8',
+        inputs: [
+          {
+            name: 'amount',
+            type: 'core::integer::u8',
+          },
+        ],
+        outputs: [],
+        state_mutability: 'external',
+      },
+      {
+        type: 'function',
+        name: 'get_balance_u8',
+        inputs: [],
+        outputs: [
+          {
+            type: 'core::integer::u8',
+          },
+        ],
+        state_mutability: 'view',
+      },
+      {
+        type: 'function',
+        name: 'test_u16',
+        inputs: [
+          {
+            name: 'p1',
+            type: 'core::integer::u16',
+          },
+        ],
+        outputs: [
+          {
+            type: 'core::integer::u16',
+          },
+        ],
+        state_mutability: 'view',
+      },
+      {
+        type: 'function',
+        name: 'test_u32',
+        inputs: [
+          {
+            name: 'p1',
+            type: 'core::integer::u32',
+          },
+        ],
+        outputs: [
+          {
+            type: 'core::integer::u32',
+          },
+        ],
+        state_mutability: 'view',
+      },
+      {
+        type: 'function',
+        name: 'test_u64',
+        inputs: [
+          {
+            name: 'p1',
+            type: 'core::integer::u64',
+          },
+        ],
+        outputs: [
+          {
+            type: 'core::integer::u64',
+          },
+        ],
+        state_mutability: 'view',
+      },
+      {
+        type: 'function',
+        name: 'test_u128',
+        inputs: [
+          {
+            name: 'p1',
+            type: 'core::integer::u128',
+          },
+        ],
+        outputs: [
+          {
+            type: 'core::integer::u128',
+          },
+        ],
+        state_mutability: 'view',
+      },
+      {
+        type: 'function',
+        name: 'test_u256',
+        inputs: [
+          {
+            name: 'p1',
+            type: 'core::integer::u256',
+          },
+        ],
+        outputs: [
+          {
+            type: 'core::integer::u256',
+          },
+        ],
+        state_mutability: 'view',
+      },
+      {
+        type: 'function',
+        name: 'emitEventRegular',
+        inputs: [
+          {
+            name: 'simpleKeyVariable',
+            type: 'core::integer::u8',
+          },
+          {
+            name: 'simpleKeyStruct',
+            type: 'hello_res_events_newTypes::hello_res_events_newTypes::HelloStarknet::SimpleStruct',
+          },
+          {
+            name: 'simpleKeyArray',
+            type: 'core::array::Array::<core::integer::u8>',
+          },
+          {
+            name: 'simpleDataVariable',
+            type: 'core::integer::u8',
+          },
+          {
+            name: 'simpleDataStruct',
+            type: 'hello_res_events_newTypes::hello_res_events_newTypes::HelloStarknet::SimpleStruct',
+          },
+          {
+            name: 'simpleDataArray',
+            type: 'core::array::Array::<core::integer::u8>',
+          },
+        ],
+        outputs: [],
+        state_mutability: 'external',
+      },
+      {
+        type: 'function',
+        name: 'emitEventNested',
+        inputs: [
+          {
+            name: 'nestedKeyStruct',
+            type: 'hello_res_events_newTypes::hello_res_events_newTypes::HelloStarknet::NestedStruct',
+          },
+          {
+            name: 'nestedDataStruct',
+            type: 'hello_res_events_newTypes::hello_res_events_newTypes::HelloStarknet::NestedStruct',
+          },
+        ],
+        outputs: [],
+        state_mutability: 'external',
+      },
+      {
+        type: 'function',
+        name: 'echo_array',
+        inputs: [
+          {
+            name: 'data',
+            type: 'core::array::Array::<core::integer::u8>',
+          },
+        ],
+        outputs: [
+          {
+            type: 'core::array::Array::<core::integer::u8>',
+          },
+        ],
+        state_mutability: 'view',
+      },
+      {
+        type: 'function',
+        name: 'echo_array_u256',
+        inputs: [
+          {
+            name: 'data',
+            type: 'core::array::Array::<core::integer::u256>',
+          },
+        ],
+        outputs: [
+          {
+            type: 'core::array::Array::<core::integer::u256>',
+          },
+        ],
+        state_mutability: 'view',
+      },
+      {
+        type: 'function',
+        name: 'echo_array_bool',
+        inputs: [
+          {
+            name: 'data',
+            type: 'core::array::Array::<core::bool>',
+          },
+        ],
+        outputs: [
+          {
+            type: 'core::array::Array::<core::bool>',
+          },
+        ],
+        state_mutability: 'view',
+      },
+      {
+        type: 'function',
+        name: 'echo_un_tuple',
+        inputs: [
+          {
+            name: 'a',
+            type: '(core::felt252, core::integer::u16)',
+          },
+        ],
+        outputs: [
+          {
+            type: '(core::felt252, core::integer::u16)',
+          },
+        ],
+        state_mutability: 'view',
+      },
+      {
+        type: 'function',
+        name: 'echo_struct',
+        inputs: [
+          {
+            name: 'tt',
+            type: 'hello_res_events_newTypes::hello_res_events_newTypes::Foo',
+          },
+        ],
+        outputs: [
+          {
+            type: 'hello_res_events_newTypes::hello_res_events_newTypes::Foo',
+          },
+        ],
+        state_mutability: 'view',
+      },
+      {
+        type: 'function',
+        name: 'set_bet',
+        inputs: [],
+        outputs: [],
+        state_mutability: 'external',
+      },
+      {
+        type: 'function',
+        name: 'get_bet',
+        inputs: [
+          {
+            name: 'test',
+            type: 'core::felt252',
+          },
+        ],
+        outputs: [
+          {
+            type: 'hello_res_events_newTypes::hello_res_events_newTypes::Bet',
+          },
+        ],
+        state_mutability: 'view',
+      },
+      {
+        type: 'function',
+        name: 'set_user1',
+        inputs: [
+          {
+            name: 'user',
+            type: 'hello_res_events_newTypes::hello_res_events_newTypes::UserData',
+          },
+        ],
+        outputs: [],
+        state_mutability: 'external',
+      },
+      {
+        type: 'function',
+        name: 'get_user1',
+        inputs: [],
+        outputs: [
+          {
+            type: 'hello_res_events_newTypes::hello_res_events_newTypes::UserData',
+          },
+        ],
+        state_mutability: 'view',
+      },
+      {
+        type: 'function',
+        name: 'get_user',
+        inputs: [],
+        outputs: [
+          {
+            type: 'hello_res_events_newTypes::hello_res_events_newTypes::UserData',
+          },
+        ],
+        state_mutability: 'view',
+      },
+      {
+        type: 'function',
+        name: 'array2d_ex',
+        inputs: [
+          {
+            name: 'test',
+            type: 'core::array::Array::<core::array::Array::<core::felt252>>',
+          },
+        ],
+        outputs: [
+          {
+            type: 'core::felt252',
+          },
+        ],
+        state_mutability: 'external',
+      },
+      {
+        type: 'function',
+        name: 'array2d_array',
+        inputs: [
+          {
+            name: 'test',
+            type: 'core::array::Array::<core::array::Array::<core::felt252>>',
+          },
+        ],
+        outputs: [
+          {
+            type: 'core::array::Array::<core::array::Array::<core::felt252>>',
+          },
+        ],
+        state_mutability: 'view',
+      },
+      {
+        type: 'function',
+        name: 'array2d_felt',
+        inputs: [
+          {
+            name: 'test',
+            type: 'core::array::Array::<core::array::Array::<core::felt252>>',
+          },
+        ],
+        outputs: [
+          {
+            type: 'core::felt252',
+          },
+        ],
+        state_mutability: 'view',
+      },
+      {
+        type: 'function',
+        name: 'tuple_echo',
+        inputs: [
+          {
+            name: 'a',
+            type: '(core::array::Array::<core::felt252>, core::array::Array::<core::felt252>)',
+          },
+        ],
+        outputs: [
+          {
+            type: '(core::array::Array::<core::felt252>, core::array::Array::<core::felt252>)',
+          },
+        ],
+        state_mutability: 'view',
+      },
+      {
+        type: 'function',
+        name: 'array_bool_tuple',
+        inputs: [
+          {
+            name: 'a',
+            type: 'core::array::Array::<core::felt252>',
+          },
+          {
+            name: 'b',
+            type: 'core::bool',
+          },
+        ],
+        outputs: [
+          {
+            type: '(core::array::Array::<core::felt252>, core::bool)',
+          },
+        ],
+        state_mutability: 'view',
+      },
+      {
+        type: 'function',
+        name: 'array2ddd_felt',
+        inputs: [
+          {
+            name: 'testdd',
+            type: 'core::array::Array::<core::array::Array::<core::felt252>>',
+          },
+        ],
+        outputs: [
+          {
+            type: 'core::felt252',
+          },
+        ],
+        state_mutability: 'view',
+      },
+      {
+        type: 'function',
+        name: 'my_enum_output',
+        inputs: [
+          {
+            name: 'val1',
+            type: 'core::integer::u16',
+          },
+        ],
+        outputs: [
+          {
+            type: 'hello_res_events_newTypes::hello_res_events_newTypes::MyEnum',
+          },
+        ],
+        state_mutability: 'view',
+      },
+      {
+        type: 'function',
+        name: 'my_enum_input',
+        inputs: [
+          {
+            name: 'customEnum',
+            type: 'hello_res_events_newTypes::hello_res_events_newTypes::MyEnum',
+          },
+        ],
+        outputs: [
+          {
+            type: 'core::integer::u16',
+          },
+        ],
+        state_mutability: 'view',
+      },
+      {
+        type: 'function',
+        name: 'option_u8_output',
+        inputs: [
+          {
+            name: 'val1',
+            type: 'core::integer::u8',
+          },
+        ],
+        outputs: [
+          {
+            type: 'core::option::Option::<core::integer::u8>',
+          },
+        ],
+        state_mutability: 'view',
+      },
+      {
+        type: 'function',
+        name: 'option_order_output',
+        inputs: [
+          {
+            name: 'val1',
+            type: 'core::integer::u16',
+          },
+        ],
+        outputs: [
+          {
+            type: 'core::option::Option::<hello_res_events_newTypes::hello_res_events_newTypes::Order>',
+          },
+        ],
+        state_mutability: 'view',
+      },
+      {
+        type: 'function',
+        name: 'option_order_input',
+        inputs: [
+          {
+            name: 'inp',
+            type: 'core::option::Option::<hello_res_events_newTypes::hello_res_events_newTypes::Order>',
+          },
+        ],
+        outputs: [
+          {
+            type: 'core::integer::u16',
+          },
+        ],
+        state_mutability: 'view',
+      },
+      {
+        type: 'function',
+        name: 'enum_result_output',
+        inputs: [
+          {
+            name: 'val1',
+            type: 'core::integer::u16',
+          },
+        ],
+        outputs: [
+          {
+            type: 'core::result::Result::<hello_res_events_newTypes::hello_res_events_newTypes::Order, core::integer::u16>',
+          },
+        ],
+        state_mutability: 'view',
+      },
+      {
+        type: 'function',
+        name: 'enum_result_input',
+        inputs: [
+          {
+            name: 'inp',
+            type: 'core::result::Result::<hello_res_events_newTypes::hello_res_events_newTypes::Order, core::integer::u16>',
+          },
+        ],
+        outputs: [
+          {
+            type: 'core::integer::u16',
+          },
+        ],
+        state_mutability: 'view',
+      },
+      {
+        type: 'function',
+        name: 'new_types',
+        inputs: [
+          {
+            name: 'ch',
+            type: 'core::starknet::class_hash::ClassHash',
+          },
+          {
+            name: 'eth_addr',
+            type: 'core::starknet::eth_address::EthAddress',
+          },
+          {
+            name: 'contr_address',
+            type: 'core::starknet::contract_address::ContractAddress',
+          },
+        ],
+        outputs: [
+          {
+            type: '(core::starknet::class_hash::ClassHash, core::starknet::eth_address::EthAddress, core::starknet::contract_address::ContractAddress)',
+          },
+        ],
+        state_mutability: 'view',
+      },
+      {
+        type: 'function',
+        name: 'new_span',
+        inputs: [
+          {
+            name: 'my_span',
+            type: 'core::array::Span::<core::integer::u16>',
+          },
+        ],
+        outputs: [
+          {
+            type: 'core::array::Span::<core::integer::u16>',
+          },
+        ],
+        state_mutability: 'view',
+      },
+      {
+        type: 'function',
+        name: 'array_new_types',
+        inputs: [
+          {
+            name: 'tup',
+            type: '(core::starknet::contract_address::ContractAddress, core::starknet::eth_address::EthAddress, core::starknet::class_hash::ClassHash)',
+          },
+          {
+            name: 'tupa',
+            type: '(core::array::Array::<core::starknet::contract_address::ContractAddress>, core::array::Array::<core::starknet::eth_address::EthAddress>, core::array::Array::<core::starknet::class_hash::ClassHash>)',
+          },
+        ],
+        outputs: [
+          {
+            type: '(core::array::Array::<core::starknet::contract_address::ContractAddress>, core::array::Array::<core::starknet::eth_address::EthAddress>, core::array::Array::<core::starknet::class_hash::ClassHash>)',
+          },
+        ],
+        state_mutability: 'view',
+      },
+      {
+        type: 'function',
+        name: 'array_contract_addr',
+        inputs: [
+          {
+            name: 'arr',
+            type: 'core::array::Array::<core::starknet::contract_address::ContractAddress>',
+          },
+        ],
+        outputs: [
+          {
+            type: 'core::array::Array::<core::starknet::contract_address::ContractAddress>',
+          },
+        ],
+        state_mutability: 'view',
+      },
+    ],
+  },
+  // {
+  //   type: 'l1_handler',
+  //   name: 'increase_bal',
+  //   inputs: [
+  //     {
+  //       name: 'from_address',
+  //       type: 'core::felt252',
+  //     },
+  //     {
+  //       name: 'amount',
+  //       type: 'core::felt252',
+  //     },
+  //   ],
+  //   outputs: [],
+  //   state_mutability: 'external',
+  // },
+  {
+    type: 'constructor',
+    name: 'constructor',
+    inputs: [],
+  },
+  {
+    type: 'event',
+    name: 'hello_res_events_newTypes::hello_res_events_newTypes::HelloStarknet::EventRegular',
+    kind: 'struct',
+    members: [
+      {
+        name: 'simpleKeyVariable',
+        type: 'core::integer::u8',
+        kind: 'key',
+      },
+      {
+        name: 'simpleKeyStruct',
+        type: 'hello_res_events_newTypes::hello_res_events_newTypes::HelloStarknet::SimpleStruct',
+        kind: 'key',
+      },
+      {
+        name: 'simpleKeyArray',
+        type: 'core::array::Array::<core::integer::u8>',
+        kind: 'key',
+      },
+      {
+        name: 'simpleDataVariable',
+        type: 'core::integer::u8',
+        kind: 'data',
+      },
+      {
+        name: 'simpleDataStruct',
+        type: 'hello_res_events_newTypes::hello_res_events_newTypes::HelloStarknet::SimpleStruct',
+        kind: 'data',
+      },
+      {
+        name: 'simpleDataArray',
+        type: 'core::array::Array::<core::integer::u8>',
+        kind: 'data',
+      },
+    ],
+  },
+  {
+    type: 'event',
+    name: 'hello_res_events_newTypes::hello_res_events_newTypes::HelloStarknet::EventNested',
+    kind: 'struct',
+    members: [
+      {
+        name: 'nestedKeyStruct',
+        type: 'hello_res_events_newTypes::hello_res_events_newTypes::HelloStarknet::NestedStruct',
+        kind: 'key',
+      },
+      {
+        name: 'nestedDataStruct',
+        type: 'hello_res_events_newTypes::hello_res_events_newTypes::HelloStarknet::NestedStruct',
+        kind: 'data',
+      },
+    ],
+  },
+  {
+    type: 'event',
+    name: 'hello_res_events_newTypes::hello_res_events_newTypes::HelloStarknet::Event',
+    kind: 'enum',
+    variants: [
+      {
+        name: 'EventRegular',
+        type: 'hello_res_events_newTypes::hello_res_events_newTypes::HelloStarknet::EventRegular',
+        kind: 'nested',
+      },
+      {
+        name: 'EventNested',
+        type: 'hello_res_events_newTypes::hello_res_events_newTypes::HelloStarknet::EventNested',
+        kind: 'nested',
+      },
+    ],
+  },
+] as const;

--- a/__tests__/cairo1_typed.test.ts
+++ b/__tests__/cairo1_typed.test.ts
@@ -20,6 +20,8 @@ import {
   compiledComplexSierra,
   compiledHelloSierra,
   compiledHelloSierraCasm,
+  describeIfDevnetSequencer,
+  describeIfSequencerGoerli,
   getTestAccount,
   getTestProvider,
 } from './fixtures';
@@ -36,13 +38,31 @@ describe('TS validation for API &  Contract interactions - tests skipped', () =>
   let cairo1Contract: TypedContract<typeof tAbi>;
   initializeMatcher(expect);
 
-  xtest('Declare & deploy v2 - Hello Cairo 1 contract', async () => {
+  beforeAll(async () => {
+    dd = await account.declareAndDeploy({
+      contract: compiledHelloSierra,
+      casm: compiledHelloSierraCasm,
+    });
+
+    cairo1Contract = new Contract(
+      compiledHelloSierra.abi,
+      dd.deploy.contract_address,
+      account
+    ).typed(tAbi);
+  });
+
+  test('Declare & deploy v2 - Hello Cairo 1 contract', async () => {
     expect(dd.declare).toMatchSchemaRef('DeclareContractResponse');
     expect(dd.deploy).toMatchSchemaRef('DeployContractUDCResponse');
     expect(cairo1Contract).toBeInstanceOf(Contract);
   });
 
-  xtest('ContractFactory on Cairo1', async () => {
+  test('getCairoVersion', async () => {
+    const version1 = await cairo1Contract.getVersion();
+    expect(version1).toEqual({ cairo: '1', compiler: '1' });
+  });
+
+  test('ContractFactory on Cairo1', async () => {
     const c1CFactory = new ContractFactory({
       compiledContract: compiledHelloSierra,
       casm: compiledHelloSierraCasm,
@@ -67,31 +87,31 @@ describe('TS validation for API &  Contract interactions - tests skipped', () =>
     });
   });
 
-  xtest('deployContract Cairo1', async () => {
+  test('deployContract Cairo1', async () => {
     const deploy = await account.deployContract({
       classHash: dd.deploy.classHash,
     });
     expect(deploy).toHaveProperty('address');
   });
 
-  xtest('GetClassByHash', async () => {
+  test('GetClassByHash', async () => {
     const classResponse = await provider.getClassByHash(dd.deploy.classHash);
     expect(classResponse).toMatchSchemaRef('SierraContractClass');
   });
 
-  xtest('GetClassAt', async () => {
+  test('GetClassAt', async () => {
     const classResponse = await provider.getClassAt(dd.deploy.contract_address);
     expect(classResponse).toMatchSchemaRef('SierraContractClass');
   });
 
-  xtest('isCairo1', async () => {
+  test('isCairo1', async () => {
     const isContractCairo1 = cairo1Contract.isCairo1();
     expect(isContractCairo1).toBe(true);
     const isAbiCairo1 = isCairo1Abi(cairo1Contract.abi);
     expect(isAbiCairo1).toBe(true);
   });
 
-  xtest('Cairo 1 Contract Interaction - skip invoke validation & call parsing', async () => {
+  test('Cairo 1 Contract Interaction - skip invoke validation & call parsing', async () => {
     const tx = await cairo1Contract.increase_balance(
       CallData.compile({
         amount: 100,
@@ -99,21 +119,21 @@ describe('TS validation for API &  Contract interactions - tests skipped', () =>
     );
     await account.waitForTransaction(tx.transaction_hash);
 
-    // const balance = await cairo1Contract.get_balance({
-    //   parseResponse: false,
-    // });
+    const balance = await cairo1Contract.get_balance({
+      parseResponse: false,
+    });
 
-    // expect(num.toBigInt(balance[0])).toBe(100n);
+    expect(num.toBigInt(balance)).toBe(100n);
   });
 
-  xtest('Cairo 1 Contract Interaction - felt252', async () => {
+  test('Cairo 1 Contract Interaction - felt252', async () => {
     const tx = await cairo1Contract.increase_balance(100);
     await account.waitForTransaction(tx.transaction_hash);
     const balance = await cairo1Contract.get_balance();
     expect(balance).toBe(200n);
   });
 
-  xtest('Cairo 1 Contract Interaction - uint 8, 16, 32, 64, 128', async () => {
+  test('Cairo 1 Contract Interaction - uint 8, 16, 32, 64, 128', async () => {
     const tx = await cairo1Contract.increase_balance_u8(255n);
     await account.waitForTransaction(tx.transaction_hash);
     const balance = await cairo1Contract.get_balance_u8();
@@ -129,7 +149,7 @@ describe('TS validation for API &  Contract interactions - tests skipped', () =>
     expect(result).toBe(256n);
   });
 
-  xtest('Cairo 1 - uint256', async () => {
+  test('Cairo 1 - uint256', async () => {
     // defined as number
     const result = await cairo1Contract.test_u256(2n ** 256n - 2n);
     expect(result).toBe(2n ** 256n - 1n);
@@ -139,7 +159,7 @@ describe('TS validation for API &  Contract interactions - tests skipped', () =>
     expect(result1).toBe(2n ** 256n - 1n);
   });
 
-  xtest('Cairo 1 Contract Interaction - bool', async () => {
+  test('Cairo 1 Contract Interaction - bool', async () => {
     const cdata = CallData.compile({ false: false, true: true });
     expect(cdata).toEqual(['0', '1']);
 
@@ -162,7 +182,7 @@ describe('TS validation for API &  Contract interactions - tests skipped', () =>
     expect(status).toBe(true);
   });
 
-  xtest('Cairo 1 Contract Interaction - ContractAddress', async () => {
+  test('Cairo 1 Contract Interaction - ContractAddress', async () => {
     const tx = await cairo1Contract.set_ca('123');
     await account.waitForTransaction(tx.transaction_hash);
     const status = await cairo1Contract.get_ca();
@@ -170,7 +190,7 @@ describe('TS validation for API &  Contract interactions - tests skipped', () =>
     expect(status).toBe(123n);
   });
 
-  xtest('Cairo1 simple getStorageAt variables retrieval', async () => {
+  test('Cairo1 simple getStorageAt variables retrieval', async () => {
     // u8
     let tx = await cairo1Contract.increase_balance(100);
     await account.waitForTransaction(tx.transaction_hash);
@@ -211,12 +231,12 @@ describe('TS validation for API &  Contract interactions - tests skipped', () =>
     // TODO: Complex mapping - https://docs.starknet.io/documentation/architecture_and_concepts/Contracts/contract-storage/
   });
 
-  xtest('Cairo 1 Contract Interaction - echo flat un-named un-nested tuple', async () => {
+  test('Cairo 1 Contract Interaction - echo flat un-named un-nested tuple', async () => {
     const status = await cairo1Contract.echo_un_tuple([77, 123]);
     expect(Object.values(status)).toEqual([77n, 123n]);
   });
 
-  xtest('Cairo 1 Contract Interaction - echo flat un-nested Array u8, uint256, bool', async () => {
+  test('Cairo 1 Contract Interaction - echo flat un-nested Array u8, uint256, bool', async () => {
     const status = await cairo1Contract.echo_array([123, 55, 77, 255]);
     expect(status).toEqual([123n, 55n, 77n, 255n]);
 
@@ -237,14 +257,14 @@ describe('TS validation for API &  Contract interactions - tests skipped', () =>
     expect(status2).toEqual([true, true, false, false]);
   });
 
-  xtest('Cairo 1 Contract Interaction - echo flat un-nested Struct', async () => {
+  test('Cairo 1 Contract Interaction - echo flat un-nested Struct', async () => {
     const status = await cairo1Contract.echo_struct({
       val: 'simple',
     });
     expect(shortString.decodeShortString(status.val as string)).toBe('simple');
   });
 
-  xtest('Cairo 1 more complex structs', async () => {
+  test('Cairo 1 more complex structs', async () => {
     const tx = await cairo1Contract.set_bet();
     await account.waitForTransaction(tx.transaction_hash);
     const status = await cairo1Contract.get_bet(
@@ -277,7 +297,7 @@ describe('TS validation for API &  Contract interactions - tests skipped', () =>
     expect(expected).toEqual(status);
   });
 
-  xtest('C1 Array 2D', async () => {
+  test('C1 Array 2D', async () => {
     const cd = CallData.compile({
       test: [
         [1, 2],
@@ -313,7 +333,7 @@ describe('TS validation for API &  Contract interactions - tests skipped', () =>
     expect(result1).toEqual(result11);
   });
 
-  xtest('mix tuples', async () => {
+  test('mix tuples', async () => {
     const res = await cairo1Contract.array_bool_tuple([1, 2, 3], true);
     expect(res).toEqual({
       0: [1n, 2n, 3n, 1n, 2n],
@@ -330,7 +350,7 @@ describe('TS validation for API &  Contract interactions - tests skipped', () =>
     });
   });
 
-  xtest('myCallData.compile for Cairo 1', async () => {
+  test('myCallData.compile for Cairo 1', async () => {
     const myFalseUint256 = { high: 1, low: 23456 }; // wrong order
     type Order2 = {
       p1: BigNumberish;
@@ -475,67 +495,72 @@ describe('TS validation for API &  Contract interactions - tests skipped', () =>
     expect(callDataFromArray).toStrictEqual(expectedResult);
   });
 
-  xtest('getCompiledClassByClassHash', async () => {
-    const compiledClass = await (provider as SequencerProvider).getCompiledClassByClassHash(
-      dd.deploy.classHash
-    );
-    expect(compiledClass).toMatchSchemaRef('CompiledClass');
+  describeIfDevnetSequencer('Sequencer only', () => {
+    test('getCompiledClassByClassHash', async () => {
+      const compiledClass = await (provider as SequencerProvider).getCompiledClassByClassHash(
+        dd.deploy.classHash
+      );
+      expect(compiledClass).toMatchSchemaRef('CompiledClass');
+    });
   });
 });
 
-describe('TS validation for Sequencer API - C1 T2 C:0x771bbe2ba64f... - tests skipped', () => {
-  const provider = getTestProvider() as SequencerProvider;
-  const classHash: any = '0x028b6f2ee9ae00d55a32072d939a55a6eb522974a283880f3c73a64c2f9fd6d6';
-  const contractAddress: any = '0x771bbe2ba64fa5ab52f0c142b4296fc67460a3a2372b4cdce752c620e3e8194';
-  let cairo1Contract: TypedContract<typeof tAbi>;
-  initializeMatcher(expect);
+describeIfSequencerGoerli('Cairo1 Testnet', () => {
+  describe('TS validation for Sequencer API - C1 T2 C:0x771bbe2ba64f... - tests skipped', () => {
+    const provider = getTestProvider() as SequencerProvider;
+    const classHash: any = '0x028b6f2ee9ae00d55a32072d939a55a6eb522974a283880f3c73a64c2f9fd6d6';
+    const contractAddress: any =
+      '0x771bbe2ba64fa5ab52f0c142b4296fc67460a3a2372b4cdce752c620e3e8194';
+    let cairo1Contract: TypedContract<typeof tAbi>;
+    initializeMatcher(expect);
 
-  xtest('getCompiledClassByClassHash', async () => {
-    const compiledClass = await provider.getCompiledClassByClassHash(classHash);
-    expect(compiledClass).toMatchSchemaRef('CompiledClass');
-  });
+    test('getCompiledClassByClassHash', async () => {
+      const compiledClass = await provider.getCompiledClassByClassHash(classHash);
+      expect(compiledClass).toMatchSchemaRef('CompiledClass');
+    });
 
-  xtest('GetClassByHash', async () => {
-    const classResponse = await provider.getClassByHash(classHash);
-    expect(classResponse).toMatchSchemaRef('SierraContractClass');
-  });
+    test('GetClassByHash', async () => {
+      const classResponse = await provider.getClassByHash(classHash);
+      expect(classResponse).toMatchSchemaRef('SierraContractClass');
+    });
 
-  xtest('GetClassAt', async () => {
-    const classResponse = await provider.getClassAt(contractAddress);
-    expect(classResponse).toMatchSchemaRef('SierraContractClass');
-  });
+    test('GetClassAt', async () => {
+      const classResponse = await provider.getClassAt(contractAddress);
+      expect(classResponse).toMatchSchemaRef('SierraContractClass');
+    });
 
-  xtest('Cairo 1 Contract Interaction - felt252', async () => {
-    const result = await cairo1Contract.test_felt252(100);
-    expect(result).toBe(101n);
-  });
+    test('Cairo 1 Contract Interaction - felt252', async () => {
+      const result = await cairo1Contract.test_felt252(100);
+      expect(result).toBe(101n);
+    });
 
-  xtest('Cairo 1 Contract Interaction - uint 8, 16, 32, 64, 128', async () => {
-    const r1 = await cairo1Contract.test_u8(100n);
-    expect(r1).toBe(107n);
-    const r2 = await cairo1Contract.test_u16(100n);
-    expect(r2).toBe(106n);
-    const r3 = await cairo1Contract.test_u32(100n);
-    expect(r3).toBe(104n);
-    const r4 = await cairo1Contract.test_u64(255n);
-    expect(r4).toBe(258n);
-    const r5 = await cairo1Contract.test_u128(255n);
-    expect(r5).toBe(257n);
-  });
+    test('Cairo 1 Contract Interaction - uint 8, 16, 32, 64, 128', async () => {
+      const r1 = await cairo1Contract.test_u8(100n);
+      expect(r1).toBe(107n);
+      const r2 = await cairo1Contract.test_u16(100n);
+      expect(r2).toBe(106n);
+      const r3 = await cairo1Contract.test_u32(100n);
+      expect(r3).toBe(104n);
+      const r4 = await cairo1Contract.test_u64(255n);
+      expect(r4).toBe(258n);
+      const r5 = await cairo1Contract.test_u128(255n);
+      expect(r5).toBe(257n);
+    });
 
-  xtest('Cairo 1 - uint256 struct', async () => {
-    const myUint256 = uint256(2n ** 256n - 2n);
-    const result = await cairo1Contract.test_u256(myUint256);
-    expect(result).toBe(2n ** 256n - 1n);
-  });
+    test('Cairo 1 - uint256 struct', async () => {
+      const myUint256 = uint256(2n ** 256n - 2n);
+      const result = await cairo1Contract.test_u256(myUint256);
+      expect(result).toBe(2n ** 256n - 1n);
+    });
 
-  xtest('Cairo 1 - uint256 by a bignumber', async () => {
-    const result = await cairo1Contract.test_u256(2n ** 256n - 2n);
-    expect(result).toBe(2n ** 256n - 1n);
-  });
+    test('Cairo 1 - uint256 by a bignumber', async () => {
+      const result = await cairo1Contract.test_u256(2n ** 256n - 2n);
+      expect(result).toBe(2n ** 256n - 1n);
+    });
 
-  xtest('Cairo 1 Contract Interaction - bool', async () => {
-    const tx = await cairo1Contract.test_bool();
-    expect(tx).toBe(true);
+    test('Cairo 1 Contract Interaction - bool', async () => {
+      const tx = await cairo1Contract.test_bool();
+      expect(tx).toBe(true);
+    });
   });
 });

--- a/__tests__/cairo1_typed.test.ts
+++ b/__tests__/cairo1_typed.test.ts
@@ -231,7 +231,7 @@ describe('TS validation for API &  Contract interactions - tests skipped', () =>
     // TODO: Complex mapping - https://docs.starknet.io/documentation/architecture_and_concepts/Contracts/contract-storage/
   });
 
-  test('Cairo 1 Contract Interaction - echo flat un-named un-nested tuple', async () => {
+  xtest('Cairo 1 Contract Interaction - echo flat un-named un-nested tuple', async () => {
     const status = await cairo1Contract.echo_un_tuple([77, 123]);
     expect(Object.values(status)).toEqual([77n, 123n]);
   });
@@ -264,7 +264,7 @@ describe('TS validation for API &  Contract interactions - tests skipped', () =>
     expect(shortString.decodeShortString(status.val as string)).toBe('simple');
   });
 
-  test('Cairo 1 more complex structs', async () => {
+  xtest('Cairo 1 more complex structs', async () => {
     const tx = await cairo1Contract.set_bet();
     await account.waitForTransaction(tx.transaction_hash);
     const status = await cairo1Contract.get_bet(
@@ -333,7 +333,7 @@ describe('TS validation for API &  Contract interactions - tests skipped', () =>
     expect(result1).toEqual(result11);
   });
 
-  test('mix tuples', async () => {
+  xtest('mix tuples', async () => {
     const res = await cairo1Contract.array_bool_tuple([1, 2, 3], true);
     expect(res).toEqual({
       0: [1n, 2n, 3n, 1n, 2n],

--- a/__tests__/cairo1v2_typed.test.ts
+++ b/__tests__/cairo1v2_typed.test.ts
@@ -1,0 +1,925 @@
+import { tAbi } from '../__mocks__/hellov2';
+import {
+  Account,
+  BigNumberish,
+  CairoCustomEnum,
+  CairoOption,
+  CairoOptionVariant,
+  CairoResult,
+  CairoResultVariant,
+  CallData,
+  Calldata,
+  CompiledSierra,
+  Contract,
+  DeclareDeployUDCResponse,
+  RawArgsArray,
+  RawArgsObject,
+  SequencerProvider,
+  TypedContractV2,
+  cairo,
+  ec,
+  hash,
+  num,
+  selector,
+  shortString,
+  stark,
+  types,
+} from '../src';
+import {
+  compiledC1Account,
+  compiledC1AccountCasm,
+  compiledC1v2,
+  compiledC1v2Casm,
+  compiledC210,
+  compiledC210Casm,
+  compiledComplexSierra,
+  describeIfDevnetSequencer,
+  getTestAccount,
+  getTestProvider,
+} from './fixtures';
+import { initializeMatcher } from './schema';
+
+const { uint256, tuple, isCairo1Abi } = cairo;
+const { toHex } = num;
+const { starknetKeccak } = selector;
+
+describe('Cairo 1', () => {
+  const provider = getTestProvider();
+  const account = getTestAccount(provider);
+  describe('API &  Contract interactions', () => {
+    let dd: DeclareDeployUDCResponse;
+    let cairo1Contract: TypedContractV2<typeof tAbi>;
+    let dd2: DeclareDeployUDCResponse;
+    let cairo210Contract: TypedContractV2<typeof tAbi>;
+    initializeMatcher(expect);
+
+    beforeAll(async () => {
+      dd = await account.declareAndDeploy({
+        contract: compiledC1v2,
+        casm: compiledC1v2Casm,
+      });
+      cairo1Contract = new Contract(compiledC1v2.abi, dd.deploy.contract_address, account).typedv2(
+        tAbi
+      );
+
+      dd2 = await account.declareAndDeploy({
+        contract: compiledC210,
+        casm: compiledC210Casm,
+      });
+      cairo210Contract = new Contract(
+        compiledC210.abi,
+        dd2.deploy.contract_address,
+        account
+      ).typedv2(tAbi);
+    });
+
+    test('Declare & deploy v2 - Hello Cairo 1 contract', async () => {
+      expect(dd.declare).toMatchSchemaRef('DeclareContractResponse');
+      expect(dd.deploy).toMatchSchemaRef('DeployContractUDCResponse');
+      expect(cairo1Contract).toBeInstanceOf(Contract);
+      expect(cairo210Contract).toBeInstanceOf(Contract);
+    });
+
+    test('getCairoVersion', async () => {
+      const version1 = await cairo1Contract.getVersion();
+      expect(version1).toEqual({ cairo: '1', compiler: '2' });
+
+      const version210 = await cairo210Contract.getVersion();
+      expect(version210).toEqual({ cairo: '1', compiler: '2' });
+    });
+
+    xtest('validate TS for redeclare - skip testing', async () => {
+      const cc0 = await account.getClassAt(dd.deploy.address);
+      const cc0_1 = await account.getClassByHash(toHex(dd.declare.class_hash));
+
+      await account.declare({
+        contract: cc0 as CompiledSierra,
+        casm: compiledC1v2Casm,
+      });
+
+      await account.declare({
+        contract: cc0_1 as CompiledSierra,
+        casm: compiledC1v2Casm,
+      });
+    });
+
+    test('deployContract Cairo1', async () => {
+      const deploy = await account.deployContract({
+        classHash: dd.deploy.classHash,
+      });
+      expect(deploy).toHaveProperty('address');
+    });
+
+    test('GetClassByHash', async () => {
+      const classResponse = await provider.getClassByHash(dd.deploy.classHash);
+      expect(classResponse).toMatchSchemaRef('SierraContractClass');
+    });
+
+    test('GetClassAt', async () => {
+      const classResponse = await provider.getClassAt(dd.deploy.contract_address);
+      expect(classResponse).toMatchSchemaRef('SierraContractClass');
+    });
+
+    test('isCairo1', async () => {
+      const isContractCairo1 = cairo1Contract.isCairo1();
+      expect(isContractCairo1).toBe(true);
+      const isAbiCairo1 = isCairo1Abi(cairo1Contract.abi);
+      expect(isAbiCairo1).toBe(true);
+    });
+
+    test('Cairo 1 Contract Interaction - skip invoke validation & call parsing', async () => {
+      const tx = await cairo1Contract.increase_balance(
+        CallData.compile({
+          amount: 100,
+        })
+      );
+      await account.waitForTransaction(tx.transaction_hash);
+
+      const balance = await cairo1Contract.get_balance({
+        parseResponse: false,
+      });
+
+      // TODO: handle parseResponse correctly, get_balance should return a list here !?
+      expect(num.toBigInt(balance)).toBe(100n);
+    });
+
+    test('Cairo 1 Contract Interaction - felt252', async () => {
+      const tx = await cairo1Contract.increase_balance(100);
+      await account.waitForTransaction(tx.transaction_hash);
+      const balance = await cairo1Contract.get_balance();
+      expect(balance).toBe(200n);
+    });
+
+    test('Cairo 1 Contract Interaction - uint 8, 16, 32, 64, 128, litterals', async () => {
+      const tx = await cairo1Contract.increase_balance_u8(255n);
+      await account.waitForTransaction(tx.transaction_hash);
+      const balance = await cairo1Contract.get_balance_u8();
+      expect(balance).toBe(255n);
+
+      let result = await cairo1Contract.test_u16(255n);
+      expect(result).toBe(256n);
+      result = await cairo1Contract.test_u32(255n);
+      expect(result).toBe(256n);
+      result = await cairo1Contract.test_u64(255n);
+      expect(result).toBe(256n);
+      result = await cairo1Contract.test_u128(255n);
+      expect(result).toBe(256n);
+    });
+
+    test('Cairo 1 - uint256', async () => {
+      // defined as number
+      const result = await cairo1Contract.test_u256(2n ** 256n - 2n);
+      expect(result).toBe(2n ** 256n - 1n);
+
+      // defined as struct
+      const result1 = await cairo1Contract.test_u256(uint256(2n ** 256n - 2n));
+      expect(result1).toBe(2n ** 256n - 1n);
+
+      // using Contract.populate result in meta-class
+      const functionParameters: RawArgsObject = { p1: cairo.uint256(15) };
+      const myCall0 = cairo1Contract.populate('test_u256', functionParameters);
+      if (myCall0.calldata !== undefined) {
+        const res0 = await cairo1Contract.test_u256(myCall0.calldata);
+        expect(res0).toBe(16n);
+      }
+      const myCall0a = cairo1Contract.populate('test_u256', { p1: 15 });
+      if (myCall0a.calldata !== undefined) {
+        const res0a = await cairo1Contract.test_u256(myCall0a.calldata);
+        expect(res0a).toBe(16n);
+      }
+      // using myCallData.compile result in meta-class
+      const contractCallData: CallData = new CallData(cairo1Contract.abi);
+      const myCalldata: Calldata = contractCallData.compile('test_u256', functionParameters);
+      const res1 = await cairo1Contract.test_u256(myCalldata);
+      expect(res1).toBe(16n);
+
+      // using CallData.compile result in meta-class
+      const contractCallData2: Calldata = CallData.compile(functionParameters);
+      const res2 = await cairo1Contract.test_u256(contractCallData2);
+      expect(res2).toBe(16n);
+    });
+
+    test('Cairo 1 Contract Interaction - bool', async () => {
+      const cdata = CallData.compile({ false: false, true: true });
+      expect(cdata).toEqual(['0', '1']);
+
+      let tx = await cairo1Contract.set_status(true);
+      await account.waitForTransaction(tx.transaction_hash);
+      let status = await cairo1Contract.get_status();
+
+      expect(status).toBe(true);
+
+      tx = await cairo1Contract.set_status(false);
+      await account.waitForTransaction(tx.transaction_hash);
+      status = await cairo1Contract.get_status();
+
+      expect(status).toBe(false);
+
+      tx = await cairo1Contract.set_status(true);
+      await account.waitForTransaction(tx.transaction_hash);
+      status = await cairo1Contract.get_status();
+
+      expect(status).toBe(true);
+    });
+
+    test('Cairo 1 Contract Interaction - ContractAddress, ClassHash, EthAddress', async () => {
+      const tx = await cairo1Contract.set_ca('123');
+      await account.waitForTransaction(tx.transaction_hash);
+      const status = await cairo1Contract.get_ca();
+      expect(status).toBe(123n);
+
+      // new types Cairo v2.0.0
+      const compiled = cairo1Contract.populate('new_types', {
+        ch: 123456789n,
+        eth_addr: 987654321n,
+        contr_address: 657563474357n,
+      });
+      const result = await cairo1Contract.call('new_types', compiled.calldata as Calldata);
+      expect(result).toStrictEqual({ '0': 123456789n, '1': 987654321n, '2': 657563474357n });
+
+      const myCalldata = new CallData(compiledC1v2.abi); // test arrays
+      const compiled2 = myCalldata.compile('array_new_types', {
+        tup: cairo.tuple(256, '0x1234567890', '0xe3456'),
+        tupa: cairo.tuple(
+          ['0x1234567890', '0xe3456'], // ContractAddress
+          ['0x1234567891', '0xe3457'], // EthAddress
+          ['0x1234567892', '0xe3458'] // ClassHash
+        ),
+      });
+      const res1 = await cairo1Contract.call('array_new_types', compiled2);
+      expect(res1).toStrictEqual({
+        '0': [78187493520n, 930902n],
+        '1': [78187493521n, 930903n],
+        '2': [78187493522n, 930904n],
+      });
+      const res2 = await cairo1Contract.call('array_contract_addr', [['0x1234567892', '0xe3458']]);
+      expect(res2).toStrictEqual([78187493522n, 930904n]);
+    });
+
+    test('Cairo1 simple getStorageAt variables retrieval', async () => {
+      // u8
+      let tx = await cairo1Contract.increase_balance(100);
+      await account.waitForTransaction(tx.transaction_hash);
+      const balance = await cairo1Contract.get_balance();
+      let key = starknetKeccak('balance');
+      let storage = await account.getStorageAt(cairo1Contract.address, key);
+      expect(BigInt(storage)).toBe(balance);
+
+      // felt
+      tx = await cairo1Contract.set_ca('123');
+      await account.waitForTransaction(tx.transaction_hash);
+      const ca = await cairo1Contract.get_ca();
+      key = starknetKeccak('ca');
+      storage = await account.getStorageAt(cairo1Contract.address, key);
+      expect(BigInt(storage)).toBe(ca);
+
+      // bool
+      tx = await cairo1Contract.set_status(true);
+      await account.waitForTransaction(tx.transaction_hash);
+      const status = await cairo1Contract.get_status();
+      key = starknetKeccak('status');
+      storage = await account.getStorageAt(cairo1Contract.address, key);
+      expect(Boolean(BigInt(storage))).toBe(status);
+
+      // simple struct
+      tx = await cairo1Contract.set_user1({
+        address: '0x54328a1075b8820eb43caf0caa233923148c983742402dcfc38541dd843d01a',
+        is_claimed: true,
+      });
+      await account.waitForTransaction(tx.transaction_hash);
+      const user = await cairo1Contract.get_user1();
+      key = starknetKeccak('user1');
+      const storage1 = await account.getStorageAt(cairo1Contract.address, key);
+      const storage2 = await account.getStorageAt(cairo1Contract.address, key + 1n);
+      expect(BigInt(storage1)).toBe(user.address);
+      expect(Boolean(BigInt(storage2))).toBe(user.is_claimed);
+
+      // TODO: Complex mapping - https://docs.starknet.io/documentation/architecture_and_concepts/Contracts/contract-storage/
+    });
+
+    test('Cairo 1 Contract Interaction - echo flat un-named un-nested tuple', async () => {
+      const status = await cairo1Contract.echo_un_tuple(tuple(77, 123));
+      expect(Object.values(status)).toEqual([77n, 123n]);
+    });
+
+    test('Cairo 1 Contract Interaction - echo flat un-nested Array u8, uint256, bool', async () => {
+      const status = await cairo1Contract.echo_array([123, 55, 77, 255]);
+      expect(status).toEqual([123n, 55n, 77n, 255n]);
+
+      // uint256 defined as number
+      const status1 = await cairo1Contract.echo_array_u256([123, 55, 77, 255]);
+      expect(status1).toEqual([123n, 55n, 77n, 255n]);
+
+      // uint256 defined as struct
+      const status11 = await cairo1Contract.echo_array_u256([
+        uint256(123),
+        uint256(55),
+        uint256(77),
+        uint256(255),
+      ]);
+      expect(status11).toEqual([123n, 55n, 77n, 255n]);
+
+      const status2 = await cairo1Contract.echo_array_bool([true, true, false, false]);
+      expect(status2).toEqual([true, true, false, false]);
+
+      // Span type
+      const comp = cairo1Contract.populate('new_span', { my_span: [1, 2, 3] });
+      const resp = await cairo1Contract.call('new_span', comp.calldata as Calldata);
+      expect(resp).toEqual([1n, 2n, 3n]);
+    });
+
+    test('Cairo 1 Contract Interaction - echo flat un-nested Struct', async () => {
+      const status = await cairo1Contract.echo_struct({
+        val: 'simple',
+      });
+      if (typeof status.val === 'string') {
+        expect(shortString.decodeShortString(status.val)).toBe('simple');
+      }
+    });
+
+    test('Cairo 1 more complex structs', async () => {
+      const tx = await cairo1Contract.set_bet();
+      await account.waitForTransaction(tx.transaction_hash);
+      const status = await cairo1Contract.get_bet(1, {
+        formatResponse: { name: 'string', description: 'string' },
+      });
+
+      const expected = {
+        name: 'test',
+        description: 'dec',
+        expire_date: 1n,
+        creation_time: 1n,
+        creator: BigInt(account.address),
+        is_cancelled: false,
+        is_voted: false,
+        bettor: {
+          address: BigInt(account.address),
+          is_claimed: false,
+        },
+        counter_bettor: {
+          address: BigInt(account.address),
+          is_claimed: false,
+        },
+        winner: false,
+        pool: 10n,
+        amount: 1000n,
+      };
+      expect(expected).toEqual(status);
+    });
+
+    test('C1 Array 2D', async () => {
+      const cd = CallData.compile({
+        test: [
+          [1, 2],
+          [3, 4],
+        ],
+      });
+
+      const tx = await cairo1Contract.array2d_ex([
+        [1, 2],
+        [3, 4],
+      ]);
+      await account.waitForTransaction(tx.transaction_hash);
+      const tx1 = await cairo1Contract.array2d_ex(cd);
+      await account.waitForTransaction(tx1.transaction_hash);
+
+      const result0 = await cairo1Contract.array2d_felt([
+        [1, 2],
+        [3, 4],
+      ]);
+      const result01 = await cairo1Contract.array2d_felt(cd);
+      expect(result0).toBe(1n);
+      expect(result0).toBe(result01);
+
+      const result1 = await cairo1Contract.array2d_array([
+        [1, 2],
+        [3, 4],
+      ]);
+      const result11 = await cairo1Contract.array2d_array(cd);
+      expect(result1).toEqual([
+        [1n, 2n],
+        [3n, 4n],
+      ]);
+      expect(result1).toEqual(result11);
+    });
+
+    test('mix tuples', async () => {
+      const res = await cairo1Contract.array_bool_tuple([1, 2, 3], true);
+      expect(res).toEqual({
+        0: [1n, 2n, 3n, 1n, 2n],
+        1: true,
+      });
+
+      const res1 = await cairo1Contract.tuple_echo(tuple([1, 2, 3], [4, 5, 6]));
+      expect(res1).toEqual({
+        0: [1n, 2n, 3n],
+        1: [4n, 5n, 6n],
+      });
+    });
+
+    test('CairoEnums', async () => {
+      type Order = {
+        p1: BigNumberish;
+        p2: number | bigint;
+      };
+      // return a Cairo Custom Enum
+      const myCairoEnum: CairoCustomEnum = await cairo1Contract.my_enum_output(50);
+      expect(myCairoEnum.unwrap()).toEqual(3n);
+      expect(myCairoEnum.activeVariant()).toEqual('Error');
+
+      const myCairoEnum2: CairoCustomEnum = await cairo1Contract.my_enum_output(100);
+      // expect(myCairoEnum2.unwrap()).toEqual(BigInt(shortString.encodeShortString('attention:100')));
+      expect(myCairoEnum2.activeVariant()).toEqual('Warning');
+
+      const myCairoEnum3: CairoCustomEnum = await cairo1Contract.my_enum_output(150);
+      const res: Order = myCairoEnum3.unwrap();
+      expect(res).toEqual({ p1: 1n, p2: 150n });
+      expect(myCairoEnum3.activeVariant()).toEqual('Response');
+
+      // Send a Cairo Custom Enum
+      const res2 = (await cairo1Contract.call('my_enum_input', [
+        new CairoCustomEnum({ Error: 100 }),
+      ])) as bigint;
+      const myOrder: Order = { p1: 100, p2: 200 };
+      const res3 = await cairo1Contract.my_enum_input(new CairoCustomEnum({ Response: myOrder }));
+      expect(res2).toEqual(100n);
+      expect(res3).toEqual(200n);
+
+      const comp2 = CallData.compile([
+        new CairoCustomEnum({
+          Response: undefined,
+          Warning: undefined,
+          Error: 100,
+        }),
+      ]);
+      const res2a = (await cairo1Contract.call('my_enum_input', comp2)) as bigint;
+      const comp3 = CallData.compile([
+        new CairoCustomEnum({
+          Response: myOrder,
+          Warning: undefined,
+          Error: undefined,
+        }),
+      ]);
+      const res3a = (await cairo1Contract.my_enum_input(comp3)) as bigint;
+      expect(res2a).toEqual(100n);
+      expect(res3a).toEqual(200n);
+
+      const comp2b = cairo1Contract.populate('my_enum_input', {
+        customEnum: new CairoCustomEnum({ Error: 100 }),
+      });
+      const res2b = (await cairo1Contract.call(
+        'my_enum_input',
+        comp2b.calldata as Calldata
+      )) as bigint;
+      const comp3b = cairo1Contract.populate('my_enum_input', {
+        customEnum: new CairoCustomEnum({ Response: myOrder }),
+      });
+      // comp3b.calldata
+      if (comp3b.calldata !== undefined) {
+        const res3b = (await cairo1Contract.my_enum_input(comp3b.calldata)) as bigint;
+        expect(res3b).toEqual(200n);
+      }
+      expect(res2b).toEqual(100n);
+
+      // return a Cairo Option
+      const myCairoOption: CairoOption<Order> = await cairo1Contract.option_order_output(50);
+      expect(myCairoOption.unwrap()).toEqual(undefined);
+      expect(myCairoOption.isNone()).toEqual(true);
+      expect(myCairoOption.isSome()).toEqual(false);
+
+      const myCairoOption2: CairoOption<Order> = await cairo1Contract.option_order_output(150);
+      expect(myCairoOption2.unwrap()).toEqual({ p1: 18n, p2: 150n });
+      expect(myCairoOption2.isNone()).toEqual(false);
+      expect(myCairoOption2.isSome()).toEqual(true);
+
+      // send a Cairo Option
+      const cairoOption1 = new CairoOption<Order>(CairoOptionVariant.None);
+      const res4 = (await cairo1Contract.call('option_order_input', [cairoOption1])) as bigint;
+      const comp4a = CallData.compile([cairoOption1]);
+      const res4a = (await cairo1Contract.call('option_order_input', comp4a)) as bigint;
+      const res5 = (await cairo1Contract.option_order_input(
+        new CairoOption<Order>(CairoOptionVariant.Some, myOrder)
+      )) as bigint;
+      const res5a = (await cairo1Contract.option_order_input(
+        CallData.compile([new CairoOption<Order>(CairoOptionVariant.Some, myOrder)])
+      )) as bigint;
+      expect(res4).toEqual(17n);
+      expect(res4a).toEqual(17n);
+      expect(res5).toEqual(200n);
+      expect(res5a).toEqual(200n);
+
+      // return a Cairo Result
+      const myCairoResult: CairoResult<Order, BigNumberish> =
+        await cairo1Contract.enum_result_output(50);
+      expect(myCairoResult.unwrap()).toEqual(14n);
+      expect(myCairoResult.isErr()).toEqual(true);
+      expect(myCairoResult.isOk()).toEqual(false);
+
+      const myCairoResult2: CairoResult<Order, BigNumberish> =
+        await cairo1Contract.enum_result_output(150);
+      expect(myCairoResult2.unwrap()).toEqual({ p1: 8n, p2: 150n });
+      expect(myCairoResult2.isErr()).toEqual(false);
+      expect(myCairoResult2.isOk()).toEqual(true);
+
+      // send a Cairo Result
+      const cairoResult1 = new CairoResult<Order, BigNumberish>(CairoResultVariant.Err, 18n);
+      const res6 = (await cairo1Contract.call('enum_result_input', [cairoResult1])) as bigint;
+      const comp6a = CallData.compile([cairoResult1]);
+      const res6a = (await cairo1Contract.call('enum_result_input', comp6a)) as bigint;
+      const res7 = (await cairo1Contract.enum_result_input(
+        new CairoResult<Order, BigNumberish>(CairoResultVariant.Ok, myOrder)
+      )) as bigint;
+      const res7a = (await cairo1Contract.enum_result_input(
+        CallData.compile([new CairoResult<Order, BigNumberish>(CairoResultVariant.Ok, myOrder)])
+      )) as bigint;
+      expect(res6).toEqual(18n);
+      expect(res6a).toEqual(18n);
+      expect(res7).toEqual(200n);
+      expect(res7a).toEqual(200n);
+    });
+
+    test('Cairo 2.1.0 simple contract', async () => {
+      const res = await cairo210Contract.test_felt(1, 100, 3);
+      expect(res).toEqual(101n);
+
+      const call1 = cairo210Contract.populate('test_len', { p1: 100, string_len: 200 });
+      expect(call1.calldata).toEqual(['100', '200']);
+    });
+
+    test('myCallData.compile for Cairo 1', async () => {
+      const myFalseUint256 = { high: 1, low: 23456 }; // wrong order
+      type Order2 = {
+        p1: BigNumberish;
+        p2: BigNumberish[];
+      };
+
+      const myOrder2bis: Order2 = {
+        // wrong order
+        p2: [234, 467456745457n, '0x56ec'],
+        p1: '17',
+      };
+      const myRawArgsObject: RawArgsObject = {
+        // wrong order
+        active: true,
+        symbol: 'NIT',
+        initial_supply: myFalseUint256,
+        recipient: '0x7e00d496e324876bbc8531f2d9a82bf154d1a04a50218ee74cdd372f75a551a',
+        decimals: 18,
+        tupoftup: tuple(tuple(34, '0x5e'), myFalseUint256),
+        card: myOrder2bis,
+        longText: 'Bug is back, for ever, here and everywhere',
+        array1: [100, 101, 102],
+        array2: [
+          [200, 201],
+          [202, 203],
+          [204, 205],
+        ],
+        array3: [myOrder2bis, myOrder2bis],
+        array4: [myFalseUint256, myFalseUint256],
+        tuple1: tuple(40000n, myOrder2bis, [54, 55n, '0xae'], 'texte'),
+        name: 'niceToken',
+        array5: [tuple(251, 40000n), tuple(252, 40001n)],
+      };
+      const myRawArgsArray: RawArgsArray = [
+        'niceToken',
+        'NIT',
+        18,
+        { low: 23456, high: 1 },
+        { p1: '17', p2: [234, 467456745457n, '0x56ec'] },
+        '0x7e00d496e324876bbc8531f2d9a82bf154d1a04a50218ee74cdd372f75a551a',
+        true,
+        { '0': { '0': 34, '1': '0x5e' }, '1': { low: 23456, high: 1 } },
+        'Bug is back, for ever, here and everywhere',
+        [100, 101, 102],
+        [
+          [200, 201],
+          [202, 203],
+          [204, 205],
+        ],
+        [
+          { p1: '17', p2: [234, 467456745457n, '0x56ec'] },
+          { p1: '17', p2: [234, 467456745457n, '0x56ec'] },
+        ],
+        [
+          { low: 23456, high: 1 },
+          { low: 23456, high: 1 },
+        ],
+        {
+          '0': 40000n,
+          '1': { p1: '17', p2: [234, 467456745457n, '0x56ec'] },
+          '2': [54, 55n, '0xae'],
+          '3': 'texte',
+        },
+        [
+          { '0': 251, '1': 40000n },
+          { '0': 252, '1': 40001n },
+        ],
+      ];
+
+      const contractCallData: CallData = new CallData(compiledComplexSierra.abi);
+      const callDataFromObject: Calldata = contractCallData.compile('constructor', myRawArgsObject);
+      const callDataFromArray: Calldata = contractCallData.compile('constructor', myRawArgsArray);
+      const expectedResult = [
+        '2036735872918048433518',
+        '5130580',
+        '18',
+        '23456',
+        '1',
+        '17',
+        '3',
+        '234',
+        '467456745457',
+        '22252',
+        '3562055384976875123115280411327378123839557441680670463096306030682092229914',
+        '1',
+        '34',
+        '94',
+        '23456',
+        '1',
+        '2',
+        '117422190885827407409664260607192623408641871979684112605616397634538401380',
+        '39164769268277364419555941',
+        '3',
+        '100',
+        '101',
+        '102',
+        '3',
+        '2',
+        '200',
+        '201',
+        '2',
+        '202',
+        '203',
+        '2',
+        '204',
+        '205',
+        '2',
+        '17',
+        '3',
+        '234',
+        '467456745457',
+        '22252',
+        '17',
+        '3',
+        '234',
+        '467456745457',
+        '22252',
+        '2',
+        '23456',
+        '1',
+        '23456',
+        '1',
+        '40000',
+        '0',
+        '17',
+        '3',
+        '234',
+        '467456745457',
+        '22252',
+        '3',
+        '54',
+        '55',
+        '174',
+        '499918599269',
+        '2',
+        '251',
+        '40000',
+        '252',
+        '40001',
+      ];
+      expect(callDataFromObject).toStrictEqual(expectedResult);
+      expect(callDataFromArray).toStrictEqual(expectedResult);
+    });
+
+    describeIfDevnetSequencer('Sequencer only', () => {
+      test('getCompiledClassByClassHash', async () => {
+        const compiledClass = await (provider as SequencerProvider).getCompiledClassByClassHash(
+          dd.deploy.classHash
+        );
+        expect(compiledClass).toMatchSchemaRef('CompiledClass');
+      });
+    });
+  });
+
+  describe('Cairo1 Account contract', () => {
+    let accountC1: Account;
+
+    beforeAll(async () => {
+      // Deploy Cairo 1 Account
+      const priKey = stark.randomAddress();
+      const pubKey = ec.starkCurve.getStarkKey(priKey);
+
+      const calldata = { publicKey: pubKey };
+
+      // declare account
+      const declareAccount = await account.declareIfNot({
+        contract: compiledC1Account,
+        casm: compiledC1AccountCasm,
+      });
+      if (declareAccount.transaction_hash) {
+        await account.waitForTransaction(declareAccount.transaction_hash);
+      }
+      const accountClassHash = declareAccount.class_hash;
+
+      // fund new account
+      const toBeAccountAddress = hash.calculateContractAddressFromHash(
+        pubKey,
+        accountClassHash,
+        calldata,
+        0
+      );
+      const devnetERC20Address =
+        '0x49D36570D4E46F48E99674BD3FCC84644DDD6B96F7C741B1562B82F9E004DC7';
+      const { transaction_hash } = await account.execute({
+        contractAddress: devnetERC20Address,
+        entrypoint: 'transfer',
+        calldata: {
+          recipient: toBeAccountAddress,
+          amount: uint256(5 * 10 ** 15),
+        },
+      });
+      await account.waitForTransaction(transaction_hash);
+
+      // deploy account
+      accountC1 = new Account(provider, toBeAccountAddress, priKey, '1');
+      const deployed = await accountC1.deploySelf({
+        classHash: accountClassHash,
+        constructorCalldata: calldata,
+        addressSalt: pubKey,
+      });
+      const receipt = await account.waitForTransaction(deployed.transaction_hash);
+      expect(receipt).toMatchSchemaRef('GetTransactionReceiptResponse');
+    });
+
+    test('deploy Cairo1 Account from Cairo0 Account', () => {
+      expect(accountC1).toBeInstanceOf(Account);
+    });
+  });
+
+  describe('Event Parsing', () => {
+    let eventContract: TypedContractV2<typeof tAbi>;
+    const simpleKeyVariable = 0n;
+    const simpleKeyStruct = {
+      first: 1n,
+      second: 2n,
+    };
+    const simpleKeyArray = [3n, 4n, 5n];
+    const simpleDataVariable = 6n;
+    const simpleDataStruct = {
+      first: 7n,
+      second: 8n,
+    };
+    const simpleDataArray = [9n, 10n, 11n];
+    const nestedKeyStruct = {
+      simpleStruct: {
+        first: 0n,
+        second: 1n,
+      },
+      simpleArray: [2n, 3n, 4n, 5n],
+    };
+    const nestedDataStruct = {
+      simpleStruct: {
+        first: 6n,
+        second: 7n,
+      },
+      simpleArray: [8n, 9n, 10n, 11n],
+    };
+    beforeAll(async () => {
+      const { deploy } = await account.declareAndDeploy({
+        contract: compiledC1v2,
+        casm: compiledC1v2Casm,
+      });
+
+      eventContract = new Contract(compiledC1v2.abi, deploy.contract_address!, account).typedv2(
+        tAbi
+      );
+    });
+
+    test('parse event returning a regular struct', async () => {
+      const { transaction_hash } = await eventContract.emitEventRegular(
+        simpleKeyVariable,
+        simpleKeyStruct,
+        simpleKeyArray,
+        simpleDataVariable,
+        simpleDataStruct,
+        simpleDataArray
+      );
+      const shouldBe: types.ParsedEvents = [
+        {
+          EventRegular: {
+            simpleKeyVariable,
+            simpleKeyStruct,
+            simpleKeyArray,
+            simpleDataVariable,
+            simpleDataStruct,
+            simpleDataArray,
+          },
+        },
+      ];
+      const tx = await provider.waitForTransaction(transaction_hash);
+      const events = eventContract.parseEvents(tx);
+      return expect(events).toStrictEqual(shouldBe);
+    });
+
+    test('parse event returning a nested struct', async () => {
+      const { transaction_hash } = await eventContract.emitEventNested(
+        nestedKeyStruct,
+        nestedDataStruct
+      );
+      const shouldBe: types.ParsedEvents = [
+        {
+          EventNested: {
+            nestedKeyStruct,
+            nestedDataStruct,
+          },
+        },
+      ];
+      const tx = await provider.waitForTransaction(transaction_hash);
+      const events = eventContract.parseEvents(tx);
+
+      return expect(events).toStrictEqual(shouldBe);
+    });
+
+    test('parse tx returning multiple similar events', async () => {
+      const anotherKeyVariable = 100n;
+      const shouldBe: types.ParsedEvents = [
+        {
+          EventRegular: {
+            simpleKeyVariable,
+            simpleKeyStruct,
+            simpleKeyArray,
+            simpleDataVariable,
+            simpleDataStruct,
+            simpleDataArray,
+          },
+        },
+        {
+          EventRegular: {
+            simpleKeyVariable: anotherKeyVariable,
+            simpleKeyStruct,
+            simpleKeyArray,
+            simpleDataVariable,
+            simpleDataStruct,
+            simpleDataArray,
+          },
+        },
+      ];
+      const callData1 = eventContract.populate('emitEventRegular', [
+        simpleKeyVariable,
+        simpleKeyStruct,
+        simpleKeyArray,
+        simpleDataVariable,
+        simpleDataStruct,
+        simpleDataArray,
+      ]);
+      const callData2 = eventContract.populate('emitEventRegular', [
+        anotherKeyVariable,
+        simpleKeyStruct,
+        simpleKeyArray,
+        simpleDataVariable,
+        simpleDataStruct,
+        simpleDataArray,
+      ]);
+      const { transaction_hash } = await account.execute([callData1, callData2]);
+      const tx = await provider.waitForTransaction(transaction_hash);
+      const events = eventContract.parseEvents(tx);
+      return expect(events).toStrictEqual(shouldBe);
+    });
+    test('parse tx returning multiple different events', async () => {
+      const shouldBe: types.ParsedEvents = [
+        {
+          EventRegular: {
+            simpleKeyVariable,
+            simpleKeyStruct,
+            simpleKeyArray,
+            simpleDataVariable,
+            simpleDataStruct,
+            simpleDataArray,
+          },
+        },
+        {
+          EventNested: {
+            nestedKeyStruct,
+            nestedDataStruct,
+          },
+        },
+      ];
+      const callData1 = eventContract.populate('emitEventRegular', [
+        simpleKeyVariable,
+        simpleKeyStruct,
+        simpleKeyArray,
+        simpleDataVariable,
+        simpleDataStruct,
+        simpleDataArray,
+      ]);
+      const callData2 = eventContract.populate('emitEventNested', [
+        nestedKeyStruct,
+        nestedDataStruct,
+      ]);
+      const { transaction_hash } = await account.execute([callData1, callData2]);
+      const tx = await provider.waitForTransaction(transaction_hash);
+      const events = eventContract.parseEvents(tx);
+      return expect(events).toStrictEqual(shouldBe);
+    });
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "@typescript-eslint/eslint-plugin": "^5.28.0",
         "@typescript-eslint/parser": "^5.28.0",
         "abi-wan-kanabi": "^1.0.3",
-        "abi-wan-kanabi-v2": "npm:abi-wan-kanabi@^2.1.0-rc.0",
+        "abi-wan-kanabi-v2": "npm:abi-wan-kanabi@^2.1.0-rc.1",
         "ajv": "^8.12.0",
         "ajv-keywords": "^5.1.0",
         "eslint": "^8.17.0",
@@ -5238,9 +5238,9 @@
     },
     "node_modules/abi-wan-kanabi-v2": {
       "name": "abi-wan-kanabi",
-      "version": "2.1.0-rc.0",
-      "resolved": "https://registry.npmjs.org/abi-wan-kanabi/-/abi-wan-kanabi-2.1.0-rc.0.tgz",
-      "integrity": "sha512-/1JPg4Ir+pePAaUaYjwuLzQ8SpD5v7HkNjcHgmHLg5PmTLx3SpP66bZPQ8a2aKJxUcx6jHwr/DD3GLxXa7fTnA==",
+      "version": "2.1.0-rc.1",
+      "resolved": "https://registry.npmjs.org/abi-wan-kanabi/-/abi-wan-kanabi-2.1.0-rc.1.tgz",
+      "integrity": "sha512-MH2vwNptNSCWYqjHL4o26MLPe7bGfk0TLjbsvoQU3iDG4snW7xD0Q0OSWr5akIoIiGgcN4DwGP4FhYneSvjGVw==",
       "dev": true,
       "dependencies": {
         "fs-extra": "^10.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "@typescript-eslint/eslint-plugin": "^5.28.0",
         "@typescript-eslint/parser": "^5.28.0",
         "abi-wan-kanabi": "^1.0.3",
-        "abi-wan-kanabi-v2": "npm:abi-wan-kanabi@^2.1.0-rc.1",
+        "abi-wan-kanabi-v2": "npm:abi-wan-kanabi@^2.1.0",
         "ajv": "^8.12.0",
         "ajv-keywords": "^5.1.0",
         "eslint": "^8.17.0",
@@ -5238,11 +5238,13 @@
     },
     "node_modules/abi-wan-kanabi-v2": {
       "name": "abi-wan-kanabi",
-      "version": "2.1.0-rc.1",
-      "resolved": "https://registry.npmjs.org/abi-wan-kanabi/-/abi-wan-kanabi-2.1.0-rc.1.tgz",
-      "integrity": "sha512-MH2vwNptNSCWYqjHL4o26MLPe7bGfk0TLjbsvoQU3iDG4snW7xD0Q0OSWr5akIoIiGgcN4DwGP4FhYneSvjGVw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/abi-wan-kanabi/-/abi-wan-kanabi-2.1.0.tgz",
+      "integrity": "sha512-sqH0woHvhTJyRhwyp6o1n8kzDuV8T7iYS897vuaB6RdnfuX9s5dSlqUFgNDQ29VpT3GFy4rqp+uT/JKxUsK6Yg==",
       "dev": true,
       "dependencies": {
+        "ansicolors": "^0.3.2",
+        "cardinal": "^2.1.1",
         "fs-extra": "^10.0.0",
         "rome": "^12.1.3",
         "typescript": "^5.2.2",
@@ -5462,8 +5464,7 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.3.2.tgz",
       "integrity": "sha512-QXu7BPrP29VllRxH8GwB7x5iX5qWKAAMLqKQGWTeLWVlNHNOpVMJ91dsxQAIWXpjuW5wqvxu3Jd/nRjrJ+0pqg==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/any-promise": {
       "version": "1.3.0",
@@ -6110,7 +6111,6 @@
       "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-2.1.1.tgz",
       "integrity": "sha512-JSr5eOgoEymtYHBjNWyjrMqet9Am2miJhlfKNdqLp6zoeAh0KN5dRAcxlecj5mAJrmQomgiOBj35xHLrFjqBpw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "ansicolors": "~0.3.2",
         "redeyed": "~2.1.0"
@@ -17068,7 +17068,6 @@
       "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-2.1.1.tgz",
       "integrity": "sha512-FNpGGo1DycYAdnrKFxCMmKYgo/mILAqtRYbkdQD8Ep/Hk2PQ5+aEAEx+IU713RTDmuBaH0c8P5ZozurNu5ObRQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "esprima": "~4.0.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "@typescript-eslint/eslint-plugin": "^5.28.0",
         "@typescript-eslint/parser": "^5.28.0",
         "abi-wan-kanabi": "^1.0.3",
+        "abi-wan-kanabi-v2": "npm:abi-wan-kanabi@^2.1.0-rc.0",
         "ajv": "^8.12.0",
         "ajv-keywords": "^5.1.0",
         "eslint": "^8.17.0",
@@ -5233,6 +5234,49 @@
       },
       "bin": {
         "generate": "dist/generate.js"
+      }
+    },
+    "node_modules/abi-wan-kanabi-v2": {
+      "name": "abi-wan-kanabi",
+      "version": "2.1.0-rc.0",
+      "resolved": "https://registry.npmjs.org/abi-wan-kanabi/-/abi-wan-kanabi-2.1.0-rc.0.tgz",
+      "integrity": "sha512-/1JPg4Ir+pePAaUaYjwuLzQ8SpD5v7HkNjcHgmHLg5PmTLx3SpP66bZPQ8a2aKJxUcx6jHwr/DD3GLxXa7fTnA==",
+      "dev": true,
+      "dependencies": {
+        "fs-extra": "^10.0.0",
+        "rome": "^12.1.3",
+        "typescript": "^5.2.2",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "generate": "dist/generate.js"
+      }
+    },
+    "node_modules/abi-wan-kanabi-v2/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/abi-wan-kanabi-v2/node_modules/typescript": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
+      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/abi-wan-kanabi/node_modules/fs-extra": {

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "@typescript-eslint/eslint-plugin": "^5.28.0",
     "@typescript-eslint/parser": "^5.28.0",
     "abi-wan-kanabi": "^1.0.3",
+    "abi-wan-kanabi-v2": "npm:abi-wan-kanabi@^2.1.0-rc.0",
     "ajv": "^8.12.0",
     "ajv-keywords": "^5.1.0",
     "eslint": "^8.17.0",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "@typescript-eslint/eslint-plugin": "^5.28.0",
     "@typescript-eslint/parser": "^5.28.0",
     "abi-wan-kanabi": "^1.0.3",
-    "abi-wan-kanabi-v2": "npm:abi-wan-kanabi@^2.1.0-rc.1",
+    "abi-wan-kanabi-v2": "npm:abi-wan-kanabi@^2.1.0",
     "ajv": "^8.12.0",
     "ajv-keywords": "^5.1.0",
     "eslint": "^8.17.0",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "@typescript-eslint/eslint-plugin": "^5.28.0",
     "@typescript-eslint/parser": "^5.28.0",
     "abi-wan-kanabi": "^1.0.3",
-    "abi-wan-kanabi-v2": "npm:abi-wan-kanabi@^2.1.0-rc.0",
+    "abi-wan-kanabi-v2": "npm:abi-wan-kanabi@^2.1.0-rc.1",
     "ajv": "^8.12.0",
     "ajv-keywords": "^5.1.0",
     "eslint": "^8.17.0",

--- a/src/contract/default.ts
+++ b/src/contract/default.ts
@@ -1,4 +1,5 @@
 import type { Abi as AbiKanabi } from 'abi-wan-kanabi';
+import type { Abi as AbiKanabiV2, TypedContract as AbiWanTypedContractV2 } from 'abi-wan-kanabi-v2';
 
 import { AccountInterface } from '../account';
 import { ProviderInterface, defaultProvider } from '../provider';
@@ -31,6 +32,8 @@ import { createAbiParser } from '../utils/calldata/parser';
 import { getAbiEvents, parseEvents as parseRawEvents } from '../utils/events/index';
 import { cleanHex } from '../utils/num';
 import { ContractInterface, TypedContract } from './interface';
+
+export type TypedContractV2<TAbi extends AbiKanabiV2> = AbiWanTypedContractV2<TAbi> & Contract;
 
 export const splitArgsAndOptions = (args: ArgsOrCalldataWithOptions) => {
   const options = [
@@ -348,5 +351,9 @@ export class Contract implements ContractInterface {
 
   public typed<TAbi extends AbiKanabi>(tAbi: TAbi): TypedContract<TAbi> {
     return this as TypedContract<typeof tAbi>;
+  }
+
+  public typedv2<TAbi extends AbiKanabiV2>(tAbi: TAbi): TypedContractV2<TAbi> {
+    return this as unknown as TypedContractV2<typeof tAbi>;
   }
 }

--- a/src/contract/interface.ts
+++ b/src/contract/interface.ts
@@ -27,8 +27,6 @@ import { CairoCustomEnum } from '../utils/calldata/enum/CairoCustomEnum';
 import { CairoOption } from '../utils/calldata/enum/CairoOption';
 import { CairoResult } from '../utils/calldata/enum/CairoResult';
 
-// import { ResolvedConfig } from 'abi-wan-kanabi-v2/config';
-
 declare module 'abi-wan-kanabi-v2' {
   export interface Config<OptionT = any, ResultT = any, ErrorT = any> {
     FeltType: BigNumberish;

--- a/src/contract/interface.ts
+++ b/src/contract/interface.ts
@@ -44,8 +44,6 @@ declare module 'abi-wan-kanabi-v2' {
   }
 }
 
-// export type X = ResolvedConfig['InvokeOptions'];
-
 export type TypedContract<TAbi extends AbiKanabi> = AbiWanTypedContract<TAbi> & ContractInterface;
 type TypedContractV2<TAbi extends AbiKanabiV2> = AbiWanTypedContractV2<TAbi> & ContractInterface;
 

--- a/src/contract/interface.ts
+++ b/src/contract/interface.ts
@@ -1,4 +1,5 @@
 import type { Abi as AbiKanabi, TypedContract as AbiWanTypedContract } from 'abi-wan-kanabi';
+import type { Abi as AbiKanabiV2, TypedContract as AbiWanTypedContractV2 } from 'abi-wan-kanabi-v2';
 
 import { AccountInterface } from '../account';
 import { ProviderInterface } from '../provider';
@@ -6,8 +7,10 @@ import {
   Abi,
   ArgsOrCalldata,
   AsyncContractFunction,
+  BigNumberish,
   BlockIdentifier,
   CallOptions,
+  Calldata,
   ContractFunction,
   ContractVersion,
   EstimateFeeResponse,
@@ -16,10 +19,35 @@ import {
   InvokeFunctionResponse,
   InvokeOptions,
   ParsedEvents,
+  RawArgs,
   Result,
+  Uint256,
 } from '../types';
+import { CairoCustomEnum } from '../utils/calldata/enum/CairoCustomEnum';
+import { CairoOption } from '../utils/calldata/enum/CairoOption';
+import { CairoResult } from '../utils/calldata/enum/CairoResult';
+
+// import { ResolvedConfig } from 'abi-wan-kanabi-v2/config';
+
+declare module 'abi-wan-kanabi-v2' {
+  export interface Config<OptionT = any, ResultT = any, ErrorT = any> {
+    FeltType: BigNumberish;
+    U256Type: number | bigint | Uint256;
+    Option: CairoOption<OptionT>;
+    Tuple: Record<number, BigNumberish | object | boolean>;
+    Result: CairoResult<ResultT, ErrorT>;
+    Enum: CairoCustomEnum;
+    Calldata: RawArgs | Calldata;
+    CallOptions: CallOptions;
+    InvokeOptions: InvokeOptions;
+    InvokeFunctionResponse: InvokeFunctionResponse;
+  }
+}
+
+// export type X = ResolvedConfig['InvokeOptions'];
 
 export type TypedContract<TAbi extends AbiKanabi> = AbiWanTypedContract<TAbi> & ContractInterface;
+type TypedContractV2<TAbi extends AbiKanabiV2> = AbiWanTypedContractV2<TAbi> & ContractInterface;
 
 export abstract class ContractInterface {
   public abstract abi: Abi;
@@ -139,4 +167,5 @@ export abstract class ContractInterface {
   public abstract getVersion(): Promise<ContractVersion>;
 
   public abstract typed<TAbi extends AbiKanabi>(tAbi: TAbi): TypedContract<TAbi>;
+  public abstract typedv2<TAbi extends AbiKanabiV2>(tAbi: TAbi): TypedContractV2<TAbi>;
 }

--- a/src/types/api/rpcspec/components.ts
+++ b/src/types/api/rpcspec/components.ts
@@ -437,7 +437,7 @@ export type SIERRA_ENTRY_POINT = {
   function_idx: number;
 };
 
-export type CONTRACT_ABI = CONTRACT_ABI_ENTRY[];
+export type CONTRACT_ABI = readonly CONTRACT_ABI_ENTRY[];
 
 export type CONTRACT_ABI_ENTRY = {
   selector: FELT;

--- a/src/types/lib/contract/abi.ts
+++ b/src/types/lib/contract/abi.ts
@@ -1,5 +1,5 @@
 /** ABI */
-export type Abi = Array<FunctionAbi | EventAbi | StructAbi | any>;
+export type Abi = ReadonlyArray<FunctionAbi | EventAbi | StructAbi | any>;
 
 // Basic elements
 export type AbiEntry = { name: string; type: 'felt' | 'felt*' | string };


### PR DESCRIPTION
## Motivation and Resolution
Cairo v1 introduced many breaking changes to the ABI, this PR aims to integrate abiwan v2 which support the new cairo versions with starknet.js

### RPC version (if applicable)


## Usage related changes

<!-- How the changes from this PR affect users. -->

Users will be able to get typed function calls on their Cairo v1 contracts, all they need to do is call the `typedv2` function and pass the ABI object

## Development related changes

<!-- How these changes affect the developers of this project - e.g. changes in testing or CI/CD. -->


## Checklist:

- [x] Performed a self-review of the code
- [ ] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Linked the issues which this PR resolves
- [ ] Documented the changes in code (API docs will be generated automatically)
- [x] Updated the tests
- [x] All tests are passing
