### PR TITLE
fix: outdated link to OZ ERC20 implementation

### DIFF
--- a/www/versioned_docs/version-4.17.1/guides/erc20.md
+++ b/www/versioned_docs/version-4.17.1/guides/erc20.md
@@ -16,7 +16,7 @@ High level explanations from StarkWare can be found in this Notion [page](https:
 ERC20 implementations:
 
 1. Argent ERC20 contract can be found [here](https://github.com/argentlabs/argent-contracts-starknet/blob/develop/contracts/lib/ERC20.cairo).
-2. OpenZeppelin ERC20 can be found [here](https://github.com/OpenZeppelin/cairo-contracts/tree/main/src/openzeppelin/token/erc20).
+2. OpenZeppelin ERC20 can be found [here](https://github.com/OpenZeppelin/cairo-contracts/tree/main/src/token/erc20).
 
 ## Setup
 


### PR DESCRIPTION
## Motivation and Resolution

Hello, I've found a broken link to the OZ ERC20 implementation. This PR fixes the issue.

## Usage related changes

<!-- How the changes from this PR affect users. -->

- Docs improvement.

## Development related changes

<!-- How these changes affect the developers of this project - e.g. changes in testing or CI/CD. -->

- No changes.

## Checklist:

- [X] Performed a self-review of the code
- [X] Rebased to the last commit of the target branch (or merged it into my branch)
- [X] Linked the issues which this PR resolves
- [X] Documented the changes in code (API docs will be generated automatically)
- [X] Updated the tests
- [X] All tests are passing
