### PR TITLE
Chore: Rename abi-wan-kanabi to abi-wan-kanabi-v1

### DIFF
--- a/__tests__/cairo1_typed.test.ts
+++ b/__tests__/cairo1_typed.test.ts
@@ -10,7 +10,7 @@ import {
   RawArgsArray,
   RawArgsObject,
   SequencerProvider,
-  TypedContract,
+  TypedContractV1,
   cairo,
   num,
   selector,
@@ -35,7 +35,7 @@ describe('TS validation for API &  Contract interactions - tests skipped', () =>
   const provider = getTestProvider();
   const account = getTestAccount(provider);
   let dd: DeclareDeployUDCResponse;
-  let cairo1Contract: TypedContract<typeof tAbi>;
+  let cairo1Contract: TypedContractV1<typeof tAbi>;
   initializeMatcher(expect);
 
   beforeAll(async () => {
@@ -48,7 +48,7 @@ describe('TS validation for API &  Contract interactions - tests skipped', () =>
       compiledHelloSierra.abi,
       dd.deploy.contract_address,
       account
-    ).typed(tAbi);
+    ).typedv1(tAbi);
   });
 
   test('Declare & deploy v2 - Hello Cairo 1 contract', async () => {
@@ -511,7 +511,7 @@ describeIfSequencerGoerli('Cairo1 Testnet', () => {
     const classHash: any = '0x028b6f2ee9ae00d55a32072d939a55a6eb522974a283880f3c73a64c2f9fd6d6';
     const contractAddress: any =
       '0x771bbe2ba64fa5ab52f0c142b4296fc67460a3a2372b4cdce752c620e3e8194';
-    let cairo1Contract: TypedContract<typeof tAbi>;
+    let cairo1Contract: TypedContractV1<typeof tAbi>;
     initializeMatcher(expect);
 
     test('getCompiledClassByClassHash', async () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@noble/curves": "~1.3.0",
         "@scure/base": "~1.1.3",
         "@scure/starknet": "~1.0.0",
-        "abi-wan-kanabi": "^1.0.3",
+        "abi-wan-kanabi-v1": "npm:abi-wan-kanabi@^1.0.3",
         "abi-wan-kanabi-v2": "npm:abi-wan-kanabi@^2.1.1",
         "isomorphic-fetch": "^3.0.0",
         "lossless-json": "^2.0.8",
@@ -5227,6 +5227,47 @@
       },
       "bin": {
         "generate": "dist/generate.js"
+      }
+    },
+    "node_modules/abi-wan-kanabi-v1": {
+      "name": "abi-wan-kanabi",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/abi-wan-kanabi/-/abi-wan-kanabi-1.0.3.tgz",
+      "integrity": "sha512-Xwva0AnhXx/IVlzo3/kwkI7Oa7ZX7codtcSn+Gmoa2PmjGPF/0jeVud9puasIPtB7V50+uBdUj4Mh3iATqtBvg==",
+      "dependencies": {
+        "abi-wan-kanabi": "^1.0.1",
+        "fs-extra": "^10.0.0",
+        "rome": "^12.1.3",
+        "typescript": "^4.9.5",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "generate": "dist/generate.js"
+      }
+    },
+    "node_modules/abi-wan-kanabi-v1/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/abi-wan-kanabi-v1/node_modules/typescript": {
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
       }
     },
     "node_modules/abi-wan-kanabi-v2": {

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "lossless-json": "^2.0.8",
     "pako": "^2.0.4",
     "url-join": "^4.0.1",
-    "abi-wan-kanabi": "^1.0.3",
+    "abi-wan-kanabi-v1": "npm:abi-wan-kanabi@^1.0.3",
     "abi-wan-kanabi-v2": "npm:abi-wan-kanabi@^2.1.1"
   },
   "lint-staged": {

--- a/src/contract/default.ts
+++ b/src/contract/default.ts
@@ -1,4 +1,4 @@
-import type { Abi as AbiKanabi } from 'abi-wan-kanabi';
+import type { Abi as AbiKanabiV1 } from 'abi-wan-kanabi-v1';
 import type { Abi as AbiKanabiV2, TypedContract as AbiWanTypedContractV2 } from 'abi-wan-kanabi-v2';
 
 import { AccountInterface } from '../account';
@@ -31,7 +31,7 @@ import { CallData, cairo } from '../utils/calldata';
 import { createAbiParser } from '../utils/calldata/parser';
 import { getAbiEvents, parseEvents as parseRawEvents } from '../utils/events/index';
 import { cleanHex } from '../utils/num';
-import { ContractInterface, TypedContract } from './interface';
+import { ContractInterface, TypedContractV1 } from './interface';
 
 export type TypedContractV2<TAbi extends AbiKanabiV2> = AbiWanTypedContractV2<TAbi> & Contract;
 
@@ -349,8 +349,8 @@ export class Contract implements ContractInterface {
     return this.providerOrAccount.getContractVersion(this.address);
   }
 
-  public typed<TAbi extends AbiKanabi>(tAbi: TAbi): TypedContract<TAbi> {
-    return this as TypedContract<typeof tAbi>;
+  public typedv1<TAbi extends AbiKanabiV1>(tAbi: TAbi): TypedContractV1<TAbi> {
+    return this as TypedContractV1<typeof tAbi>;
   }
 
   public typedv2<TAbi extends AbiKanabiV2>(tAbi: TAbi): TypedContractV2<TAbi> {

--- a/src/contract/interface.ts
+++ b/src/contract/interface.ts
@@ -1,4 +1,4 @@
-import type { Abi as AbiKanabi, TypedContract as AbiWanTypedContract } from 'abi-wan-kanabi';
+import type { Abi as AbiKanabiV1, TypedContract as AbiWanTypedContractV1 } from 'abi-wan-kanabi-v1';
 import type { Abi as AbiKanabiV2, TypedContract as AbiWanTypedContractV2 } from 'abi-wan-kanabi-v2';
 
 import { AccountInterface } from '../account';
@@ -42,7 +42,8 @@ declare module 'abi-wan-kanabi-v2' {
   }
 }
 
-export type TypedContract<TAbi extends AbiKanabi> = AbiWanTypedContract<TAbi> & ContractInterface;
+export type TypedContractV1<TAbi extends AbiKanabiV1> = AbiWanTypedContractV1<TAbi> &
+  ContractInterface;
 type TypedContractV2<TAbi extends AbiKanabiV2> = AbiWanTypedContractV2<TAbi> & ContractInterface;
 
 export abstract class ContractInterface {
@@ -162,6 +163,6 @@ export abstract class ContractInterface {
    */
   public abstract getVersion(): Promise<ContractVersion>;
 
-  public abstract typed<TAbi extends AbiKanabi>(tAbi: TAbi): TypedContract<TAbi>;
+  public abstract typedv1<TAbi extends AbiKanabiV1>(tAbi: TAbi): TypedContractV1<TAbi>;
   public abstract typedv2<TAbi extends AbiKanabiV2>(tAbi: TAbi): TypedContractV2<TAbi>;
 }

--- a/www/versioned_docs/version-5.19.5/guides/automatic_cairo_ABI_parsing.md
+++ b/www/versioned_docs/version-5.19.5/guides/automatic_cairo_ABI_parsing.md
@@ -63,7 +63,7 @@ import { tAbi } from '../__mocks__/hello';
 
 let cairo1Contract = new Contract(compiledHelloSierra.abi, dd.deploy.contract_address, account);
 
-let cairo1ContractTyped = cairo1Contract.typed(tAbi);
+let cairo1ContractTyped = cairo1Contract.typedv1(tAbi); // or typedv2(tAbi) if you're using Cairo Compiler v2
 
 cairo1ContractTyped.test_bool();
 ```

--- a/www/versioned_docs/version-5.24.3/guides/automatic_cairo_ABI_parsing.md
+++ b/www/versioned_docs/version-5.24.3/guides/automatic_cairo_ABI_parsing.md
@@ -63,7 +63,7 @@ import { tAbi } from '../__mocks__/hello';
 
 let cairo1Contract = new Contract(compiledHelloSierra.abi, dd.deploy.contract_address, account);
 
-let cairo1ContractTyped = cairo1Contract.typed(tAbi);
+let cairo1ContractTyped = cairo1Contract.typedv1(tAbi); // or typedv2(tAbi) if you are using Cairo compiler v2
 
 cairo1ContractTyped.test_bool();
 ```


### PR DESCRIPTION
## Motivation and Resolution
This avoid `npx abi-wan-kanabi` to use the installed version and forces it to get the latest version from npm


### RPC version (if applicable)

...

## Usage related changes

<!-- How the changes from this PR affect users. -->

- `typed` is now renamed to `typedv1`

## Development related changes

<!-- How these changes affect the developers of this project - e.g. changes in testing or CI/CD. -->

- Change 1.
- ...

## Checklist:

- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [ ] Linked the issues which this PR resolves
- [x] Documented the changes in code (API docs will be generated automatically)
- [x] Updated the tests
- [x] All tests are passing
