### PR TITLE
docs: add migration to V6

### DIFF
--- a/www/docusaurus.config.js
+++ b/www/docusaurus.config.js
@@ -68,7 +68,7 @@ const config = {
         //... other Algolia param
       },
       announcementBar: {
-        content: `<a href="${migrationGuideLink}">Migrate from v4</a>`,
+        content: `<a href="${migrationGuideLink}">Migrate from v5</a>`,
         backgroundColor: 'rgb(230 231 232)',
       },
       navbar: {
@@ -118,7 +118,7 @@ const config = {
                 to: '/docs/guides/intro',
               },
               {
-                label: 'Migrate from v4',
+                label: 'Migrate from v5',
                 to: migrationGuideLink,
               },
             ],


### PR DESCRIPTION
## Motivation and Resolution
In the frame of Starknet.js v6 pre-release, added in the migration guide the recommendations to migrate from v5 to v6.

## Usage related changes

Changed the start page : migration guide from v5

## Development related changes
Do not forget to create a last V5 documentation variant, before the pre-release.

## Checklist:

- [x] Rebased to the last commit of the target branch (or merged it into my branch)
