### PR TITLE
fix(RpcChannel): allow client to provide `specVersion`

### DIFF
--- a/src/channel/rpc_0_6.ts
+++ b/src/channel/rpc_0_6.ts
@@ -48,12 +48,12 @@ export class RpcChannel {
 
   private chainId?: StarknetChainId;
 
-  private speckVersion?: string;
+  private specVersion?: string;
 
   readonly waitMode: Boolean; // behave like web2 rpc and return when tx is processed
 
   constructor(optionsOrProvider?: RpcProviderOptions) {
-    const { nodeUrl, retries, headers, blockIdentifier, chainId, waitMode } =
+    const { nodeUrl, retries, headers, blockIdentifier, chainId, specVersion, waitMode } =
       optionsOrProvider || {};
     if (Object.values(NetworkName).includes(nodeUrl as NetworkName)) {
       this.nodeUrl = getDefaultNodeUrl(nodeUrl as NetworkName, optionsOrProvider?.default);
@@ -66,6 +66,7 @@ export class RpcChannel {
     this.headers = { ...defaultOptions.headers, ...headers };
     this.blockIdentifier = blockIdentifier || defaultOptions.blockIdentifier;
     this.chainId = chainId;
+    this.specVersion = specVersion;
     this.waitMode = waitMode || false;
     this.requestId = 0;
   }
@@ -121,8 +122,8 @@ export class RpcChannel {
   }
 
   public async getSpecVersion() {
-    this.speckVersion ??= (await this.fetchEndpoint('starknet_specVersion')) as StarknetChainId;
-    return this.speckVersion;
+    this.specVersion ??= (await this.fetchEndpoint('starknet_specVersion')) as StarknetChainId;
+    return this.specVersion;
   }
 
   public getNonceForAddress(

--- a/src/types/provider/configuration.ts
+++ b/src/types/provider/configuration.ts
@@ -9,6 +9,7 @@ export type RpcProviderOptions = {
   headers?: object;
   blockIdentifier?: BlockIdentifier;
   chainId?: StarknetChainId;
+  specVersion?: string;
   default?: boolean;
   waitMode?: boolean;
 };


### PR DESCRIPTION

## Motivation and Resolution

This saves an extra call on RPC for optionally-known information (like the `chainId` case).
also fixed speck -> spec typo

## Checklist:

- [v ] Performed a self-review of the code
- [v ] Rebased to the last commit of the target branch (or merged it into my branch)
- [ ] Linked the issues which this PR resolves
- [ ] Documented the changes in code (API docs will be generated automatically)
- [ ] Updated the tests
- [ ] All tests are passing
