### PR TITLE
fix: byteArray encoding for less than 31 chars

### DIFF
--- a/__tests__/cairo1v2.test.ts
+++ b/__tests__/cairo1v2.test.ts
@@ -1031,7 +1031,7 @@ describe('Cairo 1', () => {
       const callD2 = CallData.compile({ mess: message });
       expect(callD2).toEqual(expectedResult);
       const callD3 = CallData.compile({ mess: byteArray.byteArrayFromString('Take care.') });
-      expect(callD3).toEqual(['1', '0', '398475857363345939260718', '10']);
+      expect(callD3).toEqual(['0', '398475857363345939260718', '10']);
       const str1 = await stringContract.get_string();
       expect(str1).toBe(
         "Cairo has become the most popular language for developers + charizards !@#$%^&*_+|:'<>?~`"

--- a/__tests__/cairo1v2_typed.test.ts
+++ b/__tests__/cairo1v2_typed.test.ts
@@ -973,7 +973,7 @@ describe('Cairo 1', () => {
       const callD2 = CallData.compile({ mess: message });
       expect(callD2).toEqual(expectedResult);
       const callD3 = CallData.compile({ mess: byteArray.byteArrayFromString('Take care.') });
-      expect(callD3).toEqual(['1', '0', '398475857363345939260718', '10']);
+      expect(callD3).toEqual(['0', '398475857363345939260718', '10']);
       const str1 = await stringContract.get_string();
       expect(str1).toBe(
         "Cairo has become the most popular language for developers + charizards !@#$%^&*_+|:'<>?~`"

--- a/__tests__/utils/shortString.test.ts
+++ b/__tests__/utils/shortString.test.ts
@@ -65,12 +65,12 @@ describe('shortString', () => {
       pending_word_len: 0,
     });
     expect(byteArray.byteArrayFromString('ABCDEFGHIJKLMNOPQRSTUVWXYZ1234')).toEqual({
-      data: ['0x00'],
+      data: [],
       pending_word: '0x4142434445464748494a4b4c4d4e4f505152535455565758595a31323334',
       pending_word_len: 30,
     });
     expect(byteArray.byteArrayFromString('')).toEqual({
-      data: ['0x00'],
+      data: [],
       pending_word: '0x00',
       pending_word_len: 0,
     });
@@ -90,14 +90,14 @@ describe('shortString', () => {
   });
   expect(
     byteArray.stringFromByteArray({
-      data: ['0x00'],
+      data: [],
       pending_word: '0x4142434445464748494a4b4c4d4e4f505152535455565758595a31323334',
       pending_word_len: 30,
     })
   ).toBe('ABCDEFGHIJKLMNOPQRSTUVWXYZ1234');
   expect(
     byteArray.stringFromByteArray({
-      data: ['0x00'],
+      data: [],
       pending_word: '0x00',
       pending_word_len: 0,
     })

--- a/src/utils/calldata/byteArray.ts
+++ b/src/utils/calldata/byteArray.ts
@@ -9,7 +9,7 @@ import { decodeShortString, encodeShortString, splitLongString } from '../shortS
  * @example
  * ```typescript
  * const myByteArray = {
- *    data: [ '0x00' ],
+ *    data: [],
  *    pending_word: '0x414243444546474849',
  *    pending_word_len: 9
  * }
@@ -40,7 +40,7 @@ export function stringFromByteArray(myByteArray: ByteArray): string {
  * ```
  * Result is :
  * {
- *    data: [ '0x00' ],
+ *    data: [],
  *    pending_word: '0x414243444546474849',
  *    pending_word_len: 9
  * }
@@ -48,7 +48,7 @@ export function stringFromByteArray(myByteArray: ByteArray): string {
 export function byteArrayFromString(myString: string): ByteArray {
   if (myString.length === 0) {
     return {
-      data: ['0x00'],
+      data: [],
       pending_word: '0x00',
       pending_word_len: 0,
     } as ByteArray;
@@ -67,7 +67,7 @@ export function byteArrayFromString(myString: string): ByteArray {
   }
   const pendingEncodedWord: BigNumberish = myShortStringsEncoded.pop()!;
   return {
-    data: myShortStringsEncoded.length === 0 ? ['0x00'] : myShortStringsEncoded,
+    data: myShortStringsEncoded.length === 0 ? [] : myShortStringsEncoded,
     pending_word: pendingEncodedWord,
     pending_word_len: remains.length,
   } as ByteArray;

--- a/src/utils/calldata/byteArray.ts
+++ b/src/utils/calldata/byteArray.ts
@@ -36,7 +36,7 @@ export function stringFromByteArray(myByteArray: ByteArray): string {
  * @returns Cairo representation of a LongString
  * @example
  * ```typescript
- * const myByteArray: ByteArray = byteArrayFromStr("ABCDEFGHI");
+ * const myByteArray: ByteArray = byteArrayFromString("ABCDEFGHI");
  * ```
  * Result is :
  * {
@@ -45,30 +45,19 @@ export function stringFromByteArray(myByteArray: ByteArray): string {
  *    pending_word_len: 9
  * }
  */
-export function byteArrayFromString(myString: string): ByteArray {
-  if (myString.length === 0) {
-    return {
-      data: [],
-      pending_word: '0x00',
-      pending_word_len: 0,
-    } as ByteArray;
-  }
-  const myShortStrings: string[] = splitLongString(myString);
-  const remains: string = myShortStrings[myShortStrings.length - 1];
-  const myShortStringsEncoded: BigNumberish[] = myShortStrings.map((shortStr) =>
-    encodeShortString(shortStr)
-  );
-  if (remains.length === 31) {
-    return {
-      data: myShortStringsEncoded,
-      pending_word: '0x00',
-      pending_word_len: 0,
-    } as ByteArray;
-  }
-  const pendingEncodedWord: BigNumberish = myShortStringsEncoded.pop()!;
+export function byteArrayFromString(targetString: string): ByteArray {
+  const shortStrings: string[] = splitLongString(targetString);
+  const remainder: string = shortStrings[shortStrings.length - 1];
+  const shortStringsEncoded: BigNumberish[] = shortStrings.map(encodeShortString);
+
+  const [pendingWord, pendingWordLength] =
+    remainder === undefined || remainder.length === 31
+      ? ['0x00', 0]
+      : [shortStringsEncoded.pop()!, remainder.length];
+
   return {
-    data: myShortStringsEncoded.length === 0 ? [] : myShortStringsEncoded,
-    pending_word: pendingEncodedWord,
-    pending_word_len: remains.length,
-  } as ByteArray;
+    data: shortStringsEncoded.length === 0 ? [] : shortStringsEncoded,
+    pending_word: pendingWord,
+    pending_word_len: pendingWordLength,
+  };
 }

--- a/src/utils/typedData.ts
+++ b/src/utils/typedData.ts
@@ -7,6 +7,7 @@ import {
   StarkNetType,
   TypedData,
 } from '../types';
+import { byteArrayFromString } from './calldata/byteArray';
 import {
   computePedersenHash,
   computePedersenHashOnElements,
@@ -16,7 +17,7 @@ import {
 } from './hash';
 import { MerkleTree } from './merkle';
 import { isHex, toHex } from './num';
-import { encodeShortString, splitLongString } from './shortString';
+import { encodeShortString } from './shortString';
 
 /** @deprecated prefer importing from 'types' over 'typedData' */
 export * from '../types/typedData';
@@ -60,24 +61,6 @@ const revisionConfiguration: Record<Revision, Configuration> = {
     presetTypes: {},
   },
 };
-
-// TODO: replace with utils byteArrayFromString from PR#891 once it is available
-export function byteArrayFromString(targetString: string) {
-  const shortStrings: string[] = splitLongString(targetString);
-  const remainder: string = shortStrings[shortStrings.length - 1];
-  const shortStringsEncoded: BigNumberish[] = shortStrings.map(encodeShortString);
-
-  const [pendingWord, pendingWordLength] =
-    remainder === undefined || remainder.length === 31
-      ? ['0x00', 0]
-      : [shortStringsEncoded.pop()!, remainder.length];
-
-  return {
-    data: shortStringsEncoded.length === 0 ? ['0x00'] : shortStringsEncoded,
-    pending_word: pendingWord,
-    pending_word_len: pendingWordLength,
-  };
-}
 
 function identifyRevision({ types, domain }: TypedData) {
   if (revisionConfiguration[Revision.Active].domain in types && domain.revision === Revision.Active)


### PR DESCRIPTION
## Motivation and Resolution
Solve #1003 
If a ByteArray has less than 31 characters, the data array has to be empty (was containing one "0x00" item)

## Usage related changes
N/A

## Development related changes
N/A

## Checklist:

- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Linked the issues which this PR resolves
- [x] Documented the changes in code (API docs will be generated automatically)
- [x] Updated the tests
- [x] All tests are passing
