### PR TITLE
Adjust max amount and make fee margins configurable

### DIFF
--- a/__tests__/utils/stark.test.ts
+++ b/__tests__/utils/stark.test.ts
@@ -79,9 +79,19 @@ describe('stark', () => {
       overall_fee: '1000',
       unit: 'FRI',
     };
+    const estimateFeeResponse07: FeeEstimate = {
+      ...estimateFeeResponse,
+      data_gas_consumed: '100',
+      data_gas_price: '10',
+      overall_fee: '2000',
+    };
     expect(stark.estimateFeeToBounds(estimateFeeResponse)).toStrictEqual({
       l2_gas: { max_amount: '0x0', max_price_per_unit: '0x0' },
       l1_gas: { max_amount: '0x6e', max_price_per_unit: '0xf' },
+    });
+    expect(stark.estimateFeeToBounds(estimateFeeResponse07)).toStrictEqual({
+      l2_gas: { max_amount: '0x0', max_price_per_unit: '0x0' },
+      l1_gas: { max_amount: '0xdc', max_price_per_unit: '0xf' },
     });
   });
 

--- a/__tests__/utils/stark.test.ts
+++ b/__tests__/utils/stark.test.ts
@@ -87,11 +87,11 @@ describe('stark', () => {
     };
     expect(stark.estimateFeeToBounds(estimateFeeResponse)).toStrictEqual({
       l2_gas: { max_amount: '0x0', max_price_per_unit: '0x0' },
-      l1_gas: { max_amount: '0x6e', max_price_per_unit: '0xf' },
+      l1_gas: { max_amount: '0x96', max_price_per_unit: '0xf' },
     });
     expect(stark.estimateFeeToBounds(estimateFeeResponse07)).toStrictEqual({
       l2_gas: { max_amount: '0x0', max_price_per_unit: '0x0' },
-      l1_gas: { max_amount: '0xdc', max_price_per_unit: '0xf' },
+      l1_gas: { max_amount: '0x12c', max_price_per_unit: '0xf' },
     });
   });
 

--- a/__tests__/utils/utils.test.ts
+++ b/__tests__/utils/utils.test.ts
@@ -70,11 +70,11 @@ describe('computeHashOnElements()', () => {
 });
 describe('estimatedFeeToMaxFee()', () => {
   test('should return maxFee for 0', () => {
-    const res = stark.estimatedFeeToMaxFee(0, 0.15);
+    const res = stark.estimatedFeeToMaxFee(0, 15);
     expect(res).toBe(0n);
   });
   test('should return maxFee for 10_000', () => {
-    const res = stark.estimatedFeeToMaxFee(10_000, 0.15);
+    const res = stark.estimatedFeeToMaxFee(10_000, 15);
     expect(res).toBe(11500n);
   });
 });

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -48,6 +48,12 @@ export enum TransactionHashPrefix {
   L1_HANDLER = '0x6c315f68616e646c6572', // encodeShortString('l1_handler'),
 }
 
+export const enum feeMarginPercentage {
+  L1_BOUND_MAX_AMOUNT = 50,
+  L1_BOUND_MAX_PRICE_PER_UNIT = 50,
+  MAX_FEE = 50,
+}
+
 export const UDC = {
   ADDRESS: '0x041a78e741e5af2fec34b695679bc6891742439f7afb8484ecd7766661ad02bf',
   ENTRYPOINT: 'deployContract',

--- a/src/provider/rpc.ts
+++ b/src/provider/rpc.ts
@@ -31,15 +31,17 @@ import { isSierra } from '../utils/contract';
 import { RPCResponseParser } from '../utils/responseParser/rpc';
 
 export class RpcProvider implements ProviderInterface {
-  private responseParser = new RPCResponseParser();
+  private responseParser: RPCResponseParser;
 
   public channel: RPC07.RpcChannel | RPC06.RpcChannel;
 
   constructor(optionsOrProvider?: RpcProviderOptions | ProviderInterface | RpcProvider) {
     if (optionsOrProvider && 'channel' in optionsOrProvider) {
       this.channel = optionsOrProvider.channel;
+      this.responseParser = (optionsOrProvider as any).responseParser;
     } else {
       this.channel = new RpcChannel({ ...optionsOrProvider, waitMode: false });
+      this.responseParser = new RPCResponseParser(optionsOrProvider?.feeMarginPercentage);
     }
   }
 
@@ -176,7 +178,7 @@ export class RpcProvider implements ProviderInterface {
     // can't be named simulateTransaction because of argument conflict with account
     return this.channel
       .simulateTransaction(invocations, options)
-      .then(this.responseParser.parseSimulateTransactionResponse);
+      .then((r) => this.responseParser.parseSimulateTransactionResponse(r));
   }
 
   public async waitForTransaction(txHash: BigNumberish, options?: waitForTransactionOptions) {
@@ -278,7 +280,7 @@ export class RpcProvider implements ProviderInterface {
         ],
         { blockIdentifier, skipValidate }
       )
-      .then(this.responseParser.parseFeeEstimateResponse);
+      .then((r) => this.responseParser.parseFeeEstimateResponse(r));
   }
 
   public async getDeclareEstimateFee(
@@ -298,7 +300,7 @@ export class RpcProvider implements ProviderInterface {
         ],
         { blockIdentifier, skipValidate }
       )
-      .then(this.responseParser.parseFeeEstimateResponse);
+      .then((r) => this.responseParser.parseFeeEstimateResponse(r));
   }
 
   public async getDeployAccountEstimateFee(
@@ -318,7 +320,7 @@ export class RpcProvider implements ProviderInterface {
         ],
         { blockIdentifier, skipValidate }
       )
-      .then(this.responseParser.parseFeeEstimateResponse);
+      .then((r) => this.responseParser.parseFeeEstimateResponse(r));
   }
 
   public async getEstimateFeeBulk(
@@ -327,7 +329,7 @@ export class RpcProvider implements ProviderInterface {
   ) {
     return this.channel
       .getEstimateFee(invocations, options)
-      .then(this.responseParser.parseFeeEstimateBulkResponse);
+      .then((r) => this.responseParser.parseFeeEstimateBulkResponse(r));
   }
 
   public async invokeFunction(

--- a/src/types/provider/configuration.ts
+++ b/src/types/provider/configuration.ts
@@ -12,4 +12,9 @@ export type RpcProviderOptions = {
   specVersion?: string;
   default?: boolean;
   waitMode?: boolean;
+  feeMarginPercentage?: {
+    l1BoundMaxAmount: number;
+    l1BoundMaxPricePerUnit: number;
+    maxFee: number;
+  };
 };

--- a/src/utils/stark.ts
+++ b/src/utils/stark.ts
@@ -114,7 +114,11 @@ export function estimateFeeToBounds(
   if (typeof estimate.gas_consumed === 'undefined' || typeof estimate.gas_price === 'undefined') {
     throw Error('estimateFeeToBounds: estimate is undefined');
   }
-  const maxUnits = toHex(addPercent(estimate.gas_consumed, amountOverhead));
+
+  const maxUnits =
+    estimate.data_gas_consumed !== undefined && estimate.data_gas_price !== undefined // RPC v0.7
+      ? toHex(addPercent(BigInt(estimate.overall_fee) / BigInt(estimate.gas_price), amountOverhead))
+      : toHex(addPercent(estimate.gas_consumed, amountOverhead));
   const maxUnitPrice = toHex(addPercent(estimate.gas_price, priceOverhead));
   return {
     l2_gas: { max_amount: '0x0', max_price_per_unit: '0x0' },

--- a/src/utils/stark.ts
+++ b/src/utils/stark.ts
@@ -1,7 +1,7 @@
 import { getStarkKey, utils } from '@scure/starknet';
 import { gzip, ungzip } from 'pako';
 
-import { ZERO } from '../constants';
+import { ZERO, feeMarginPercentage } from '../constants';
 import {
   ArraySignatureType,
   BigNumberish,
@@ -95,14 +95,17 @@ export function signatureToHexArray(sig?: Signature): ArraySignatureType {
 /**
  * Convert estimated fee to max fee with overhead
  */
-export function estimatedFeeToMaxFee(estimatedFee: BigNumberish, overhead: number = 0.5): bigint {
-  return addPercent(estimatedFee, overhead * 100);
+export function estimatedFeeToMaxFee(
+  estimatedFee: BigNumberish,
+  overhead: number = feeMarginPercentage.MAX_FEE
+): bigint {
+  return addPercent(estimatedFee, overhead);
 }
 
 export function estimateFeeToBounds(
   estimate: FeeEstimate | 0n,
-  amountOverhead: number = 10,
-  priceOverhead = 50
+  amountOverhead: number = feeMarginPercentage.L1_BOUND_MAX_AMOUNT,
+  priceOverhead: number = feeMarginPercentage.L1_BOUND_MAX_PRICE_PER_UNIT
 ): ResourceBounds {
   if (typeof estimate === 'bigint') {
     return {


### PR DESCRIPTION
## Motivation and Resolution

The PR alters the resource bound max amount calculation in line with the recommendation from the Starknet v0.13.1 pre-release notes. It also makes the fee margins configurable at Provider/Account class initialization.

## Usage related changes

<!-- How the changes from this PR affect users. -->

- The max amount bound calculation is modified
- Users can fine-tune fee margins through the `ProviderOptions` constructor parameter
- The `overhead` parameter of the `estimatedFeeToMaxFee` utility function is changed from using a decimal notation to using a percentage notation (e.g. 0.2 to 20) to be in line with the `estimateFeeToBounds` function


## Checklist:

- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [ ] Linked the issues which this PR resolves
- [ ] Documented the changes in code (API docs will be generated automatically)
- [x] Updated the tests
- [x] All tests are passing
