### PR TITLE
fix: repair i128 typed data encoding and add typed data range checks

### DIFF
--- a/__mocks__/typedData/example_baseTypes.json
+++ b/__mocks__/typedData/example_baseTypes.json
@@ -12,10 +12,11 @@
       { "name": "n2", "type": "string" },
       { "name": "n3", "type": "selector" },
       { "name": "n4", "type": "u128" },
-      { "name": "n5", "type": "ContractAddress" },
-      { "name": "n6", "type": "ClassHash" },
-      { "name": "n7", "type": "timestamp" },
-      { "name": "n8", "type": "shortstring" }
+      { "name": "n5", "type": "i128" },
+      { "name": "n6", "type": "ContractAddress" },
+      { "name": "n7", "type": "ClassHash" },
+      { "name": "n8", "type": "timestamp" },
+      { "name": "n9", "type": "shortstring" }
     ]
   },
   "primaryType": "Example",
@@ -30,10 +31,11 @@
     "n1": true,
     "n2": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
     "n3": "transfer",
-    "n4": "0x3e8",
-    "n5": "0x3e8",
+    "n4": 10,
+    "n5": -10,
     "n6": "0x3e8",
-    "n7": 1000,
-    "n8": "transfer"
+    "n7": "0x3e8",
+    "n8": 1000,
+    "n9": "transfer"
   }
 }

--- a/__tests__/utils/typedData.test.ts
+++ b/__tests__/utils/typedData.test.ts
@@ -6,7 +6,7 @@ import exampleEnum from '../../__mocks__/typedData/example_enum.json';
 import examplePresetTypes from '../../__mocks__/typedData/example_presetTypes.json';
 import typedDataStructArrayExample from '../../__mocks__/typedData/mail_StructArray.json';
 import typedDataSessionExample from '../../__mocks__/typedData/session_MerkleTree.json';
-import { BigNumberish, StarkNetDomain, num } from '../../src';
+import { BigNumberish, StarknetDomain, num } from '../../src';
 import { PRIME } from '../../src/constants';
 import { getSelectorFromName } from '../../src/utils/hash';
 import { MerkleTree } from '../../src/utils/merkle';
@@ -170,7 +170,7 @@ describe('typedData', () => {
     const hash = getStructHash(
       typedDataExample.types,
       'StarkNetDomain',
-      typedDataExample.domain as StarkNetDomain
+      typedDataExample.domain as StarknetDomain
     );
     expect(hash).toMatchInlineSnapshot(
       `"0x54833b121883a3e3aebff48ec08a962f5742e5f7b973469c1f8f4f55d470b07"`
@@ -181,7 +181,7 @@ describe('typedData', () => {
     const hash = getStructHash(
       exampleBaseTypes.types,
       'StarknetDomain',
-      exampleBaseTypes.domain as StarkNetDomain,
+      exampleBaseTypes.domain as StarknetDomain,
       TypedDataRevision.Active
     );
     expect(hash).toMatchInlineSnapshot(

--- a/__tests__/utils/typedData.test.ts
+++ b/__tests__/utils/typedData.test.ts
@@ -7,6 +7,7 @@ import examplePresetTypes from '../../__mocks__/typedData/example_presetTypes.js
 import typedDataStructArrayExample from '../../__mocks__/typedData/mail_StructArray.json';
 import typedDataSessionExample from '../../__mocks__/typedData/session_MerkleTree.json';
 import { BigNumberish, StarkNetDomain, num } from '../../src';
+import { PRIME } from '../../src/constants';
 import { getSelectorFromName } from '../../src/utils/hash';
 import { MerkleTree } from '../../src/utils/merkle';
 import {
@@ -43,7 +44,7 @@ describe('typedData', () => {
     );
     encoded = encodeType(exampleBaseTypes.types, 'Example', TypedDataRevision.Active);
     expect(encoded).toMatchInlineSnapshot(
-      `"\\"Example\\"(\\"n0\\":\\"felt\\",\\"n1\\":\\"bool\\",\\"n2\\":\\"string\\",\\"n3\\":\\"selector\\",\\"n4\\":\\"u128\\",\\"n5\\":\\"ContractAddress\\",\\"n6\\":\\"ClassHash\\",\\"n7\\":\\"timestamp\\",\\"n8\\":\\"shortstring\\")"`
+      `"\\"Example\\"(\\"n0\\":\\"felt\\",\\"n1\\":\\"bool\\",\\"n2\\":\\"string\\",\\"n3\\":\\"selector\\",\\"n4\\":\\"u128\\",\\"n5\\":\\"i128\\",\\"n6\\":\\"ContractAddress\\",\\"n7\\":\\"ClassHash\\",\\"n8\\":\\"timestamp\\",\\"n9\\":\\"shortstring\\")"`
     );
     encoded = encodeType(examplePresetTypes.types, 'Example', TypedDataRevision.Active);
     expect(encoded).toMatchInlineSnapshot(
@@ -83,7 +84,7 @@ describe('typedData', () => {
     );
     typeHash = getTypeHash(exampleBaseTypes.types, 'Example', TypedDataRevision.Active);
     expect(typeHash).toMatchInlineSnapshot(
-      `"0x2e5b7e12ca4388c49b4ceb305d853b8f7bf5f36525fea5e4255346b80153249"`
+      `"0x1f94cd0be8b4097a41486170fdf09a4cd23aefbc74bb2344718562994c2c111"`
     );
     typeHash = getTypeHash(examplePresetTypes.types, 'Example', TypedDataRevision.Active);
     expect(typeHash).toMatchInlineSnapshot(
@@ -274,7 +275,7 @@ describe('typedData', () => {
     let messageHash: string;
     messageHash = getMessageHash(exampleBaseTypes, exampleAddress);
     expect(messageHash).toMatchInlineSnapshot(
-      `"0x790d9fa99cf9ad91c515aaff9465fcb1c87784d9cfb27271ed193675cd06f9c"`
+      `"0xdb7829db8909c0c5496f5952bcfc4fc894341ce01842537fc4f448743480b6"`
     );
 
     messageHash = getMessageHash(examplePresetTypes, exampleAddress);
@@ -291,5 +292,27 @@ describe('typedData', () => {
     expect(spyPoseidon).toHaveBeenCalled();
     spyPedersen.mockRestore();
     spyPoseidon.mockRestore();
+  });
+
+  describe('should fail validation', () => {
+    const baseTypes = (type: string, value: any = PRIME) => {
+      const copy = JSON.parse(JSON.stringify(exampleBaseTypes)) as typeof exampleBaseTypes;
+      const property = copy.types.Example.find((e) => e.type === type)!.name;
+      (copy.message as any)[property] = value;
+      return copy;
+    };
+
+    test.each([
+      { type: 'felt' },
+      { type: 'bool' },
+      { type: 'u128' },
+      { type: 'i128' },
+      { type: 'ContractAddress' },
+      { type: 'ClassHash' },
+      { type: 'timestamp' },
+      { type: 'shortstring' },
+    ])('out of bounds - $type', ({ type }) => {
+      expect(() => getMessageHash(baseTypes(type), exampleAddress)).toThrow(RegExp(type));
+    });
   });
 });

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -17,10 +17,16 @@ export { ETransactionVersion as TRANSACTION_VERSION };
 export const ZERO = 0n;
 export const MASK_250 = 2n ** 250n - 1n; // 2 ** 250 - 1
 export const API_VERSION = ZERO;
+export const PRIME = 2n ** 251n + 17n * 2n ** 192n + 1n;
 
 // based on: https://github.com/starkware-libs/cairo-lang/blob/v0.12.3/src/starkware/starknet/common/storage.cairo#L3
 export const MAX_STORAGE_ITEM_SIZE = 256n;
 export const ADDR_BOUND = 2n ** 251n - MAX_STORAGE_ITEM_SIZE;
+
+const range = (min: bigint, max: bigint) => ({ min, max }) as const;
+export const RANGE_FELT = range(ZERO, PRIME - 1n);
+export const RANGE_I128 = range(-(2n ** 127n), 2n ** 127n - 1n);
+export const RANGE_U128 = range(ZERO, 2n ** 128n - 1n);
 
 export enum BaseUrl {
   SN_MAIN = 'https://alpha-mainnet.starknet.io',

--- a/src/types/api/rpcspec_0_6/methods.ts
+++ b/src/types/api/rpcspec_0_6/methods.ts
@@ -162,7 +162,7 @@ type ReadMethods = {
     errors: Errors.BLOCK_NOT_FOUND;
   };
 
-  // Call a StarkNet function without creating a StarkNet transaction
+  // Call a Starknet function without creating a Starknet transaction
   starknet_call: {
     params: {
       request: FUNCTION_CALL;
@@ -172,7 +172,7 @@ type ReadMethods = {
     errors: Errors.CONTRACT_NOT_FOUND | Errors.CONTRACT_ERROR | Errors.BLOCK_NOT_FOUND;
   };
 
-  // Estimate the fee for StarkNet transactions
+  // Estimate the fee for Starknet transactions
   starknet_estimateFee: {
     params: {
       request: BROADCASTED_TXN[];
@@ -207,7 +207,7 @@ type ReadMethods = {
     errors: Errors.NO_BLOCKS;
   };
 
-  // Return the currently configured StarkNet chain id
+  // Return the currently configured Starknet chain id
   starknet_chainId: {
     params: [];
     result: CHAIN_ID;

--- a/src/types/api/rpcspec_0_7/methods.ts
+++ b/src/types/api/rpcspec_0_7/methods.ts
@@ -172,7 +172,7 @@ type ReadMethods = {
     errors: Errors.BLOCK_NOT_FOUND;
   };
 
-  // Call a StarkNet function without creating a StarkNet transaction
+  // Call a Starknet function without creating a Starknet transaction
   starknet_call: {
     params: {
       request: FUNCTION_CALL;
@@ -182,7 +182,7 @@ type ReadMethods = {
     errors: Errors.CONTRACT_NOT_FOUND | Errors.CONTRACT_ERROR | Errors.BLOCK_NOT_FOUND;
   };
 
-  // Estimate the fee for StarkNet transactions
+  // Estimate the fee for Starknet transactions
   starknet_estimateFee: {
     params: {
       request: BROADCASTED_TXN[];
@@ -217,7 +217,7 @@ type ReadMethods = {
     errors: Errors.NO_BLOCKS;
   };
 
-  // Return the currently configured StarkNet chain id
+  // Return the currently configured Starknet chain id
   starknet_chainId: {
     params: [];
     result: CHAIN_ID;

--- a/src/types/typedData.ts
+++ b/src/types/typedData.ts
@@ -1,17 +1,15 @@
-// TODO: adjust starknet casing in v6
-
 export enum TypedDataRevision {
   Active = '1',
   Legacy = '0',
 }
 
-export type StarkNetEnumType = {
+export type StarknetEnumType = {
   name: string;
   type: 'enum';
   contains: string;
 };
 
-export type StarkNetMerkleType = {
+export type StarknetMerkleType = {
   name: string;
   type: 'merkletree';
   contains: string;
@@ -23,18 +21,18 @@ export type StarkNetMerkleType = {
  * Note that the `uint` and `int` aliases like in Solidity, and fixed point numbers are not supported by the EIP-712
  * standard.
  */
-export type StarkNetType =
+export type StarknetType =
   | {
       name: string;
       type: string;
     }
-  | StarkNetEnumType
-  | StarkNetMerkleType;
+  | StarknetEnumType
+  | StarknetMerkleType;
 
 /**
  * The EIP712 domain struct. Any of these fields are optional, but it must contain at least one field.
  */
-export interface StarkNetDomain extends Record<string, unknown> {
+export interface StarknetDomain extends Record<string, unknown> {
   name?: string;
   version?: string;
   chainId?: string | number;
@@ -45,8 +43,8 @@ export interface StarkNetDomain extends Record<string, unknown> {
  * The complete typed data, with all the structs, domain data, primary type of the message, and the message itself.
  */
 export interface TypedData {
-  types: Record<string, StarkNetType[]>;
+  types: Record<string, StarknetType[]>;
   primaryType: string;
-  domain: StarkNetDomain;
+  domain: StarknetDomain;
   message: Record<string, unknown>;
 }

--- a/src/utils/typedData.ts
+++ b/src/utils/typedData.ts
@@ -3,9 +3,9 @@ import { PRIME, RANGE_FELT, RANGE_I128, RANGE_U128 } from '../constants';
 import {
   BigNumberish,
   TypedDataRevision as Revision,
-  StarkNetEnumType,
-  StarkNetMerkleType,
-  StarkNetType,
+  StarknetEnumType,
+  StarknetMerkleType,
+  StarknetType,
   TypedData,
 } from '../types';
 import assert from './assert';
@@ -107,7 +107,7 @@ export function prepareSelector(selector: string): string {
   return isHex(selector) ? selector : getSelectorFromName(selector);
 }
 
-export function isMerkleTreeType(type: StarkNetType): type is StarkNetMerkleType {
+export function isMerkleTreeType(type: StarknetType): type is StarknetMerkleType {
   return type.type === 'merkletree';
 }
 
@@ -142,7 +142,7 @@ export function getDependencies(
 
   return [
     type,
-    ...(types[type] as StarkNetEnumType[]).reduce<string[]>(
+    ...(types[type] as StarknetEnumType[]).reduce<string[]>(
       (previous, t) => [
         ...previous,
         ...getDependencies(types, t.type, previous, t.contains, revision).filter(
@@ -198,7 +198,7 @@ export function encodeType(
       const dependencyElements = allTypes[dependency].map((t) => {
         const targetType =
           t.type === 'enum' && revision === Revision.Active
-            ? (t as StarkNetEnumType).contains
+            ? (t as StarknetEnumType).contains
             : t.type;
         // parentheses handling for enum variant types
         const typeString = targetType.match(/^\(.*\)$/)
@@ -265,9 +265,9 @@ export function encodeValue(
       if (revision === Revision.Active) {
         const [variantKey, variantData] = Object.entries(data as TypedData['message'])[0];
 
-        const parentType = types[ctx.parent as string][0] as StarkNetEnumType;
+        const parentType = types[ctx.parent as string][0] as StarknetEnumType;
         const enumType = types[parentType.contains];
-        const variantType = enumType.find((t) => t.name === variantKey) as StarkNetType;
+        const variantType = enumType.find((t) => t.name === variantKey) as StarknetType;
         const variantIndex = enumType.indexOf(variantType);
 
         const encodedSubtypes = variantType.type


### PR DESCRIPTION
## Motivation and Resolution

Resolves #1002 (i128 typed data encoding). Also adds typed data range checks for primitive types and a "StarkNet" casing update for typed data types.

## Usage related changes

The encoding changes should not affect users that use valid data, if the data is outside the permitted range it will generate errors with the code from this PR. If users are using some of the updated types they will need to update them to their new name.

## Checklist:

- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Linked the issues which this PR resolves
- [ ] Documented the changes in code (API docs will be generated automatically)
- [x] Updated the tests
- [x] All tests are passing
