### PR TITLE
simplify extends for the account class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# [6.5.0](https://github.com/starknet-io/starknet.js/compare/v6.4.2...v6.5.0) (2024-03-14)
+
+### Bug Fixes
+
+- adjust max amount bound calculation for RPC v0.7.0 ([dd34cdb](https://github.com/starknet-io/starknet.js/commit/dd34cdb8b9817a55a16a97d960b1544d75c0059a))
+
+### Features
+
+- make fee margins configurable ([cedd984](https://github.com/starknet-io/starknet.js/commit/cedd984e1106db5b73d17630e282eb956d344a97))
+
 ## [6.4.2](https://github.com/starknet-io/starknet.js/compare/v6.4.1...v6.4.2) (2024-03-14)
 
 ### Bug Fixes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,8 @@ Or run tests in watch mode:
 npm test --watch
 ```
 
-By default the tests are executed in your local Devnet. If you want to use a specific rpc node, you have to set some global variables before executing the tests :
+By default the tests are executed in your local Devnet. If you want to use a specific
+RPC node, you have to set some global variables before executing the tests:
 
 ```bash
 export TEST_RPC_URL=http://192.168.1.44:9545/rpc/v0.5 # example of a Pathfinder node located in your local network
@@ -42,6 +43,16 @@ export TEST_RPC_URL=https://starknet-testnet.public.blastapi.io/rpc/v0.5 # examp
 export TEST_ACCOUNT_ADDRESS=0x065A822f0000000000000000000000000c26641
 export TEST_ACCOUNT_PRIVATE_KEY=0x02a80000000000000000000000001754438a
 ```
+
+The global variables above will only be valid for some of the tests.
+The recommended and more straightforward approach is to go with the docker.
+You just need to do the following steps:
+
+- Install [Docker](https://docs.docker.com/engine/install/) (it can also be installed via a package manager, e.g. `brew` for Mac)
+- Run `Docker` on your machine (open the application).
+- Go to the [starknet-devnet-rs](https://hub.docker.com/r/shardlabs/starknet-devnet-rs/tags) and copy the `docker pull` command from the latest tag
+- Run `docker pull shardlabs/starknet-devnet-rs:latest` in your terminal
+- Run tests locally with `npm run test`
 
 **Don’t forget to add tests and [update documentation](./www/README.md) for your changes.**
 Documentation can be archived by using JSDoc.

--- a/__tests__/config/constants.ts
+++ b/__tests__/config/constants.ts
@@ -1,0 +1,2 @@
+/* Default test config based on run `starknet-devnet --seed 0` */
+export const GS_DEFAULT_TEST_PROVIDER_URL = 'http://127.0.0.1:5050/';

--- a/__tests__/config/helpers/env.ts
+++ b/__tests__/config/helpers/env.ts
@@ -1,0 +1,4 @@
+export const setIfNullish = (envName: string, value?: boolean) => {
+  const stringifiedBooleanValue = value ? 'true' : 'false';
+  process.env[envName] ??= stringifiedBooleanValue;
+};

--- a/__tests__/config/helpers/localDevnetDetector.ts
+++ b/__tests__/config/helpers/localDevnetDetector.ts
@@ -1,0 +1,73 @@
+/* eslint-disable no-console */
+import { GS_DEFAULT_TEST_PROVIDER_URL } from '../constants';
+import { setIfNullish } from './env';
+
+export type DevnetStrategy = Record<'isDevnet' | 'isRS', boolean>;
+
+const LOCAL_DEVNET_NOT_RUNNING_MESSAGE = `
+Local devnet is not running. In order to properly run it you need to do the following: \n
+  - Go to the: https://hub.docker.com/r/shardlabs/starknet-devnet-rs/tags
+  - Find the latest tag and copy the "docker pull" command
+  - Run Docker on your machine
+  - Run the command: "docker pull shardlabs/starknet-devnet-rs:latest"
+`;
+
+class LocalDevnetDetector {
+  private strategy: DevnetStrategy = { isDevnet: false, isRS: false };
+
+  get isDevnet() {
+    return this.strategy.isDevnet;
+  }
+
+  get isRS() {
+    return this.strategy.isRS;
+  }
+
+  private setup() {
+    setIfNullish('IS_LOCALHOST_DEVNET', this.isDevnet);
+    setIfNullish('IS_RPC_DEVNET', this.isDevnet && (this.isRS || !!process.env.TEST_RPC_URL));
+    setIfNullish('IS_SEQUENCER_DEVNET', this.isDevnet && process.env.IS_RPC_DEVNET === 'false');
+    return this.strategy;
+  }
+
+  private async isLocalDevnet(): Promise<boolean> {
+    // if is_alive work it is local devnet
+    const devnetResult = await fetch(`${GS_DEFAULT_TEST_PROVIDER_URL}is_alive`)
+      .then((res) => res.text())
+      .catch(() => null);
+
+    return devnetResult === 'Alive!!!';
+  }
+
+  private async isRsDevnet(): Promise<boolean> {
+    const response = await fetch(GS_DEFAULT_TEST_PROVIDER_URL, {
+      method: 'POST',
+      headers: { Accept: 'application/json', 'Content-Type': 'application/json' },
+      body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'starknet_syncing' }),
+    });
+    const { jsonrpc } = await response.json();
+    return jsonrpc === '2.0';
+  }
+
+  async execute() {
+    this.strategy.isDevnet = await this.isLocalDevnet();
+
+    if (!this.strategy.isDevnet) {
+      console.log('\x1b[36m%s\x1b[0m', LOCAL_DEVNET_NOT_RUNNING_MESSAGE);
+      this.setup();
+      throw new Error('Local devnet is not Running. Please follow the devnet setup instructions.');
+    }
+
+    // if on base url RPC endpoint work it is devnet-rs else it devnet-py
+    try {
+      this.strategy.isRS = await this.isRsDevnet();
+      if (this.isRS) console.log('Detected Devnet-RS');
+    } catch (error) {
+      return this.setup();
+    }
+
+    return this.setup();
+  }
+}
+
+export default new LocalDevnetDetector();

--- a/__tests__/utils/stark.test.ts
+++ b/__tests__/utils/stark.test.ts
@@ -79,9 +79,19 @@ describe('stark', () => {
       overall_fee: '1000',
       unit: 'FRI',
     };
+    const estimateFeeResponse07: FeeEstimate = {
+      ...estimateFeeResponse,
+      data_gas_consumed: '100',
+      data_gas_price: '10',
+      overall_fee: '2000',
+    };
     expect(stark.estimateFeeToBounds(estimateFeeResponse)).toStrictEqual({
       l2_gas: { max_amount: '0x0', max_price_per_unit: '0x0' },
       l1_gas: { max_amount: '0x6e', max_price_per_unit: '0xf' },
+    });
+    expect(stark.estimateFeeToBounds(estimateFeeResponse07)).toStrictEqual({
+      l2_gas: { max_amount: '0x0', max_price_per_unit: '0x0' },
+      l1_gas: { max_amount: '0xdc', max_price_per_unit: '0xf' },
     });
   });
 

--- a/__tests__/utils/stark.test.ts
+++ b/__tests__/utils/stark.test.ts
@@ -87,11 +87,11 @@ describe('stark', () => {
     };
     expect(stark.estimateFeeToBounds(estimateFeeResponse)).toStrictEqual({
       l2_gas: { max_amount: '0x0', max_price_per_unit: '0x0' },
-      l1_gas: { max_amount: '0x6e', max_price_per_unit: '0xf' },
+      l1_gas: { max_amount: '0x96', max_price_per_unit: '0xf' },
     });
     expect(stark.estimateFeeToBounds(estimateFeeResponse07)).toStrictEqual({
       l2_gas: { max_amount: '0x0', max_price_per_unit: '0x0' },
-      l1_gas: { max_amount: '0xdc', max_price_per_unit: '0xf' },
+      l1_gas: { max_amount: '0x12c', max_price_per_unit: '0xf' },
     });
   });
 

--- a/__tests__/utils/utils.test.ts
+++ b/__tests__/utils/utils.test.ts
@@ -70,11 +70,11 @@ describe('computeHashOnElements()', () => {
 });
 describe('estimatedFeeToMaxFee()', () => {
   test('should return maxFee for 0', () => {
-    const res = stark.estimatedFeeToMaxFee(0, 0.15);
+    const res = stark.estimatedFeeToMaxFee(0, 15);
     expect(res).toBe(0n);
   });
   test('should return maxFee for 10_000', () => {
-    const res = stark.estimatedFeeToMaxFee(10_000, 0.15);
+    const res = stark.estimatedFeeToMaxFee(10_000, 15);
     expect(res).toBe(11500n);
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "starknet",
-  "version": "6.4.2",
+  "version": "6.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "starknet",
-      "version": "6.4.2",
+      "version": "6.5.0",
       "license": "MIT",
       "dependencies": {
         "@noble/curves": "~1.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "starknet",
-  "version": "6.4.2",
+  "version": "6.5.0",
   "description": "JavaScript library for Starknet",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/src/account/default.ts
+++ b/src/account/default.ts
@@ -89,7 +89,7 @@ export class Account extends Provider implements AccountInterface {
   }
 
   // provided version or contract based preferred transactionVersion
-  private getPreferredVersion(type12: ETransactionVersion, type3: ETransactionVersion) {
+  protected getPreferredVersion(type12: ETransactionVersion, type3: ETransactionVersion) {
     if (this.transactionVersion === ETransactionVersion.V3) return type3;
     if (this.transactionVersion === ETransactionVersion.V2) return type12;
 
@@ -100,7 +100,7 @@ export class Account extends Provider implements AccountInterface {
     return super.getNonceForAddress(this.address, blockIdentifier);
   }
 
-  private async getNonceSafe(nonce?: BigNumberish) {
+  protected async getNonceSafe(nonce?: BigNumberish) {
     // Patch DEPLOY_ACCOUNT: RPC getNonce for non-existing address will result in error, on Sequencer it is '0x0'
     try {
       return toBigInt(nonce ?? (await this.getNonce()));
@@ -600,7 +600,7 @@ export class Account extends Provider implements AccountInterface {
    * Support methods
    */
 
-  private async getUniversalSuggestedFee(
+  protected async getUniversalSuggestedFee(
     version: ETransactionVersion,
     { type, payload }: EstimateFeeAction,
     details: UniversalDetails

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -48,6 +48,12 @@ export enum TransactionHashPrefix {
   L1_HANDLER = '0x6c315f68616e646c6572', // encodeShortString('l1_handler'),
 }
 
+export const enum feeMarginPercentage {
+  L1_BOUND_MAX_AMOUNT = 50,
+  L1_BOUND_MAX_PRICE_PER_UNIT = 50,
+  MAX_FEE = 50,
+}
+
 export const UDC = {
   ADDRESS: '0x041a78e741e5af2fec34b695679bc6891742439f7afb8484ecd7766661ad02bf',
   ENTRYPOINT: 'deployContract',

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -59,7 +59,7 @@ export const UDC = {
   ENTRYPOINT: 'deployContract',
 };
 
-export const RPC_DEFAULT_VERSION = 'v0_6';
+export const RPC_DEFAULT_VERSION = 'v0_7';
 
 export const RPC_NODES = {
   SN_GOERLI: [

--- a/src/provider/rpc.ts
+++ b/src/provider/rpc.ts
@@ -31,15 +31,17 @@ import { isSierra } from '../utils/contract';
 import { RPCResponseParser } from '../utils/responseParser/rpc';
 
 export class RpcProvider implements ProviderInterface {
-  private responseParser = new RPCResponseParser();
+  private responseParser: RPCResponseParser;
 
   public channel: RPC07.RpcChannel | RPC06.RpcChannel;
 
   constructor(optionsOrProvider?: RpcProviderOptions | ProviderInterface | RpcProvider) {
     if (optionsOrProvider && 'channel' in optionsOrProvider) {
       this.channel = optionsOrProvider.channel;
+      this.responseParser = (optionsOrProvider as any).responseParser;
     } else {
       this.channel = new RpcChannel({ ...optionsOrProvider, waitMode: false });
+      this.responseParser = new RPCResponseParser(optionsOrProvider?.feeMarginPercentage);
     }
   }
 
@@ -176,7 +178,7 @@ export class RpcProvider implements ProviderInterface {
     // can't be named simulateTransaction because of argument conflict with account
     return this.channel
       .simulateTransaction(invocations, options)
-      .then(this.responseParser.parseSimulateTransactionResponse);
+      .then((r) => this.responseParser.parseSimulateTransactionResponse(r));
   }
 
   public async waitForTransaction(txHash: BigNumberish, options?: waitForTransactionOptions) {
@@ -278,7 +280,7 @@ export class RpcProvider implements ProviderInterface {
         ],
         { blockIdentifier, skipValidate }
       )
-      .then(this.responseParser.parseFeeEstimateResponse);
+      .then((r) => this.responseParser.parseFeeEstimateResponse(r));
   }
 
   public async getDeclareEstimateFee(
@@ -298,7 +300,7 @@ export class RpcProvider implements ProviderInterface {
         ],
         { blockIdentifier, skipValidate }
       )
-      .then(this.responseParser.parseFeeEstimateResponse);
+      .then((r) => this.responseParser.parseFeeEstimateResponse(r));
   }
 
   public async getDeployAccountEstimateFee(
@@ -318,7 +320,7 @@ export class RpcProvider implements ProviderInterface {
         ],
         { blockIdentifier, skipValidate }
       )
-      .then(this.responseParser.parseFeeEstimateResponse);
+      .then((r) => this.responseParser.parseFeeEstimateResponse(r));
   }
 
   public async getEstimateFeeBulk(
@@ -327,7 +329,7 @@ export class RpcProvider implements ProviderInterface {
   ) {
     return this.channel
       .getEstimateFee(invocations, options)
-      .then(this.responseParser.parseFeeEstimateBulkResponse);
+      .then((r) => this.responseParser.parseFeeEstimateBulkResponse(r));
   }
 
   public async invokeFunction(

--- a/src/types/provider/configuration.ts
+++ b/src/types/provider/configuration.ts
@@ -12,4 +12,9 @@ export type RpcProviderOptions = {
   specVersion?: string;
   default?: boolean;
   waitMode?: boolean;
+  feeMarginPercentage?: {
+    l1BoundMaxAmount: number;
+    l1BoundMaxPricePerUnit: number;
+    maxFee: number;
+  };
 };

--- a/src/utils/stark.ts
+++ b/src/utils/stark.ts
@@ -114,7 +114,11 @@ export function estimateFeeToBounds(
   if (typeof estimate.gas_consumed === 'undefined' || typeof estimate.gas_price === 'undefined') {
     throw Error('estimateFeeToBounds: estimate is undefined');
   }
-  const maxUnits = toHex(addPercent(estimate.gas_consumed, amountOverhead));
+
+  const maxUnits =
+    estimate.data_gas_consumed !== undefined && estimate.data_gas_price !== undefined // RPC v0.7
+      ? toHex(addPercent(BigInt(estimate.overall_fee) / BigInt(estimate.gas_price), amountOverhead))
+      : toHex(addPercent(estimate.gas_consumed, amountOverhead));
   const maxUnitPrice = toHex(addPercent(estimate.gas_price, priceOverhead));
   return {
     l2_gas: { max_amount: '0x0', max_price_per_unit: '0x0' },

--- a/src/utils/stark.ts
+++ b/src/utils/stark.ts
@@ -1,7 +1,7 @@
 import { getStarkKey, utils } from '@scure/starknet';
 import { gzip, ungzip } from 'pako';
 
-import { ZERO } from '../constants';
+import { ZERO, feeMarginPercentage } from '../constants';
 import {
   ArraySignatureType,
   BigNumberish,
@@ -95,14 +95,17 @@ export function signatureToHexArray(sig?: Signature): ArraySignatureType {
 /**
  * Convert estimated fee to max fee with overhead
  */
-export function estimatedFeeToMaxFee(estimatedFee: BigNumberish, overhead: number = 0.5): bigint {
-  return addPercent(estimatedFee, overhead * 100);
+export function estimatedFeeToMaxFee(
+  estimatedFee: BigNumberish,
+  overhead: number = feeMarginPercentage.MAX_FEE
+): bigint {
+  return addPercent(estimatedFee, overhead);
 }
 
 export function estimateFeeToBounds(
   estimate: FeeEstimate | 0n,
-  amountOverhead: number = 10,
-  priceOverhead = 50
+  amountOverhead: number = feeMarginPercentage.L1_BOUND_MAX_AMOUNT,
+  priceOverhead: number = feeMarginPercentage.L1_BOUND_MAX_PRICE_PER_UNIT
 ): ResourceBounds {
   if (typeof estimate === 'bigint') {
     return {

--- a/www/docs/guides/connect_network.md
+++ b/www/docs/guides/connect_network.md
@@ -16,17 +16,17 @@ Then you need to select a node. A node is a safe way to connect with the Starkne
   > Main development devnets are Starknet-devnet-rs, Madara, ...
 
 Each node is communicating with Starknet.js using a rpc specification. Most of the nodes are able to use 2 rpc spec versions.  
-For example, this node is compatible with v0.5.1 & v0.6.0, using the following entry points :
+For example, this node is compatible with v0.6.0 & v0.7.0, using the following entry points :
 
-- "https://free-rpc.nethermind.io/goerli-juno/v0_5"
 - "https://free-rpc.nethermind.io/goerli-juno/v0_6"
+- "https://free-rpc.nethermind.io/goerli-juno/v0_7"
 
 From rpc spec v0.5.0, you can request the rpc spec version that uses a node address :
 
 ```typescript
 const resp = await myProvider.getSpecVersion();
 console.log('rpc version =', resp);
-// result : rpc version = 0.6.0
+// result : rpc version = 0.7.0
 ```
 
 On Starknet.js side, you have to select the proper version, to be in accordance with the node you want to use :
@@ -35,9 +35,9 @@ On Starknet.js side, you have to select the proper version, to be in accordance 
 | :---------------------------: | ---------------------------- |
 |            v0.4.0             | Starknet.js v5.21.1          |
 |            v0.5.0             | Starknet.js v5.23.0          |
-|            v0.5.1             | Starknet.js v5.29.0 & v6.3.0 |
-|            v0.6.0             | Starknet.js v6.3.0           |
-|            v0.7.0             | Starknet.js v6.3.0           |
+|            v0.5.1             | Starknet.js v5.29.0 & v6.1.0 |
+|            v0.6.0             | Starknet.js v6.4.3           |
+|            v0.7.0             | Starknet.js v6.4.3           |
 
 [!NOTE] Each Starknet.js version 6.x.x is compatible with 3 rpc spec versions, and recognize automatically the spec version if not provided.
 
@@ -51,7 +51,7 @@ import { RpcProvider } from 'starknet';
 
 ### Default Rpc node
 
-If you don't want to use a specific node, or to handle an API key, you can use by default:
+If you don't want to use a specific node, or to handle an API key, you can use by default (using Rpc spec 0.7.0):
 
 ```typescript
 const myProvider = new RpcProvider({ nodeUrl: constants.NetworkName.SN_GOERLI });
@@ -62,7 +62,7 @@ const myProvider = new RpcProvider(); // Goerli
 
 > when using this syntax, a random public node will be selected.
 
-Using a specific nodeUrl is the better approach, as such a node will have fewer limitations and will be less crowded.
+Using a specific nodeUrl is the better approach, as such a node will have fewer limitations, the last version of software and will be less crowded.
 
 Some examples of RpcProvider instantiation to connect to RPC node providers:
 
@@ -73,39 +73,27 @@ Some examples of RpcProvider instantiation to connect to RPC node providers:
 const providerInfuraMainnet = new RpcProvider({
   nodeUrl: 'https://starknet-mainnet.infura.io/v3/' + infuraKey,
 });
-// Blast node rpc 0.5.1 & 0.6.0 for Mainnet:
+// Blast node rpc 0.7.0 for Mainnet (0.4, 0.5 & 0_6 also available):
 const providerBlastMainnet = new RpcProvider({
-  nodeUrl: 'https://starknet-mainnet.blastapi.io/' + blastKey + '/rpc/v0.5',
+  nodeUrl: 'https://starknet-mainnet.blastapi.io/' + blastKey + '/rpc/v0_7',
 });
-const providerBlastMainnet = new RpcProvider({
-  nodeUrl: 'https://starknet-mainnet.blastapi.io/' + blastKey + '/rpc/v0_6',
-});
-// Lava node rpc 0.4.0 for Mainnet:
+// Lava node rpc 0.6.0 for Mainnet:
 const providerMainnetLava = new RpcProvider({
   nodeUrl: 'https://g.w.lavanet.xyz:443/gateway/strk/rpc-http/' + lavaMainnetKey,
 });
-// Alchemy node rpc 0.5.1 for Mainnet:
+// Alchemy node rpc 0.6.0 for Mainnet:
 const providerAlchemyMainnet = new RpcProvider({
-  nodeUrl: 'https://starknet-mainnet.g.alchemy.com/starknet/version/rpc/v0.5/' + alchemyKey,
+  nodeUrl: 'https://starknet-mainnet.g.alchemy.com/starknet/version/rpc/v0_6/' + alchemyKey,
 });
-// Public Nethermind node rpc 0.5.1 & 0.6.0 for Mainnet:
+// Public Nethermind node rpc 0.7.0 for Mainnet (0_6 also available):
 const providerMainnetNethermindPublic = new RpcProvider({
-  nodeUrl: 'https://free-rpc.nethermind.io/mainnet-juno/v0_5',
+  nodeUrl: 'https://free-rpc.nethermind.io/mainnet-juno/v0_7',
 });
-const providerMainnetNethermindPublic = new RpcProvider({
-  nodeUrl: 'https://free-rpc.nethermind.io/mainnet-juno/v0_6',
-});
-// Public Blast node rpc 0.4.0, 0.5.1 & 0.6.0 for Mainnet:
+// Public Blast node rpc 0.7.0 for Mainnet (0.4, 0.5 & 0_6 also available) :
 const providerBlastMainnet = new RpcProvider({
-  nodeUrl: 'https://starknet-mainnet.public.blastapi.io/rpc/v0.4',
+  nodeUrl: 'https://starknet-mainnet.public.blastapi.io/rpc/v0_7',
 });
-const providerBlastMainnet = new RpcProvider({
-  nodeUrl: 'https://starknet-mainnet.public.blastapi.io/rpc/v0.5',
-});
-const providerBlastMainnet = new RpcProvider({
-  nodeUrl: 'https://starknet-mainnet.public.blastapi.io/rpc/v0_6',
-});
-// Public Lava node rpc 0.4.0 for Mainnet:
+// Public Lava node rpc 0.6.0 for Mainnet:
 const providerLavaMainnet = new RpcProvider({
   nodeUrl: 'https://json-rpc.starknet-mainnet.public.lavanet.xyz',
 });
@@ -120,42 +108,38 @@ const providerLavaMainnet = new RpcProvider({
 const providerInfuraTestnet = new RpcProvider({
   nodeUrl: 'https://starknet-goerli.infura.io/v3/' + infuraKey,
 });
-// Blast node rpc 0.5.1 & 0.6.0 for Goerli Testnet:
+// Blast node rpc 0.7.0 for Goerli Testnet (0.4, 0.5 & 0_6 also available) :
 const providerBlastTestnet = new RpcProvider({
-  nodeUrl: 'https://starknet-testnet.blastapi.io/' + blastKey + '/rpc/v0.5',
+  nodeUrl: 'https://starknet-testnet.blastapi.io/' + blastKey + '/rpc/v0_7',
 });
-const providerBlastTestnet = new RpcProvider({
-  nodeUrl: 'https://starknet-testnet.blastapi.io/' + blastKey + '/rpc/v0_6',
-});
-// Alchemy node rpc 0.5.1 for Goerli Testnet:
+// Alchemy node rpc 0.6.0 for Goerli Testnet:
 const providerAlchemyTestnet = new RpcProvider({
-  nodeUrl: 'https://starknet-goerli.g.alchemy.com/starknet/version/rpc/v0.5/' + alchemyKey,
+  nodeUrl: 'https://starknet-goerli.g.alchemy.com/starknet/version/rpc/v0_6/' + alchemyKey,
 });
-// Public Nethermind node rpc 0.5.1 & 0.6.0 for Goerli Testnet:
+// Public Nethermind node rpc 0.7.0 for Goerli Testnet (0_6 also available) :
 const providerTestnetNethermindPublic = new RpcProvider({
-  nodeUrl: 'https://free-rpc.nethermind.io/goerli-juno/v0_5',
+  nodeUrl: 'https://free-rpc.nethermind.io/goerli-juno/v0_7',
 });
-const providerTestnetNethermindPublic = new RpcProvider({
-  nodeUrl: 'https://free-rpc.nethermind.io/goerli-juno/v0_6',
+// Public Blast node rpc 0.7.0 for Goerli Testnet (0.4, 0.5 & 0_6 also available) :
+const providerTestnetBlastPublic = new RpcProvider({
+  nodeUrl: 'https://starknet-testnet.public.blastapi.io/rpc/v0_7',
 });
 ```
 
 ### Sepolia Testnet
 
 ```typescript
-// Blast node rpc 0.5.1 & 0.60 for Sepolia Testnet:
-const providerBlastTestnet = new RpcProvider({
-  nodeUrl: 'https://starknet-testnet.blastapi.io/' + blastKey + '/rpc/v0.5',
+// Infura node rpc 0.5.1 for Sepolia Testnet :
+const providerInfuraSepoliaTestnet = new RpcProvider({
+  nodeUrl: 'https://starknet-sepolia.infura.io/v3/' + infuraKey,
 });
-const providerBlastTestnet = new RpcProvider({
-  nodeUrl: 'https://starknet-testnet.blastapi.io/' + blastKey + '/rpc/v0_6',
+// Public Nethermind node rpc 0.7.0 for Sepolia Testnet (0_6 also available) :
+const providerSepoliaTestnetNethermindPublic = new RpcProvider({
+  nodeUrl: 'https://free-rpc.nethermind.io/sepolia-juno/v0_7',
 });
-// Alchemy node rpc for Sepolia Testnet:
-const providerSepoliaNethermindPublic = new RpcProvider({
-  nodeUrl: 'https://free-rpc.nethermind.io/sepolia-juno/v0_5',
-});
-const providerSepoliaNethermindPublic = new RpcProvider({
-  nodeUrl: 'https://free-rpc.nethermind.io/sepolia-juno/v0_6',
+// Public Blast node rpc 0.7.0 for Sepolia Testnet (0_6 also available) :
+const providerSepoliaTestnetBlastPublic = new RpcProvider({
+  nodeUrl: 'https://starknet-sepolia.public.blastapi.io/rpc/v0_7',
 });
 ```
 
@@ -166,14 +150,14 @@ const providerSepoliaNethermindPublic = new RpcProvider({
 For a local [Pathfinder](https://github.com/eqlabs/pathfinder) node:
 
 ```typescript
-const provider = new RpcProvider({ nodeUrl: '127.0.0.1:9545/rpc/v0_6' });
+const provider = new RpcProvider({ nodeUrl: '127.0.0.1:9545/rpc/v0_7' });
 ```
 
 Your node can be located in your local network (example: Pathfinder node running on a computer in your network, launched with this additional option: `--http-rpc 0.0.0.0:9545`).
 You can connect with:
 
 ```typescript
-const provider = new RpcProvider({ nodeUrl: '192.168.1.99:9545/rpc/v0_6' });
+const provider = new RpcProvider({ nodeUrl: '192.168.1.99:9545/rpc/v0_7' });
 ```
 
 ### Juno
@@ -181,7 +165,7 @@ const provider = new RpcProvider({ nodeUrl: '192.168.1.99:9545/rpc/v0_6' });
 For a local [Juno](https://github.com/NethermindEth/juno) node initialize the provider with:
 
 ```typescript
-const provider = new RpcProvider({ nodeUrl: 'http://127.0.0.1:6060/v0_6' });
+const provider = new RpcProvider({ nodeUrl: 'http://127.0.0.1:6060/v0_7' });
 ```
 
 > If Juno is running on a separate computer in your local network, don't forget to add the option `--http-host 0.0.0.0` when launching Juno.


### PR DESCRIPTION
## Motivation and Resolution

I am working with Starknet abstract account. To support our work, I am extending the starknet.js `Account` class to add some additional behaviours on the application side. I am **not** changing the way the transaction version is used internally and would still need to implement the account deployment.

You have defined 3 `private` methods in the class which makes sense to not expose to the outside. However in the context of extending that class we would prefer to access those 3 methods instead of rewriting them. Obviously, this is your decision to make. For that particular scenario, I think having those 3 `private` methods turned into `protected` makes more sense.

### RPC version (if applicable)

- not applicable

## Usage related changes

- It will not affect any user that is not extending the account class (i.e. most developers)
- It will simplify the ability to extend the `Account`

## Development related changes

<!-- How these changes affect the developers of this project - e.g. changes in testing or CI/CD. -->

- We did not add any test as the protected functions can still not be accessed from the outside and the code can easily be copied/pasted into a new `private` function anyway.
- If you think something should be done to enhanced my request, let me know.

## Checklist:

- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [ ] Linked the issues which this PR resolves
- [x] Documented the changes in code (API docs will be generated automatically)
- [ ] Updated the tests
- [x] All tests are passing
