### PR TITLE
fix: remove unnecessary abis parameter from signer and .execute

### DIFF
--- a/__tests__/account.test.ts
+++ b/__tests__/account.test.ts
@@ -370,17 +370,16 @@ describe('deploy and test Wallet', () => {
     expect(balance.low).toStrictEqual(toBigInt(990));
   });
 
-  test('execute with syntax without abi parameter', async () => {
-    const { transaction_hash } = await account.execute(
-      {
-        contractAddress: erc20Address,
-        entrypoint: 'transfer',
-        calldata: [erc20.address, '10', '0'],
-      },
-      { maxFee: 6n * 10n ** 15n }
-    );
+  test('execute with and without deprecated abis parameter', async () => {
+    const transaction = {
+      contractAddress: erc20Address,
+      entrypoint: 'transfer',
+      calldata: [erc20.address, '10', '0'],
+    };
+    const details = { maxFee: 0n };
 
-    await provider.waitForTransaction(transaction_hash);
+    await expect(account.execute(transaction, details)).rejects.toThrow(/zero/);
+    await expect(account.execute(transaction, undefined, details)).rejects.toThrow(/zero/);
   });
 
   test('execute with custom nonce', async () => {

--- a/__tests__/account.test.ts
+++ b/__tests__/account.test.ts
@@ -370,6 +370,19 @@ describe('deploy and test Wallet', () => {
     expect(balance.low).toStrictEqual(toBigInt(990));
   });
 
+  test('execute with syntax without abi parameter', async () => {
+    const { transaction_hash } = await account.execute(
+      {
+        contractAddress: erc20Address,
+        entrypoint: 'transfer',
+        calldata: [erc20.address, '10', '0'],
+      },
+      { maxFee: 6n * 10n ** 15n }
+    );
+
+    await provider.waitForTransaction(transaction_hash);
+  });
+
   test('execute with custom nonce', async () => {
     const result = await account.getNonce();
     const nonce = toBigInt(result);

--- a/package-lock.json
+++ b/package-lock.json
@@ -14283,11 +14283,6 @@
         "node": "^16.14.0 || >=18.0.0"
       }
     },
-    "node_modules/npm/node_modules/ip": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/npm/node_modules/ip-address": {
       "version": "9.0.5",
       "dev": true,

--- a/src/account/default.ts
+++ b/src/account/default.ts
@@ -315,23 +315,10 @@ export class Account extends Provider implements AccountInterface {
   ): Promise<InvokeFunctionResponse>;
   public async execute(
     transactions: AllowArray<Call>,
-    arg2: Abi[] | UniversalDetails | undefined = undefined,
+    arg2?: Abi[] | UniversalDetails,
     transactionsDetail: UniversalDetails = {}
   ): Promise<InvokeFunctionResponse> {
-    let details: UniversalDetails;
-    switch (true) {
-      case Array.isArray(arg2):
-        details = transactionsDetail;
-        break;
-      case typeof arg2 === 'object':
-        details = arg2;
-        break;
-      case typeof arg2 === 'undefined':
-        details = transactionsDetail;
-        break;
-      default:
-        throw Error(`wrong input parameters: ${arg2}, ${transactionsDetail}`);
-    }
+    const details = arg2 === undefined || Array.isArray(arg2) ? transactionsDetail : arg2;
     const calls = Array.isArray(transactions) ? transactions : [transactions];
     const nonce = toBigInt(details.nonce ?? (await this.getNonce()));
     const version = toTransactionVersion(

--- a/src/account/interface.ts
+++ b/src/account/interface.ts
@@ -203,9 +203,24 @@ export abstract class AccountInterface extends ProviderInterface {
    * - entrypoint - the entrypoint of the contract
    * - calldata - (defaults to []) the calldata
    * - signature - (defaults to []) the signature
-   * @param abi (optional) the abi of the contract for better displaying
+   * @param {InvocationsDetails} transactionsDetail Additional optional parameters for the transaction
    *
    * @returns response from addTransaction
+   */
+  public abstract execute(
+    transactions: AllowArray<Call>,
+    transactionsDetail?: InvocationsDetails
+  ): Promise<InvokeFunctionResponse>;
+  /**
+   * @deprecated
+   * @param transactions the invocation object or an array of them, containing:
+   * - contractAddress - the address of the contract
+   * - entrypoint - the entrypoint of the contract
+   * - calldata - (defaults to []) the calldata
+   * - signature - (defaults to []) the signature
+   * @param abis (optional) the abi of the contract for better displaying
+   * @param {InvocationsDetails} transactionsDetail Additional optional parameters for the transaction
+   * * @returns response from addTransaction
    */
   public abstract execute(
     transactions: AllowArray<Call>,

--- a/src/signer/interface.ts
+++ b/src/signer/interface.ts
@@ -1,5 +1,4 @@
 import {
-  Abi,
   Call,
   DeclareSignerDetails,
   DeployAccountSignerDetails,
@@ -39,12 +38,10 @@ export abstract class SignerInterface {
    *  - maxFee<br/>
    *  - version<br/>
    *  - nonce<br/>
-   * @param abis - (optional) An array of Abi objects for displaying decoded data
    */
   public abstract signTransaction(
     transactions: Call[],
-    transactionsDetail: InvocationsSignerDetails,
-    abis?: Abi[]
+    transactionsDetail: InvocationsSignerDetails
   ): Promise<Signature>;
 
   /**

--- a/www/docs/guides/connect_account.md
+++ b/www/docs/guides/connect_account.md
@@ -80,10 +80,11 @@ As a consequence of account abstraction, you can find accounts that uses Ethereu
 To connect to this type of account:
 
 ```typescript
-const myEthPrivateKey = "0x525bc68475c0955fae83869beec0996114d4bb27b28b781ed2a20ef23121b8de";
-const myEthAccountAddressInStarknet = "0x65a822fbee1ae79e898688b5a4282dc79e0042cbed12f6169937fddb4c26641";
+const myEthPrivateKey = '0x525bc68475c0955fae83869beec0996114d4bb27b28b781ed2a20ef23121b8de';
+const myEthAccountAddressInStarknet =
+  '0x65a822fbee1ae79e898688b5a4282dc79e0042cbed12f6169937fddb4c26641';
 const myEthSigner = new EthSigner(myEthPrivateKey);
-const myEthAccount = new Account(provider, myEthAccountAddressInStarknet, myEthSigner)
+const myEthAccount = new Account(provider, myEthAccountAddressInStarknet, myEthSigner);
 ```
 
 And if you need a random Ethereum private key:

--- a/www/docs/guides/define_call_message.md
+++ b/www/docs/guides/define_call_message.md
@@ -242,28 +242,24 @@ If your abi is requesting this type : `core::starknet::secp256k1::Secp256k1Point
 - If you are using a calldata construction method using the Abi, you have just to use a 512 bits number (so, without parity) :
 
 ```typescript
-const privateKeyETH = "0x45397ee6ca34cb49060f1c303c6cb7ee2d6123e617601ef3e31ccf7bf5bef1f9";
+const privateKeyETH = '0x45397ee6ca34cb49060f1c303c6cb7ee2d6123e617601ef3e31ccf7bf5bef1f9';
 const ethSigner = new EthSigner(privateKeyETH);
 const ethFullPublicKey = await ethSigner.getPubKey(); // 512 bits number
 const myCallData = new CallData(ethAccountAbi);
-const accountETHconstructorCalldata = myCallData.compile(
-    "constructor",
-    {
-        public_key: ethFullPublicKey
-    }
-);
+const accountETHconstructorCalldata = myCallData.compile('constructor', {
+  public_key: ethFullPublicKey,
+});
 ```
 
 - If you are using a calldata construction method without the Abi, you have to send a tuple of 2 u256 :
 
 ```typescript
-const ethFullPublicKey = "0x0178bb97615b49070eefad71cb2f159392274404e41db748d9397147cb25cf597ebfcf2f399e635b72b99b8f76e9080763c65a42c842869815039d912150ddfe"; // 512 bits number
-const pubKeyETH = encode.addHexPrefix(encode.removeHexPrefix(ethFullPublicKey).padStart(128, "0"));
+const ethFullPublicKey =
+  '0x0178bb97615b49070eefad71cb2f159392274404e41db748d9397147cb25cf597ebfcf2f399e635b72b99b8f76e9080763c65a42c842869815039d912150ddfe'; // 512 bits number
+const pubKeyETH = encode.addHexPrefix(encode.removeHexPrefix(ethFullPublicKey).padStart(128, '0'));
 const pubKeyETHx = cairo.uint256(addAddressPadding(encode.addHexPrefix(pubKeyETH.slice(2, -64))));
 const pubKeyETHy = cairo.uint256(addAddressPadding(encode.addHexPrefix(pubKeyETH.slice(-64))));
-const accountETHconstructorCalldata = CallData.compile([
-    cairo.tuple(pubKeyETHx, pubKeyETHy)
-]);
+const accountETHconstructorCalldata = CallData.compile([cairo.tuple(pubKeyETHx, pubKeyETHy)]);
 ```
 
 ### struct

--- a/www/docs/guides/interact.md
+++ b/www/docs/guides/interact.md
@@ -131,7 +131,7 @@ const myCall = myTestContract.populate('test_fail', [100]);
 const maxQtyGasAuthorized = 1800n; // max quantity of gas authorized
 const maxPriceAuthorizeForOneGas = 12n * 10n ** 9n; // max FRI authorized to pay 1 gas (1 FRI=10**-18 STRK)
 console.log('max authorized cost =', maxQtyGasAuthorized * maxPriceAuthorizeForOneGas, 'FRI');
-const { transaction_hash: txH } = await account0.execute(myCall, undefined, {
+const { transaction_hash: txH } = await account0.execute(myCall, {
   version: 3,
   maxFee: 10 ** 15,
   feeDataAvailabilityMode: RPC.EDataAvailabilityMode.L1,

--- a/www/docs/guides/signature.md
+++ b/www/docs/guides/signature.md
@@ -196,10 +196,11 @@ try {
 All the previous examples are using the standard Starknet signature process, but you can also use the Ethereum one.
 
 ```typescript
-const myEthPrivateKey = "0x525bc68475c0955fae83869beec0996114d4bb27b28b781ed2a20ef23121b8de";
-const myEthAccountAddressInStarknet = "0x65a822fbee1ae79e898688b5a4282dc79e0042cbed12f6169937fddb4c26641";
+const myEthPrivateKey = '0x525bc68475c0955fae83869beec0996114d4bb27b28b781ed2a20ef23121b8de';
+const myEthAccountAddressInStarknet =
+  '0x65a822fbee1ae79e898688b5a4282dc79e0042cbed12f6169937fddb4c26641';
 const myEthSigner = new EthSigner(myEthPrivateKey);
-console.log("Complete public key =", await myEthSigner.getPubKey());
+console.log('Complete public key =', await myEthSigner.getPubKey());
 const sig0 = await myEthSigner.signMessage(message, myEthAccountAddressInStarknet);
-console.log("signature message =", sig0);
+console.log('signature message =', sig0);
 ```


### PR DESCRIPTION
## Motivation and Resolution
Solve issue #1030 .
`Account.execute()` uses an optional `abis` parameter that is useless. Same for `Signer` interface.

- Signer optional `abis` parameter is deleted.
- `Account.execute()` accepts both signatures with and without `abis` parameter (to not break the current syntax).

## Usage related changes
All these syntaxes are valid :
```typescript
const res1 = await account0.execute(myCall,undefined,{maxFee:10n**17n});
const res2 = await account0.execute(myCall);
const res3 = await account0.execute(myCall,{maxFee:10n**17n});
```

## Development related changes
- Abis removed of Signer interface
- Account interface with execute method overloaded.
- Added a test of the new syntax.

**Nota** : Guides are automatically modified by CI during commit. I think that this has to be deactivated. Documentation content has to be handled only by the author.

## Checklist:

- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Linked the issues which this PR resolves
- [x] Documented the changes in code (API docs will be generated automatically)
- [x] Updated the tests
- [x] All tests are passing
