### PR TITLE
docs: fix nodeUrl code typo

### DIFF
--- a/www/versioned_docs/version-5.24.3/guides/events.md
+++ b/www/versioned_docs/version-5.24.3/guides/events.md
@@ -120,7 +120,7 @@ In this example, if you want to read the events recorded in the last 10 blocks, 
 ```typescript
 import { RpcProvider } from 'starknet';
 const providerRPC = new RpcProvider({
-  nodeUrl: "{ nodeUrl: 'https://starknet-goerli.infura.io/v3/' + infuraKey }",
+  nodeUrl: 'https://starknet-goerli.infura.io/v3/' + infuraKey,
 }); // for an Infura node on Testnet
 const lastBlock = await providerRPC.getBlock('latest');
 const keyFilter = [num.toHex(hash.starknetKeccak('EventPanic')), '0x8'];


### PR DESCRIPTION
## Motivation and Resolution

Previously, at https://www.starknetjs.com/docs/guides/events#without-transaction-hash, the code contains a typo which won't run:

![image](https://github.com/starknet-io/starknet.js/assets/22465806/4efeb977-782e-467a-98fd-fb88f0726107)

## Usage related changes

The users will see the correct code.

## Checklist:

- [x] Performed a self-review of the code
- [x]  Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Linked the issues which this PR resolves
- [x] Documented the changes in code (API docs will be generated automatically)
- [x] Updated the tests
- [x] All tests are passing
