### PR TITLE
chore: expose data gas consumed and data gas price for 0.7 rpc

### DIFF
--- a/src/account/default.ts
+++ b/src/account/default.ts
@@ -618,6 +618,8 @@ export class Account extends Provider implements AccountInterface {
           unit: 'FRI',
           suggestedMaxFee: ZERO,
           resourceBounds: estimateFeeToBounds(ZERO),
+          data_gas_consumed: 0n,
+          data_gas_price: 0n,
         };
         break;
     }

--- a/src/types/provider/response.ts
+++ b/src/types/provider/response.ts
@@ -121,6 +121,8 @@ export interface EstimateFeeResponse {
   unit: PRICE_UNIT;
   suggestedMaxFee: bigint;
   resourceBounds: ResourceBounds;
+  data_gas_consumed: bigint;
+  data_gas_price: bigint;
 }
 
 export type EstimateFeeResponseBulk = Array<EstimateFeeResponse>;

--- a/src/utils/responseParser/rpc.ts
+++ b/src/utils/responseParser/rpc.ts
@@ -6,20 +6,20 @@ import {
   BlockWithTxHashes,
   ContractClassPayload,
   ContractClassResponse,
-  TransactionReceipt,
   EstimateFeeResponse,
   EstimateFeeResponseBulk,
-  GetBlockResponse,
   FeeEstimate,
+  GetBlockResponse,
+  GetTxReceiptResponseWithoutHelper,
+  RpcProviderOptions,
   SimulateTransactionResponse,
   SimulatedTransaction,
-  RpcProviderOptions,
-  GetTxReceiptResponseWithoutHelper,
+  TransactionReceipt,
 } from '../../types/provider';
 import { toBigInt } from '../num';
+import { isString } from '../shortString';
 import { estimateFeeToBounds, estimatedFeeToMaxFee } from '../stark';
 import { ResponseParser } from '.';
-import { isString } from '../shortString';
 
 export class RPCResponseParser
   implements
@@ -80,6 +80,8 @@ export class RPCResponseParser
       unit: val.unit,
       suggestedMaxFee: this.estimatedFeeToMaxFee(val.overall_fee),
       resourceBounds: this.estimateFeeToBounds(val),
+      data_gas_consumed: val.data_gas_consumed ? toBigInt(val.data_gas_consumed) : 0n,
+      data_gas_price: val.data_gas_price ? toBigInt(val.data_gas_price) : 0n,
     };
   }
 
@@ -91,6 +93,8 @@ export class RPCResponseParser
       unit: val.unit,
       suggestedMaxFee: this.estimatedFeeToMaxFee(val.overall_fee),
       resourceBounds: this.estimateFeeToBounds(val),
+      data_gas_consumed: val.data_gas_consumed ? toBigInt(val.data_gas_consumed) : 0n,
+      data_gas_price: val.data_gas_price ? toBigInt(val.data_gas_price) : 0n,
     }));
   }
 

--- a/www/versioned_docs/version-5.24.3/guides/events.md
+++ b/www/versioned_docs/version-5.24.3/guides/events.md
@@ -120,7 +120,7 @@ In this example, if you want to read the events recorded in the last 10 blocks, 
 ```typescript
 import { RpcProvider } from 'starknet';
 const providerRPC = new RpcProvider({
-  nodeUrl: "{ nodeUrl: 'https://starknet-goerli.infura.io/v3/' + infuraKey }",
+  nodeUrl: 'https://starknet-goerli.infura.io/v3/' + infuraKey,
 }); // for an Infura node on Testnet
 const lastBlock = await providerRPC.getBlock('latest');
 const keyFilter = [num.toHex(hash.starknetKeccak('EventPanic')), '0x8'];


### PR DESCRIPTION
## Motivation and Resolution

With starknet 0.13.1, overall_fee is calculated with data_gas_consumed and data_gas_price. Let's expose this if wallets or dapps wants to use it

### RPC version (if applicable)

0.7

## Usage related changes

<!-- How the changes from this PR affect users. -->

- Change 1.
- ...

## Development related changes

<!-- How these changes affect the developers of this project - e.g. changes in testing or CI/CD. -->

- Change 1.
- ...

## Checklist:

- [ ] Performed a self-review of the code
- [ ] Rebased to the last commit of the target branch (or merged it into my branch)
- [ ] Linked the issues which this PR resolves
- [ ] Documented the changes in code (API docs will be generated automatically)
- [ ] Updated the tests
- [ ] All tests are passing
