### PR TITLE
Doc : Goerli deprecated

### DIFF
--- a/src/utils/provider.ts
+++ b/src/utils/provider.ts
@@ -75,7 +75,7 @@ export const getDefaultNodeUrl = (networkName?: NetworkName, mute: boolean = fal
   if (!mute)
     // eslint-disable-next-line no-console
     console.warn('Using default public node url, please provide nodeUrl in provider options!');
-  const nodes = RPC_NODES[networkName ?? NetworkName.SN_GOERLI]; // TODO: when goerli deprecated switch default to sepolia
+  const nodes = RPC_NODES[networkName ?? NetworkName.SN_SEPOLIA];
   const randIdx = Math.floor(Math.random() * nodes.length);
   return nodes[randIdx];
 };

--- a/www/docs/guides/L1message.md
+++ b/www/docs/guides/L1message.md
@@ -7,7 +7,7 @@ sidebar_position: 13
 You can exchange messages between L1 & L2 networks:
 
 - L2 Starknet mainnet ↔️ L1 Ethereum.
-- L2 Starknet testnet ↔️ L1 Goerli ETH testnet.
+- L2 Starknet testnet ↔️ L1 Sepolia ETH testnet.
 - L2 local Starknet devnet ↔️ L1 local ETH testnet (Ganache, ...).
 
 You can find an explanation of the global mechanism [here](https://docs.starknet.io/documentation/architecture_and_concepts/L1-L2_Communication/messaging-mechanism/).
@@ -35,8 +35,8 @@ function sendMessageToL2(
 You have to pay in the L1 an extra fee when invoking `sendMessageToL2` (of course paid with the L1 fee TOKEN), to pay the L2 part of the messaging mechanism. You can estimate this fee with this function:
 
 ```typescript
-import { SequencerProvider } from 'starknet';
-const provider = new SequencerProvider({ baseUrl: constants.BaseUrl.SN_GOERLI }); // for testnet
+import { RpcProvider, constants } from 'starknet';
+const provider = new RpcProvider({ nodeUrl: constants.NetworkName.SN_SEPOLIA }); // for testnet
 
 const responseEstimateMessageFee = await provider.estimateMessageFee({
   from_address: L1address,

--- a/www/docs/guides/connect_network.md
+++ b/www/docs/guides/connect_network.md
@@ -18,8 +18,8 @@ Then you need to select a node. A node is a safe way to connect with the Starkne
 Each node is communicating with Starknet.js using a rpc specification. Most of the nodes are able to use 2 rpc spec versions.  
 For example, this node is compatible with v0.6.0 & v0.7.0, using the following entry points :
 
-- "https://free-rpc.nethermind.io/goerli-juno/v0_6"
-- "https://free-rpc.nethermind.io/goerli-juno/v0_7"
+- "https://free-rpc.nethermind.io/sepolia-juno/v0_6"
+- "https://free-rpc.nethermind.io/sepolia-juno/v0_7"
 
 From rpc spec v0.5.0, you can request the rpc spec version that uses a node address :
 
@@ -36,8 +36,8 @@ On Starknet.js side, you have to select the proper version, to be in accordance 
 |            v0.4.0             | Starknet.js v5.21.1          |
 |            v0.5.0             | Starknet.js v5.23.0          |
 |            v0.5.1             | Starknet.js v5.29.0 & v6.1.0 |
-|            v0.6.0             | Starknet.js v6.4.3           |
-|            v0.7.0             | Starknet.js v6.4.3           |
+|            v0.6.0             | Starknet.js v6.6.6           |
+|            v0.7.0             | Starknet.js v6.6.6           |
 
 [!NOTE] Each Starknet.js version 6.x.x is compatible with 3 rpc spec versions, and recognize automatically the spec version if not provided.
 
@@ -54,10 +54,10 @@ import { RpcProvider } from 'starknet';
 If you don't want to use a specific node, or to handle an API key, you can use by default (using Rpc spec 0.7.0):
 
 ```typescript
-const myProvider = new RpcProvider({ nodeUrl: constants.NetworkName.SN_GOERLI });
+const myProvider = new RpcProvider({ nodeUrl: constants.NetworkName.SN_SEPOLIA });
 const myProvider = new RpcProvider({ nodeUrl: constants.NetworkName.SN_MAIN });
 // or
-const myProvider = new RpcProvider(); // Goerli
+const myProvider = new RpcProvider(); // Sepolia
 ```
 
 > when using this syntax, a random public node will be selected.
@@ -103,28 +103,9 @@ const providerLavaMainnet = new RpcProvider({
 
 ### Goerli Testnet
 
-```typescript
-// Infura node rpc 0.5.1 for Goerli Testnet:
-const providerInfuraTestnet = new RpcProvider({
-  nodeUrl: 'https://starknet-goerli.infura.io/v3/' + infuraKey,
-});
-// Blast node rpc 0.7.0 for Goerli Testnet (0.4, 0.5 & 0_6 also available) :
-const providerBlastTestnet = new RpcProvider({
-  nodeUrl: 'https://starknet-testnet.blastapi.io/' + blastKey + '/rpc/v0_7',
-});
-// Alchemy node rpc 0.6.0 for Goerli Testnet:
-const providerAlchemyTestnet = new RpcProvider({
-  nodeUrl: 'https://starknet-goerli.g.alchemy.com/starknet/version/rpc/v0_6/' + alchemyKey,
-});
-// Public Nethermind node rpc 0.7.0 for Goerli Testnet (0_6 also available) :
-const providerTestnetNethermindPublic = new RpcProvider({
-  nodeUrl: 'https://free-rpc.nethermind.io/goerli-juno/v0_7',
-});
-// Public Blast node rpc 0.7.0 for Goerli Testnet (0.4, 0.5 & 0_6 also available) :
-const providerTestnetBlastPublic = new RpcProvider({
-  nodeUrl: 'https://starknet-testnet.public.blastapi.io/rpc/v0_7',
-});
-```
+[!IMPORTANT]
+
+> The Goerli testnet is no more in service.
 
 ### Sepolia Testnet
 

--- a/www/docs/guides/create_account.md
+++ b/www/docs/guides/create_account.md
@@ -58,12 +58,14 @@ How to proceed is out of the scope of this guide, but you can for example:
 
 - Transfer ETH from another wallet.
 - Bridge ETH to this Starknet address.
-- Use a faucet. (https://faucet.goerli.starknet.io/)
+- Use a faucet. (https://starknet-faucet.vercel.app/)
 - Mint ETH on starknet-devnet-rs, like so:
 
 ```bash
-curl -X POST http://127.0.0.1:5050/mint -d '{"address":"0x04a093c37ab61065d001550089b1089922212c60b34e662bb14f2f91faee2979","amount":50000000000000000000,"lite":true}' -H "Content-Type:application/json"
-// {"new_balance":50000000000000000000,"tx_hash":null,"unit":"wei"}
+// ETH
+curl -X POST http://127.0.0.1:5050/mint -d '{"address":"0x04a093c37ab61065d001550089b1089922212c60b34e662bb14f2f91faee2979","amount":50000000000000000000}' -H "Content-Type:application/json"
+// STRK
+curl -X POST http://127.0.0.1:5050/mint -d '{"address":"0x04a093c37ab61065d001550089b1089922212c60b34e662bb14f2f91faee2979","amount":50000000000000000000,"unit":"FRI"}' -H "Content-Type:application/json"
 ```
 
 ### Deployment of the new account
@@ -150,7 +152,7 @@ More complicated, a Braavos account needs a proxy and a specific signature. Star
 We will deploy hereunder a Braavos account in devnet. So launch starknet-devnet with these parameters:
 
 ```bash
-starknet-devnet --seed 0 --fork-network alpha-goerli
+starknet-devnet --seed 0 --fork-network 'https://free-rpc.nethermind.io/sepolia-juno/v0_7'
 ```
 
 Initialization:
@@ -204,7 +206,6 @@ const { data: answer } = await axios.post(
   {
     address: BraavosProxyAddress,
     amount: 10_000_000_000_000_000_000,
-    lite: true,
   },
   { headers: { 'Content-Type': 'application/json' } }
 );

--- a/www/docs/guides/interact.md
+++ b/www/docs/guides/interact.md
@@ -9,7 +9,7 @@ Once your provider, contract, and account are connected, you can interact with t
 - you can read the memory of the contract, without fees.
 - you can write to memory, but you have to pay fees.
   - On Mainnet, you have to pay fees with a bridged ETH token.
-  - On Testnets, you have to pay with a bridged Goerli or Sepolia ETH token.
+  - On Testnet, you have to pay with a bridged Sepolia ETH token.
   - On devnet, you have to pay with a dummy ETH token.
 
 Your account should be funded enough to pay fees (0.01 ETH should be enough to start).

--- a/www/docs/guides/migrate.md
+++ b/www/docs/guides/migrate.md
@@ -8,22 +8,33 @@ This document only covers the features present in v5 which have changed in some 
 
 If you encounter any missing changes, please let us know and we will update this guide.
 
-## Transaction response
+## Transaction receipt
 
-When sending a transaction, the response type has changed.
-
-Previously, the response was just the transaction hash value. Now, the response is an object including many other data.
-This has an impact on `provider.waitForTransaction()`:
+When sending a transaction, the receipt type has changed.
+In V5, it's an object that can have varied definitions, depending of the status and the type of transaction.
+In V6, this object is in `TxR.value`, and several helpers are available (`.statusReceipt`, `isSuccess()`, `isRejected()`, `isReverted()`, `.isError()`, `match`, ...)
 
 ```typescript
 const response = await ethContract.approve(swapContractAddress, cairo.uint256(100000));
-
-// v5
-const transactionReceipt = await provider.waitForTransaction(response);
-
-// v6
 const transactionReceipt = await provider.waitForTransaction(response.transaction_hash);
+
+// v5 : transactionReceipt is just an object
+{
+type: 'INVOKE',
+  transaction_hash: '0x5286217518c621581ac85505a99ffe182ce1114abaa8fce8b418d2b27c3c04c',
+  actual_fee: { unit: 'WEI', amount: '0x1c1902fe99800' },
+  messages_sent: [],
+  execution_status: 'SUCCEEDED',
+  finality_status: 'ACCEPTED_ON_L2',
+  // ...
+}
+// v6 : transactionReceipt is an object + helpers
+const receipt = transactionReceipt.value;
+const status: boolean = transactionReceipt.isSuccess();
+
 ```
+
+> See this [guide](./interact.md#transaction-receipt-response)
 
 ## Long strings
 

--- a/www/docs/guides/signature.md
+++ b/www/docs/guides/signature.md
@@ -144,7 +144,7 @@ const typedDataValidate: TypedData = {
   domain: {
     name: 'myDapp', // put the name of your dapp to ensure that the signatures will not be used by other DAPP
     version: '1',
-    chainId: shortString.encodeShortString('SN_GOERLI'), // shortString of 'SN_GOERLI' (or 'SN_MAIN'), to be sure that signature can't be used by other network.
+    chainId: shortString.encodeShortString('SN_SEPOLIA'), // shortString of 'SN_SEPOLIA' (or 'SN_MAIN'), to be sure that signature can't be used by other network.
   },
   message: {
     id: '0x0000004f000f',

--- a/www/docs/guides/what_s_starknet.js.md
+++ b/www/docs/guides/what_s_starknet.js.md
@@ -15,8 +15,8 @@ Some important topics that have to be understood:
 - You can connect your DAPP to several networks:
 
   - [Starknet mainnet](https://starkscan.co) (Layer 2 of [Ethereum network](https://etherscan.io/) ).
-  - [Starknet testnet](https://testnet.starkscan.co/) (Layer 2 of [Goerli network](https://goerli.etherscan.io/) (testnet of Ethereum)).
-  - [Starknet-devnet](https://shard-labs.github.io/starknet-devnet/docs/intro) (your local Starknet network, for developers).
+  - [Starknet testnet](https://sepolia.starkscan.co/) (Layer 2 of [Sepolia network](https://sepolia.etherscan.io/) (testnet of Ethereum)).
+  - [Starknet-devnet](https://github.com/0xSpaceShard/starknet-devnet-rs) (your local Starknet network, for developers).
 
   and also to some more specific solutions:
 


### PR DESCRIPTION
## Motivation and Resolution
Starknet Goerli testnet has been shut down yesterday.

## Usage related changes
Documentation has been updated accordingly.
> At the same time, a small update in migrate.md has been made.

## Development related changes

default network has been changed to SEPOLIA.
> data in constants.ts have not been modified, because it has to be modified also for get-starknet and compatibility with L3 (enum -> string).

## Checklist:

- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] All tests are passing
