### PR TITLE
Test RPC default Providers Services

### DIFF
--- a/__tests__/defaultNodes.test.ts
+++ b/__tests__/defaultNodes.test.ts
@@ -1,0 +1,46 @@
+import { Provider, constants } from '../src';
+
+describe('Default RPC Nodes', () => {
+  test('Default lib configured version', async () => {
+    const result = await Promise.all(
+      Object.keys(constants.RPC_NODES).map(async (network: any) => {
+        return Promise.all(
+          constants.RPC_NODES[network as keyof typeof constants.RPC_NODES].map(async (it: any) => {
+            const provider = new Provider({ nodeUrl: it });
+            return {
+              network,
+              nodeUrl: provider.channel.nodeUrl,
+              version: await provider.getSpecVersion(),
+            };
+          })
+        );
+      })
+    );
+
+    console.table(result.flat());
+  });
+  test('Default RPC configured version on base route', async () => {
+    function getBaseUrl(url: string) {
+      const pathArray = url.split('/');
+      // Hotfix for juno but not generic
+      const net = pathArray[3].includes('juno') ? `${pathArray[3]}` : '';
+      return `${pathArray[0]}//${pathArray[2]}/${net}`;
+    }
+    const result = await Promise.all(
+      Object.keys(constants.RPC_NODES).map(async (network: any) => {
+        return Promise.all(
+          constants.RPC_NODES[network as keyof typeof constants.RPC_NODES].map(async (it: any) => {
+            const provider = new Provider({ nodeUrl: getBaseUrl(it) });
+            return {
+              network,
+              nodeUrl: provider.channel.nodeUrl,
+              version: await provider.getSpecVersion(),
+            };
+          })
+        );
+      })
+    );
+
+    console.table(result.flat());
+  });
+});


### PR DESCRIPTION
## Motivation and Resolution
This issue https://github.com/starknet-io/starknet.js/issues/1058 motivated me to add a test for the default RPC version defined by lib and the default RPC version server by RPC.

This test does not ensure any security just print results.
Could we maybe add some CI warning or action for testing RPC versions?
We could set expectations in this two tests like
- we expect 0.7 as the default version from RPC on base route
- we expect 0.7 as the lib default version and all rpc should have 0.7 implemented

Some feedback @ivpavici @penovicp 

### RPC version (if applicable)
Ensure and Test RPC Providers

## Checklist:

- [ ] Performed a self-review of the code
- [ ] Rebased to the last commit of the target branch (or merged it into my branch)
- [ ] Linked the issues which this PR resolves
- [ ] Documented the changes in code (API docs will be generated automatically)
- [ ] Updated the tests
- [ ] All tests are passing
