### PR TITLE
Export function parseCalldataField()

### DIFF
--- a/src/utils/calldata/index.ts
+++ b/src/utils/calldata/index.ts
@@ -37,6 +37,7 @@ import validateFields from './validate';
 
 export * as cairo from './cairo';
 export * as byteArray from './byteArray';
+export * as calldata from './requestParser';
 
 export class CallData {
   abi: Abi;


### PR DESCRIPTION
## Motivation and Resolution
Solve issue #1073

## Usage related changes
can now use :
```typescript
import { calldata } from "starknet";
const res = calldata.parseCalldataField(...);
```

## Development related changes
Export the function `parseCalldataField` from `requestParser.ts`
Exported in `calldata` namespace.

## Checklist:

- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Linked the issues which this PR resolves
- [x] All tests are passing
