### PR TITLE
fix in doc: word <any> not authorized in jsdoc

### DIFF
--- a/src/utils/calldata/requestParser.ts
+++ b/src/utils/calldata/requestParser.ts
@@ -270,7 +270,7 @@ function parseCalldataValue(
 /**
  * Parse one field of the calldata by using input field from the abi for that method
  *
- * @param argsIterator - Iterator<any> for value of the field
+ * @param argsIterator - Iterator for value of the field
  * @param input  - input(field) information from the abi that will be used to parse the data
  * @param structs - structs from abi
  * @param enums - enums from abi


### PR DESCRIPTION
## Motivation and Resolution
Documentation site build is generating an error : 
```
SyntaxError: /D/starknetFork/starknet.js/www/docs/API/modules.md: Expected corresponding JSX closing tag for <any>. (976:86)
```
The problem is in the JSDoc of `export function parseCalldataField()`, where the word `<any>` is not authorized.

## Usage related changes
N/A

## Development related changes
N/A

## Checklist:

- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Documented the changes in code (API docs will be generated automatically)
- [x] All tests are passing
