### PR TITLE
fix: remove [warning] from typedoc for external usage

### DIFF
--- a/src/account/interface.ts
+++ b/src/account/interface.ts
@@ -147,11 +147,11 @@ export abstract class AccountInterface extends ProviderInterface {
    * Estimate Fee for executing a list of transactions on starknet
    * Contract must be deployed for fee estimation to be possible
    *
-   * @param transactions array of transaction object containing :
+   * @param invocations array of transaction object containing :
    * - type - the type of transaction : 'DECLARE' | (multi)'DEPLOY' | (multi)'INVOKE_FUNCTION' | 'DEPLOY_ACCOUNT'
    * - payload - the payload of the transaction
    *
-   *  @param estimateFeeDetails -
+   *  @param details -
    * - blockIdentifier?
    * - nonce?
    * - skipValidate? - default true
@@ -344,32 +344,32 @@ export abstract class AccountInterface extends ProviderInterface {
   ): Promise<DeployContractResponse>;
 
   /**
-   * Signs a JSON object for off-chain usage with the Starknet private key and returns the signature
+   * Signs a TypedData object for off-chain usage with the Starknet private key and returns the signature
    * This adds a message prefix so it can't be interchanged with transactions
    *
-   * @param json - JSON object to be signed
-   * @returns the signature of the JSON object
-   * @throws {Error} if the JSON object is not a valid JSON
+   * @param typedData The TypedData object to be signed
+   * @returns the signature of the TypedData object
+   * @throws {Error} if the typedData is not a valid TypedData
    */
   public abstract signMessage(typedData: TypedData): Promise<Signature>;
 
   /**
-   * Hash a JSON object with Pedersen hash and return the hash
+   * Hash a TypedData object with Pedersen hash and return the hash
    * This adds a message prefix so it can't be interchanged with transactions
    *
-   * @param json - JSON object to be hashed
-   * @returns the hash of the JSON object
-   * @throws {Error} if the JSON object is not a valid JSON
+   * @param typedData The TypedData object to hash
+   * @returns the hash of the TypedData object
+   * @throws {Error} if typedData is not a valid TypedData
    */
   public abstract hashMessage(typedData: TypedData): Promise<string>;
 
   /**
-   * Verify a signature of a JSON object
+   * Verify a signature of a TypedData object
    *
-   * @param typedData - JSON object to be verified
-   * @param signature - signature of the JSON object
+   * @param typedData the TypedData object to be verified
+   * @param signature signature of the TypedData object
    * @returns true if the signature is valid, false otherwise
-   * @throws {Error} if the JSON object is not a valid JSON or the signature is not a valid signature
+   * @throws {Error} if typedData is not a valid TypedData or the signature is not a valid signature
    */
   public abstract verifyMessage(typedData: TypedData, signature: Signature): Promise<boolean>;
 
@@ -377,8 +377,8 @@ export abstract class AccountInterface extends ProviderInterface {
    * Verify a signature of a given hash
    * @warning This method is not recommended, use verifyMessage instead
    *
-   * @param hash - hash to be verified
-   * @param signature - signature of the hash
+   * @param hash hash to be verified
+   * @param signature signature of the hash
    * @returns true if the signature is valid, false otherwise
    * @throws {Error} if the signature is not a valid signature
    */
@@ -387,7 +387,7 @@ export abstract class AccountInterface extends ProviderInterface {
   /**
    * Gets the nonce of the account with respect to a specific block
    *
-   * @param  {BlockIdentifier} blockIdentifier - optional blockIdentifier. Defaults to 'pending'
+   * @param  {BlockIdentifier} blockIdentifier optional blockIdentifier. Defaults to 'pending'
    * @returns nonce of the account
    */
   public abstract getNonce(blockIdentifier?: BlockIdentifier): Promise<Nonce>;

--- a/src/channel/rpc_0_6.ts
+++ b/src/channel/rpc_0_6.ts
@@ -222,12 +222,13 @@ export class RpcChannel {
    */
   public simulateTransaction(
     invocations: AccountInvocations,
-    {
+    simulateTransactionOptions: getSimulateTransactionOptions = {}
+  ) {
+    const {
       blockIdentifier = this.blockIdentifier,
       skipValidate = true,
       skipFeeCharge = true,
-    }: getSimulateTransactionOptions = {}
-  ) {
+    } = simulateTransactionOptions;
     const block_id = new Block(blockIdentifier).identifier;
     const simulationFlags: RPC.ESimulationFlag[] = [];
     if (skipValidate) simulationFlags.push(RPC.ESimulationFlag.SKIP_VALIDATE);

--- a/src/channel/rpc_0_7.ts
+++ b/src/channel/rpc_0_7.ts
@@ -227,12 +227,13 @@ export class RpcChannel {
    */
   public simulateTransaction(
     invocations: AccountInvocations,
-    {
+    simulateTransactionOptions: getSimulateTransactionOptions = {}
+  ) {
+    const {
       blockIdentifier = this.blockIdentifier,
       skipValidate = true,
       skipFeeCharge = true,
-    }: getSimulateTransactionOptions = {}
-  ) {
+    } = simulateTransactionOptions;
     const block_id = new Block(blockIdentifier).identifier;
     const simulationFlags: RPC.ESimulationFlag[] = [];
     if (skipValidate) simulationFlags.push(RPC.ESimulationFlag.SKIP_VALIDATE);

--- a/src/provider/interface.ts
+++ b/src/provider/interface.ts
@@ -61,8 +61,7 @@ export abstract class ProviderInterface {
    * @param blockIdentifier block identifier
    * @returns the block object
    */
-  public abstract getBlock(): Promise<PendingBlock>;
-  public abstract getBlock(blockIdentifier: 'pending'): Promise<PendingBlock>;
+  public abstract getBlock(blockIdentifier?: 'pending'): Promise<PendingBlock>;
   public abstract getBlock(blockIdentifier: 'latest'): Promise<Block>;
   public abstract getBlock(blockIdentifier: BlockIdentifier): Promise<GetBlockResponse>;
 
@@ -126,7 +125,7 @@ export abstract class ProviderInterface {
   /**
    * Gets the transaction information from a tx id.
    *
-   * @param txHash
+   * @param transactionHash
    * @returns the transaction object \{ transaction_id, status, transaction, block_number?, block_number?, transaction_index?, transaction_failure_reason? \}
    */
   public abstract getTransaction(transactionHash: BigNumberish): Promise<GetTransactionResponse>;
@@ -134,7 +133,7 @@ export abstract class ProviderInterface {
   /**
    * Gets the transaction receipt from a tx hash.
    *
-   * @param txHash
+   * @param transactionHash
    * @returns the transaction receipt object
    */
   public abstract getTransactionReceipt(

--- a/src/provider/rpc.ts
+++ b/src/provider/rpc.ts
@@ -169,7 +169,7 @@ export class RpcProvider implements ProviderInterface {
 
   /**
    * @param invocations AccountInvocations
-   * @param simulateTransactionOptions blockIdentifier and flags to skip validation and fee charge<br/>
+   * @param options blockIdentifier and flags to skip validation and fee charge<br/>
    * - blockIdentifier<br/>
    * - skipValidate (default false)<br/>
    * - skipFeeCharge (default true)<br/>

--- a/src/signer/interface.ts
+++ b/src/signer/interface.ts
@@ -47,7 +47,7 @@ export abstract class SignerInterface {
   /**
    * Signs a DEPLOY_ACCOUNT transaction with the Starknet private key and returns the signature
    *
-   * @param transaction<br/>
+   * @param transaction <br/>
    * - contractAddress<br/>
    * - chainId<br/>
    * - classHash<br/>
@@ -64,7 +64,7 @@ export abstract class SignerInterface {
   /**
    * Signs a DECLARE transaction with the Starknet private key and returns the signature
    *
-   * @param transaction<br/>
+   * @param transaction <br/>
    * - classHash<br/>
    * - compiledClassHash? - used for Cairo1<br/>
    * - senderAddress<br/>

--- a/src/types/account.ts
+++ b/src/types/account.ts
@@ -76,11 +76,6 @@ export type SimulateTransactionDetails = {
   skipExecute?: boolean;
 } & Partial<V3TransactionDetails>;
 
-export enum SIMULATION_FLAG {
-  SKIP_VALIDATE = 'SKIP_VALIDATE',
-  SKIP_EXECUTE = 'SKIP_EXECUTE',
-}
-
 export type EstimateFeeAction =
   | {
       type: TransactionType.INVOKE;

--- a/src/types/api/rpcspec_0_6/contract.ts
+++ b/src/types/api/rpcspec_0_6/contract.ts
@@ -11,7 +11,7 @@ export type ABI = Array<
   FUNCTION | CONSTRUCTOR | L1_HANDLER | EVENT | STRUCT | ENUM | INTERFACE | IMPL
 >;
 
-type FUNCTION = {
+export type FUNCTION = {
   type: 'function';
   name: string;
   inputs: Array<{
@@ -24,7 +24,7 @@ type FUNCTION = {
   state_mutability: 'view' | 'external';
 };
 
-type CONSTRUCTOR = {
+export type CONSTRUCTOR = {
   type: 'constructor';
   name: 'constructor';
   inputs: Array<{
@@ -33,7 +33,7 @@ type CONSTRUCTOR = {
   }>;
 };
 
-type L1_HANDLER = {
+export type L1_HANDLER = {
   type: 'l1_handler';
   name: string;
   inputs: Array<{
@@ -46,22 +46,22 @@ type L1_HANDLER = {
   state_mutability: 'view' | 'external';
 };
 
-type EVENT = {
+export type EVENT = {
   type: 'event';
   name: string;
 } & (ENUM_EVENT | STRUCT_EVENT);
 
-type STRUCT_EVENT = {
+export type STRUCT_EVENT = {
   kind: 'struct';
   members: Array<EVENT_FIELD>;
 };
 
-type ENUM_EVENT = {
+export type ENUM_EVENT = {
   kind: 'enum';
   variants: Array<EVENT_FIELD>;
 };
 
-type STRUCT = {
+export type STRUCT = {
   type: 'struct';
   name: string;
   members: Array<{
@@ -70,7 +70,7 @@ type STRUCT = {
   }>;
 };
 
-type ENUM = {
+export type ENUM = {
   type: 'enum';
   name: string;
   variants: Array<{
@@ -79,13 +79,13 @@ type ENUM = {
   }>;
 };
 
-type INTERFACE = {
+export type INTERFACE = {
   type: 'interface';
   name: string;
   items: Array<FUNCTION>;
 };
 
-type IMPL = {
+export type IMPL = {
   type: 'impl';
   name: string;
   interface_name: string;
@@ -94,7 +94,7 @@ type IMPL = {
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 type EVENT_KIND = 'struct' | 'enum';
 
-type EVENT_FIELD = {
+export type EVENT_FIELD = {
   name: string;
   type: string;
   kind: 'key' | 'data' | 'nested';

--- a/src/types/api/rpcspec_0_6/index.ts
+++ b/src/types/api/rpcspec_0_6/index.ts
@@ -2,8 +2,8 @@
  * version 0.6.0
  */
 
-export { Methods } from './methods';
-export { ABI } from './contract';
+export * from './methods';
+export * from './contract';
 export * as Errors from './errors';
 export * as SPEC from './components';
 export * from './nonspec';

--- a/src/types/api/rpcspec_0_6/methods.ts
+++ b/src/types/api/rpcspec_0_6/methods.ts
@@ -41,7 +41,7 @@ import {
 
 export type Methods = ReadMethods & WriteMethods & TraceMethods;
 
-type ReadMethods = {
+export type ReadMethods = {
   // Returns the version of the Starknet JSON-RPC specification being used
   starknet_specVersion: {
     params: [];
@@ -243,7 +243,7 @@ type ReadMethods = {
   };
 };
 
-type WriteMethods = {
+export type WriteMethods = {
   // Submit a new transaction to be added to the chain
   starknet_addInvokeTransaction: {
     params: {
@@ -302,7 +302,7 @@ type WriteMethods = {
   };
 };
 
-type TraceMethods = {
+export type TraceMethods = {
   // For a given executed transaction, return the trace of its execution, including internal calls
   starknet_traceTransaction: {
     params: { transaction_hash: TXN_HASH };

--- a/src/types/api/rpcspec_0_7/index.ts
+++ b/src/types/api/rpcspec_0_7/index.ts
@@ -2,7 +2,7 @@
  * version v0.7.0-rc1
  */
 
-export { Methods } from './methods';
+export * from './methods';
 export { ABI } from './contract';
 export * as Errors from './errors';
 export * as SPEC from './components';

--- a/src/types/api/rpcspec_0_7/methods.ts
+++ b/src/types/api/rpcspec_0_7/methods.ts
@@ -42,7 +42,7 @@ import {
 
 export type Methods = ReadMethods & WriteMethods & TraceMethods;
 
-type ReadMethods = {
+export type ReadMethods = {
   // Returns the version of the Starknet JSON-RPC specification being used
   starknet_specVersion: {
     params: [];
@@ -253,7 +253,7 @@ type ReadMethods = {
   };
 };
 
-type WriteMethods = {
+export type WriteMethods = {
   // Submit a new transaction to be added to the chain
   starknet_addInvokeTransaction: {
     params: {
@@ -312,7 +312,7 @@ type WriteMethods = {
   };
 };
 
-type TraceMethods = {
+export type TraceMethods = {
   // For a given executed transaction, return the trace of its execution, including internal calls
   starknet_traceTransaction: {
     params: { transaction_hash: TXN_HASH };

--- a/src/types/lib/contract/abi.ts
+++ b/src/types/lib/contract/abi.ts
@@ -6,7 +6,7 @@ export type AbiEntry = { name: string; type: 'felt' | 'felt*' | string };
 
 export type EventEntry = { name: string; type: 'felt' | 'felt*' | string; kind: 'key' | 'data' };
 
-enum FunctionAbiType {
+export enum FunctionAbiType {
   'function',
   'l1_handler',
   'constructor',

--- a/src/types/provider/response.ts
+++ b/src/types/provider/response.ts
@@ -37,6 +37,8 @@ import {
   TransactionWithHash,
 } from './spec';
 
+export type { BLOCK_HASH, BLOCK_NUMBER, RESOURCE_PRICE, TXN_HASH };
+
 export { BlockWithTxHashes, ContractClassPayload, FeeEstimate, TransactionReceipt } from './spec';
 
 export type GetBlockResponse = PendingBlock | Block;
@@ -102,18 +104,24 @@ export type SuccessfulTransactionReceiptResponse =
   | DeployTransactionReceiptResponse
   | DeclareTransactionReceiptResponse;
 
+export type { TransactionWithHash };
 export type GetTransactionResponse = TransactionWithHash;
 // Spread individual types for usage convenience
+export type { INVOKE_TXN_RECEIPT, PENDING_INVOKE_TXN_RECEIPT };
 export type InvokeTransactionReceiptResponse = INVOKE_TXN_RECEIPT | PENDING_INVOKE_TXN_RECEIPT;
+export type { DECLARE_TXN_RECEIPT, PENDING_DECLARE_TXN_RECEIPT };
 export type DeclareTransactionReceiptResponse = DECLARE_TXN_RECEIPT | PENDING_DECLARE_TXN_RECEIPT;
 export type DeployTransactionReceiptResponse = InvokeTransactionReceiptResponse;
+export type { DEPLOY_ACCOUNT_TXN_RECEIPT, PENDING_DEPLOY_ACCOUNT_TXN_RECEIPT };
 export type DeployAccountTransactionReceiptResponse =
   | DEPLOY_ACCOUNT_TXN_RECEIPT
   | PENDING_DEPLOY_ACCOUNT_TXN_RECEIPT;
+export type { L1_HANDLER_TXN_RECEIPT, PENDING_L1_HANDLER_TXN_RECEIPT };
 export type L1HandlerTransactionReceiptResponse =
   | L1_HANDLER_TXN_RECEIPT
   | PENDING_L1_HANDLER_TXN_RECEIPT;
 
+export type { PRICE_UNIT };
 export interface EstimateFeeResponse {
   gas_consumed: bigint;
   overall_fee: bigint;
@@ -127,18 +135,23 @@ export interface EstimateFeeResponse {
 
 export type EstimateFeeResponseBulk = Array<EstimateFeeResponse>;
 
+export type { InvokedTransaction };
 export type InvokeFunctionResponse = InvokedTransaction;
 
+export type { DeclaredTransaction };
 export type DeclareContractResponse = DeclaredTransaction;
 
 export type CallContractResponse = string[];
 
+export type { FELT };
 export type Storage = FELT;
 
 export type Nonce = string;
 
+export type { SIMULATION_FLAG };
 export type SimulationFlags = Array<SIMULATION_FLAG>;
 
+export type { SimulateTransaction, ResourceBounds };
 export type SimulatedTransaction = SimulateTransaction & {
   suggestedMaxFee: bigint;
   resourceBounds: ResourceBounds;
@@ -147,7 +160,9 @@ export type SimulatedTransaction = SimulateTransaction & {
 export type SimulateTransactionResponse = SimulatedTransaction[];
 
 export type StateUpdateResponse = StateUpdate | PendingStateUpdate;
+export type { STATE_UPDATE };
 export type StateUpdate = STATE_UPDATE;
+export type { PENDING_STATE_UPDATE };
 export type PendingStateUpdate = PENDING_STATE_UPDATE;
 
 /**

--- a/src/utils/calldata/byteArray.ts
+++ b/src/utils/calldata/byteArray.ts
@@ -32,7 +32,7 @@ export function stringFromByteArray(myByteArray: ByteArray): string {
 
 /**
  * convert a JS string to a Cairo ByteArray
- * @param myString a JS string
+ * @param targetString a JS string
  * @returns Cairo representation of a LongString
  * @example
  * ```typescript

--- a/src/utils/calldata/index.ts
+++ b/src/utils/calldata/index.ts
@@ -38,6 +38,7 @@ import validateFields from './validate';
 export * as cairo from './cairo';
 export * as byteArray from './byteArray';
 
+export { AbiParserInterface };
 export class CallData {
   abi: Abi;
 
@@ -103,7 +104,7 @@ export class CallData {
    * Compile contract callData with abi
    * Parse the calldata by using input fields from the abi for that method
    * @param method string - method name
-   * @param args RawArgs - arguments passed to the method. Can be an array of arguments (in the order of abi definition), or an object constructed in conformity with abi (in this case, the parameter can be in a wrong order).
+   * @param argsCalldata RawArgs - arguments passed to the method. Can be an array of arguments (in the order of abi definition), or an object constructed in conformity with abi (in this case, the parameter can be in a wrong order).
    * @return Calldata - parsed arguments in format that contract is expecting
    * @example
    * ```typescript

--- a/src/utils/hash/transactionHash/index.ts
+++ b/src/utils/hash/transactionHash/index.ts
@@ -32,7 +32,7 @@ function isV3InvokeTx(args: CalcInvokeTxHashArgs): args is CalcV3InvokeTxHashArg
   );
 }
 
-type CalcV2InvokeTxHashArgs = {
+export type CalcV2InvokeTxHashArgs = {
   senderAddress: BigNumberish;
   version: `${ETransactionVersion2}`;
   compiledCalldata: Calldata;
@@ -41,7 +41,7 @@ type CalcV2InvokeTxHashArgs = {
   nonce: BigNumberish;
 };
 
-type CalcV3InvokeTxHashArgs = {
+export type CalcV3InvokeTxHashArgs = {
   senderAddress: BigNumberish;
   version: `${ETransactionVersion3}`;
   compiledCalldata: Calldata;
@@ -55,7 +55,7 @@ type CalcV3InvokeTxHashArgs = {
   paymasterData: BigNumberish[];
 };
 
-type CalcInvokeTxHashArgs = CalcV2InvokeTxHashArgs | CalcV3InvokeTxHashArgs;
+export type CalcInvokeTxHashArgs = CalcV2InvokeTxHashArgs | CalcV3InvokeTxHashArgs;
 
 export function calculateInvokeTransactionHash(args: CalcInvokeTxHashArgs) {
   if (isV3InvokeTx(args)) {
@@ -92,7 +92,7 @@ function isV3DeclareTx(args: CalcDeclareTxHashArgs): args is CalcV3DeclareTxHash
   );
 }
 
-type CalcV2DeclareTxHashArgs = {
+export type CalcV2DeclareTxHashArgs = {
   classHash: string;
   senderAddress: BigNumberish;
   version: `${ETransactionVersion2}`;
@@ -102,7 +102,7 @@ type CalcV2DeclareTxHashArgs = {
   compiledClassHash?: string;
 };
 
-type CalcV3DeclareTxHashArgs = {
+export type CalcV3DeclareTxHashArgs = {
   classHash: string;
   compiledClassHash: string;
   senderAddress: BigNumberish;
@@ -117,7 +117,7 @@ type CalcV3DeclareTxHashArgs = {
   paymasterData: BigNumberish[];
 };
 
-type CalcDeclareTxHashArgs = CalcV2DeclareTxHashArgs | CalcV3DeclareTxHashArgs;
+export type CalcDeclareTxHashArgs = CalcV2DeclareTxHashArgs | CalcV3DeclareTxHashArgs;
 
 export function calculateDeclareTransactionHash(args: CalcDeclareTxHashArgs) {
   if (isV3DeclareTx(args)) {
@@ -160,7 +160,7 @@ function isV3DeployAccountTx(
   );
 }
 
-type CalcV2DeployAccountTxHashArgs = {
+export type CalcV2DeployAccountTxHashArgs = {
   contractAddress: BigNumberish;
   classHash: BigNumberish;
   constructorCalldata: Calldata;
@@ -171,7 +171,7 @@ type CalcV2DeployAccountTxHashArgs = {
   nonce: BigNumberish;
 };
 
-type CalcV3DeployAccountTxHashArgs = {
+export type CalcV3DeployAccountTxHashArgs = {
   contractAddress: BigNumberish;
   classHash: BigNumberish;
   compiledConstructorCalldata: Calldata;
@@ -186,7 +186,9 @@ type CalcV3DeployAccountTxHashArgs = {
   paymasterData: BigNumberish[];
 };
 
-type CalcDeployAccountTxHashArgs = CalcV2DeployAccountTxHashArgs | CalcV3DeployAccountTxHashArgs;
+export type CalcDeployAccountTxHashArgs =
+  | CalcV2DeployAccountTxHashArgs
+  | CalcV3DeployAccountTxHashArgs;
 
 export function calculateDeployAccountTransactionHash(args: CalcDeployAccountTxHashArgs) {
   if (isV3DeployAccountTx(args)) {

--- a/src/utils/typedData.ts
+++ b/src/utils/typedData.ts
@@ -24,7 +24,7 @@ import { encodeShortString, isString } from './shortString';
 /** @deprecated prefer importing from 'types' over 'typedData' */
 export * from '../types/typedData';
 
-interface Context {
+export interface Context {
   parent?: string;
   key?: string;
 }

--- a/src/wallet/account.ts
+++ b/src/wallet/account.ts
@@ -39,6 +39,7 @@ import {
 import { StarknetWalletProvider } from './types';
 import { StarknetChainId } from '../constants';
 
+export { StarknetWalletProvider };
 // Represent 'Selected Active' Account inside Connected Wallet
 export class WalletAccount extends Account implements AccountInterface {
   public address: string = '';

--- a/src/wallet/connect.ts
+++ b/src/wallet/connect.ts
@@ -135,7 +135,8 @@ export function addDeployAccountTransaction(
 
 /**
  * Sign typed data using the wallet.
- * @param params The typed data to sign.
+ * @param swo the starknet (wallet) window object to request the signature.
+ * @param typedData The typed data to sign.
  * @returns An array of signatures as strings.
  */
 export function signMessage(swo: StarknetWindowObject, typedData: TypedData) {


### PR DESCRIPTION
running `npx typedoc --entryPoints src --out build` generates a number of warnings that are addressed here. This goes from misnamed or unnamed function parameters to exported types with unexported referenced types.

## Motivation and Resolution

This PR addresses a number of [warning] reported by `typedoc` some of which that are small enhancement to use the starknet.js library, including:
- renaming @param to match the function spec
- naming function parameters
- exporting underlying type with exposed type to ease the use for external projects

### RPC version (if applicable)

0.6 and 0.7

## Usage related changes

None

## Development related changes

None

## Checklist:

- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [ ] Linked the issues which this PR resolves
- [x] Documented the changes in code (API docs will be generated automatically)
- [ ] Updated the tests
- [ ] All tests are passing
