### PR TITLE
fix: remove [warning] from typedoc for external usage

### DIFF
--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -21,7 +21,7 @@ jobs:
     # TODO - periodically check if conditional services are supported; https://github.com/actions/runner/issues/822
     services:
       devnet:
-        image: ${{ (inputs.use-devnet) && 'shardlabs/starknet-devnet-rs:0.0.4-seed0' || '' }}
+        image: ${{ (inputs.use-devnet) && 'shardlabs/starknet-devnet-rs:0.0.5-seed0' || '' }}
         ports:
           - 5050:5050
 

--- a/src/account/interface.ts
+++ b/src/account/interface.ts
@@ -147,11 +147,11 @@ export abstract class AccountInterface extends ProviderInterface {
    * Estimate Fee for executing a list of transactions on starknet
    * Contract must be deployed for fee estimation to be possible
    *
-   * @param transactions array of transaction object containing :
+   * @param invocations array of transaction object containing :
    * - type - the type of transaction : 'DECLARE' | (multi)'DEPLOY' | (multi)'INVOKE_FUNCTION' | 'DEPLOY_ACCOUNT'
    * - payload - the payload of the transaction
    *
-   *  @param estimateFeeDetails -
+   *  @param details -
    * - blockIdentifier?
    * - nonce?
    * - skipValidate? - default true
@@ -344,34 +344,34 @@ export abstract class AccountInterface extends ProviderInterface {
   ): Promise<DeployContractResponse>;
 
   /**
-   * Signs a JSON object for off-chain usage with the Starknet private key and returns the signature
+   * Signs a TypedData object for off-chain usage with the Starknet private key and returns the signature
    * This adds a message prefix so it can't be interchanged with transactions
    *
-   * @param json - JSON object to be signed
-   * @returns the signature of the JSON object
-   * @throws {Error} if the JSON object is not a valid JSON
+   * @param typedData - TypedData object to be signed
+   * @returns the signature of the TypedData object
+   * @throws {Error} if typedData is not a valid TypedData
    */
   public abstract signMessage(typedData: TypedData): Promise<Signature>;
 
   /**
-   * Hash a JSON object with Pedersen hash and return the hash
+   * Hash a TypedData object with Pedersen hash and return the hash
    * This adds a message prefix so it can't be interchanged with transactions
    *
-   * @param json - JSON object to be hashed
-   * @returns the hash of the JSON object
-   * @throws {Error} if the JSON object is not a valid JSON
+   * @param typedData - TypedData object to be hashed
+   * @returns the hash of the TypedData object
+   * @throws {Error} if typedData is not a valid TypedData
    */
   public abstract hashMessage(typedData: TypedData): Promise<string>;
 
   /**
-   * Verify a signature of a JSON object
+   * Verify a signature of a TypedData object
    *
-   * @param typedData - JSON object to be verified
-   * @param signature - signature of the JSON object
+   * @param typedData - TypedData object to be verified
+   * @param signature - signature of the TypedData object
    * @param signatureVerificationFunctionName - optional account contract verification function name override
    * @param signatureVerificationResponse - optional response override { okResponse: string[]; nokResponse: string[]; error: string[] }
    * @returns true if the signature is valid, false otherwise
-   * @throws {Error} if the JSON object is not a valid JSON or the signature is not a valid signature
+   * @throws {Error} if typedData is not a valid TypedData or the signature is not a valid signature
    */
   public abstract verifyMessage(typedData: TypedData, signature: Signature): Promise<boolean>;
 

--- a/src/channel/rpc_0_6.ts
+++ b/src/channel/rpc_0_6.ts
@@ -222,12 +222,13 @@ export class RpcChannel {
    */
   public simulateTransaction(
     invocations: AccountInvocations,
-    {
+    simulateTransactionOptions: getSimulateTransactionOptions = {}
+  ) {
+    const {
       blockIdentifier = this.blockIdentifier,
       skipValidate = true,
       skipFeeCharge = true,
-    }: getSimulateTransactionOptions = {}
-  ) {
+    } = simulateTransactionOptions;
     const block_id = new Block(blockIdentifier).identifier;
     const simulationFlags: RPC.ESimulationFlag[] = [];
     if (skipValidate) simulationFlags.push(RPC.ESimulationFlag.SKIP_VALIDATE);

--- a/src/channel/rpc_0_7.ts
+++ b/src/channel/rpc_0_7.ts
@@ -242,12 +242,13 @@ export class RpcChannel {
    */
   public simulateTransaction(
     invocations: AccountInvocations,
-    {
+    simulateTransactionOptions: getSimulateTransactionOptions = {}
+  ) {
+    const {
       blockIdentifier = this.blockIdentifier,
       skipValidate = true,
       skipFeeCharge = true,
-    }: getSimulateTransactionOptions = {}
-  ) {
+    } = simulateTransactionOptions;
     const block_id = new Block(blockIdentifier).identifier;
     const simulationFlags: RPC.ESimulationFlag[] = [];
     if (skipValidate) simulationFlags.push(RPC.ESimulationFlag.SKIP_VALIDATE);

--- a/src/channel/rpc_0_7.ts
+++ b/src/channel/rpc_0_7.ts
@@ -50,11 +50,21 @@ export class RpcChannel {
 
   private specVersion?: string;
 
+  private transactionRetryIntervalFallback?: number;
+
   readonly waitMode: Boolean; // behave like web2 rpc and return when tx is processed
 
   constructor(optionsOrProvider?: RpcProviderOptions) {
-    const { nodeUrl, retries, headers, blockIdentifier, chainId, specVersion, waitMode } =
-      optionsOrProvider || {};
+    const {
+      nodeUrl,
+      retries,
+      headers,
+      blockIdentifier,
+      chainId,
+      specVersion,
+      waitMode,
+      transactionRetryIntervalFallback,
+    } = optionsOrProvider || {};
     if (Object.values(NetworkName).includes(nodeUrl as NetworkName)) {
       this.nodeUrl = getDefaultNodeUrl(nodeUrl as NetworkName, optionsOrProvider?.default);
     } else if (nodeUrl) {
@@ -69,6 +79,11 @@ export class RpcChannel {
     this.specVersion = specVersion;
     this.waitMode = waitMode || false;
     this.requestId = 0;
+    this.transactionRetryIntervalFallback = transactionRetryIntervalFallback;
+  }
+
+  private get transactionRetryIntervalDefault() {
+    return this.transactionRetryIntervalFallback ?? 5000;
   }
 
   public setChainId(chainId: StarknetChainId) {
@@ -250,7 +265,7 @@ export class RpcChannel {
     let { retries } = this;
     let onchain = false;
     let isErrorState = false;
-    const retryInterval = options?.retryInterval ?? 5000;
+    const retryInterval = options?.retryInterval ?? this.transactionRetryIntervalDefault;
     const errorStates: any = options?.errorStates ?? [
       RPC.ETransactionStatus.REJECTED,
       // TODO: commented out to preserve the long-standing behavior of "reverted" not being treated as an error by default

--- a/src/provider/interface.ts
+++ b/src/provider/interface.ts
@@ -134,7 +134,7 @@ export abstract class ProviderInterface {
   /**
    * Gets the transaction information from a tx id.
    *
-   * @param txHash
+   * @param transactionHash
    * @returns the transaction object \{ transaction_id, status, transaction, block_number?, block_number?, transaction_index?, transaction_failure_reason? \}
    */
   public abstract getTransaction(transactionHash: BigNumberish): Promise<GetTransactionResponse>;
@@ -142,7 +142,7 @@ export abstract class ProviderInterface {
   /**
    * Gets the transaction receipt from a tx hash.
    *
-   * @param txHash
+   * @param transactionHash
    * @returns the transaction receipt object
    */
   public abstract getTransactionReceipt(

--- a/src/provider/interface.ts
+++ b/src/provider/interface.ts
@@ -61,8 +61,7 @@ export abstract class ProviderInterface {
    * @param blockIdentifier block identifier
    * @returns the block object
    */
-  public abstract getBlock(): Promise<PendingBlock>;
-  public abstract getBlock(blockIdentifier: 'pending'): Promise<PendingBlock>;
+  public abstract getBlock(blockIdentifier?: 'pending'): Promise<PendingBlock>;
   public abstract getBlock(blockIdentifier: 'latest'): Promise<Block>;
   public abstract getBlock(blockIdentifier: BlockIdentifier): Promise<GetBlockResponse>;
 

--- a/src/provider/rpc.ts
+++ b/src/provider/rpc.ts
@@ -176,7 +176,7 @@ export class RpcProvider implements ProviderInterface {
 
   /**
    * @param invocations AccountInvocations
-   * @param simulateTransactionOptions blockIdentifier and flags to skip validation and fee charge<br/>
+   * @param options blockIdentifier and flags to skip validation and fee charge<br/>
    * - blockIdentifier<br/>
    * - skipValidate (default false)<br/>
    * - skipFeeCharge (default true)<br/>

--- a/src/provider/rpc.ts
+++ b/src/provider/rpc.ts
@@ -199,6 +199,7 @@ export class RpcProvider implements ProviderInterface {
       txHash,
       options
     )) as GetTxReceiptResponseWithoutHelper;
+
     return new ReceiptTx(receiptWoHelper) as GetTransactionReceiptResponse;
   }
 

--- a/src/signer/interface.ts
+++ b/src/signer/interface.ts
@@ -47,7 +47,7 @@ export abstract class SignerInterface {
   /**
    * Signs a DEPLOY_ACCOUNT transaction with the Starknet private key and returns the signature
    *
-   * @param transaction<br/>
+   * @param transaction <br/>
    * - contractAddress<br/>
    * - chainId<br/>
    * - classHash<br/>
@@ -64,7 +64,7 @@ export abstract class SignerInterface {
   /**
    * Signs a DECLARE transaction with the Starknet private key and returns the signature
    *
-   * @param transaction<br/>
+   * @param transaction <br/>
    * - classHash<br/>
    * - compiledClassHash? - used for Cairo1<br/>
    * - senderAddress<br/>

--- a/src/types/account.ts
+++ b/src/types/account.ts
@@ -76,11 +76,6 @@ export type SimulateTransactionDetails = {
   skipExecute?: boolean;
 } & Partial<V3TransactionDetails>;
 
-export enum SIMULATION_FLAG {
-  SKIP_VALIDATE = 'SKIP_VALIDATE',
-  SKIP_EXECUTE = 'SKIP_EXECUTE',
-}
-
 export type EstimateFeeAction =
   | {
       type: TransactionType.INVOKE;

--- a/src/types/provider/configuration.ts
+++ b/src/types/provider/configuration.ts
@@ -6,6 +6,7 @@ export interface ProviderOptions extends RpcProviderOptions {}
 export type RpcProviderOptions = {
   nodeUrl?: string | NetworkName;
   retries?: number;
+  transactionRetryIntervalFallback?: number;
   headers?: object;
   blockIdentifier?: BlockIdentifier;
   chainId?: StarknetChainId;

--- a/src/types/provider/response.ts
+++ b/src/types/provider/response.ts
@@ -137,6 +137,7 @@ export type Storage = FELT;
 
 export type Nonce = string;
 
+export type { SIMULATION_FLAG };
 export type SimulationFlags = Array<SIMULATION_FLAG>;
 
 export type SimulatedTransaction = SimulateTransaction & {

--- a/src/utils/calldata/byteArray.ts
+++ b/src/utils/calldata/byteArray.ts
@@ -32,7 +32,7 @@ export function stringFromByteArray(myByteArray: ByteArray): string {
 
 /**
  * convert a JS string to a Cairo ByteArray
- * @param myString a JS string
+ * @param targetString a JS string
  * @returns Cairo representation of a LongString
  * @example
  * ```typescript

--- a/src/utils/calldata/index.ts
+++ b/src/utils/calldata/index.ts
@@ -104,7 +104,7 @@ export class CallData {
    * Compile contract callData with abi
    * Parse the calldata by using input fields from the abi for that method
    * @param method string - method name
-   * @param args RawArgs - arguments passed to the method. Can be an array of arguments (in the order of abi definition), or an object constructed in conformity with abi (in this case, the parameter can be in a wrong order).
+   * @param argsCalldata RawArgs - arguments passed to the method. Can be an array of arguments (in the order of abi definition), or an object constructed in conformity with abi (in this case, the parameter can be in a wrong order).
    * @return Calldata - parsed arguments in format that contract is expecting
    * @example
    * ```typescript

--- a/src/wallet/connect.ts
+++ b/src/wallet/connect.ts
@@ -121,7 +121,8 @@ export function addDeclareTransaction(
 
 /**
  * Sign typed data using the wallet.
- * @param params The typed data to sign.
+ * @param swo the starknet (wallet) window object to request the signature.
+ * @param typedData The typed data to sign.
  * @returns An array of signatures as strings.
  */
 export function signMessage(swo: StarknetWindowObject, typedData: TypedData) {


### PR DESCRIPTION
running `npx typedoc --entryPoints src --out build` generates a number of warnings that are addressed here.  This PR replaces #1092. It is based on `next-version` and the changes are now split by commits so that they are easy to understand and if needed can be cherry-picked

## Motivation and Resolution

Some of the issues addressed that are small enhancements to use the starknet.js library. Others are more opinionated or improvements. For a better understanding, changes have been grouped per commits. This is the list of commits and fixes:

- fix: rename the @param to match the definitions
- fix: add a space before typedoc \<br/\> so that it catches the name
- fix: improve function declaration so that typedoc matches it
- fix: reintroduce the parameter name
- fix: remove unused type declaration and export
- ~~fix: export underlying types for RPC 0.6~~
- ~~fix: export the underlying types with the composite types~~

### RPC version (if applicable)

0.6 and 0.7

## Usage related changes

None

## Development related changes

None

## Checklist:

- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [ ] Linked the issues which this PR resolves
- [x] Documented the changes in code (API docs will be generated automatically)
- [ ] Updated the tests
- [ ] All tests are passing
