### PR TITLE
fix: cannot infer (TS2742) types from starknet-types@0.7

### DIFF
--- a/src/account/default.ts
+++ b/src/account/default.ts
@@ -1,3 +1,5 @@
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import type { SPEC } from 'starknet-types-07';
 import { UDC, ZERO } from '../constants';
 import { Provider, ProviderInterface } from '../provider';
 import { Signer, SignerInterface } from '../signer';

--- a/src/utils/stark.ts
+++ b/src/utils/stark.ts
@@ -1,3 +1,5 @@
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import type { SPEC } from 'starknet-types-07';
 import { getStarkKey, utils } from '@scure/starknet';
 import { gzip, ungzip } from 'pako';
 

--- a/src/wallet/account.ts
+++ b/src/wallet/account.ts
@@ -3,6 +3,8 @@ import {
   type AddStarknetChainParameters,
   type NetworkChangeEventHandler,
   type WatchAssetParameters,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  type SPEC,
 } from 'starknet-types-07';
 
 import { Account, AccountInterface } from '../account';

--- a/src/wallet/connect.ts
+++ b/src/wallet/connect.ts
@@ -8,6 +8,8 @@ import {
   type ChainId,
   type StarknetWindowObject,
   type TypedData,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  type SPEC,
 } from 'starknet-types-07';
 
 /**


### PR DESCRIPTION
the externalization of types in starknet-types that come with starknet.js 6.8 prevents typescript from inferring types that are not available in the project. To workaround this issue, this commit declares the SPEC type, helping the typescript inference.

## Motivation and Resolution

The typescript language server reports 4 errors like the one below in the project :

```
The inferred type of 'signMessage' cannot be named without a reference to
'../../node_modules/starknet-types-07/dist/types/api/components'. This is likely
not portable. A type annotation is necessary.ts(2742)
function signMessage(swo: StarknetWindowObject, typedData: TypedData): Promise<SIGNATURE>
```

> Note: this error does not prevent the build

### RPC version (if applicable)

0.7

## Usage related changes

None

## Development related changes

None

## Checklist:

- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [ ] Linked the issues which this PR resolves
- [x] Documented the changes in code (API docs will be generated automatically)
- [ ] Updated the tests
- [ ] All tests are passing
