### PR TITLE
Relocate documentation of Eth priv key randomness

### DIFF
--- a/www/docs/guides/connect_account.md
+++ b/www/docs/guides/connect_account.md
@@ -86,9 +86,3 @@ const myEthAccountAddressInStarknet =
 const myEthSigner = new EthSigner(myEthPrivateKey);
 const myEthAccount = new Account(provider, myEthAccountAddressInStarknet, myEthSigner);
 ```
-
-And if you need a random Ethereum private key:
-
-```typescript
-const myPrivateKey = eth.ethRandomPrivateKey();
-```

--- a/www/docs/guides/create_account.md
+++ b/www/docs/guides/create_account.md
@@ -250,6 +250,14 @@ const contractETHaddress = hash.calculateContractAddressFromHash(
 console.log('Pre-calculated ETH account address =', contractETHaddress);
 ```
 
+> If you need a random Ethereum private key:
+>
+> ```typescript
+> const myPrivateKey = eth.ethRandomPrivateKey();
+> ```
+
+````
+
 Then you have to fund this address.
 
 ### Deployment of the new account
@@ -271,7 +279,7 @@ const { transaction_hash, contract_address } = await ethAccount.deployAccount(
 );
 await provider.waitForTransaction(transaction_hash);
 console.log('✅ New Ethereum account final address =', contract_address);
-```
+````
 
 ## Create your account abstraction
 


### PR DESCRIPTION
## Motivation and Resolution

Documentation of Eth Randomness of private key  is located today in the `connect to an existing account`.
It's better to locate this subject in `Create an account` guide.

## Usage related changes
See above.

## Development related changes
N/A

## Checklist:

- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] All tests are passing
