### PR TITLE
fix: remove default from computeHintedClassHash to be able to export

### DIFF
--- a/src/utils/hash/classHash.ts
+++ b/src/utils/hash/classHash.ts
@@ -135,13 +135,16 @@ export function formatSpaces(json: string): string {
  * Compute hinted class hash for legacy compiled contract (Cairo 0)
  * @param {LegacyCompiledContract} compiledContract
  * @returns {string} hex-string
- * No example, as this function is not exported to user
- */
-export default function computeHintedClassHash(compiledContract: LegacyCompiledContract) {
+ * @example
+ * ```typescript
+ * const compiledCairo0 = json.parse(fs.readFileSync("./cairo0contract.json").toString("ascii"));
+ * const result=hash.computeHintedClassHash(compiledCairo0);
+ * // result = "0x293eabb06955c0a1e55557014675aa4e7a1fd69896147382b29b2b6b166a2ac"
+ * ``` */
+export function computeHintedClassHash(compiledContract: LegacyCompiledContract): string {
   const { abi, program } = compiledContract;
   const contractClass = { abi, program };
   const serializedJson = formatSpaces(stringify(contractClass, nullSkipReplacer));
-
   return addHexPrefix(starkCurve.keccak(utf8ToArray(serializedJson)).toString(16));
 }
 


### PR DESCRIPTION
## Motivation and Resolution
Solves issue #1135 
hash/computeHintedClassHash is now accessible for users

## Usage related changes
This code is now accessible to users :
```typescript
const compiledCairo0 = json.parse(fs.readFileSync("./cairo0contract.json").toString("ascii"));
const result=hash.computeHintedClassHash(compiledCairo0);
// result = "0x293eabb06955c0a1e55557014675aa4e7a1fd69896147382b29b2b6b166a2ac"
 ```

## Development related changes

Just removed `default` from the export.

## Checklist:

- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Linked the issues which this PR resolves
- [x] Documented the changes in code (API docs will be generated automatically)
- [x] All tests are passing
