### PR TITLE
docs(interface): fix interface error

### DIFF
--- a/www/docs/guides/automatic_cairo_ABI_parsing.md
+++ b/www/docs/guides/automatic_cairo_ABI_parsing.md
@@ -77,6 +77,6 @@ const provider = new RpcProvider({ nodeUrl: constants.NetworkName.SN_MAIN });
 const contract = new Contract(ABI, address, provider).typedv2(ABI);
 
 // Notice the types inferred for the parameter and the returned value
-const primary_inteface_id = contract.get_primary_interface_id();
+const primary_interface_id = contract.get_primary_interface_id();
 const protocol_fees_collected = contract.get_protocol_fees_collected('0x1');
 ```


### PR DESCRIPTION
## Motivation and Resolution
While going through starknet.js docs, I was trying out [Automatic TypeScript parsing of Cairo ABI-s](https://www.starknetjs.com/docs/guides/automatic_cairo_ABI_parsing)
where I came across the issue that the word interface is typed wrong
```
// Notice the types inferred for the parameter and the returned value
const primary_inteface_id = contract.get_primary_interface_id();
const protocol_fees_collected = contract.get_protocol_fees_collected('0x1');
```
...

### RPC version (if applicable)

...

## Usage related changes

<!-- How the changes from this PR affect users. -->

- Change 1.
- Fixes any sort of issues that might be faced by changing the word `inteface` to `interface`

## Development related changes

<!-- How these changes affect the developers of this project - e.g. changes in testing or CI/CD. -->

- Change 1.
- ...

## Checklist:

- [X] Performed a self-review of the code
- [X] Rebased to the last commit of the target branch (or merged it into my branch)
- [ ] Linked the issues which this PR resolves
- [ ] Documented the changes in code (API docs will be generated automatically)
- [ ] Updated the tests
- [] All tests are passing
