### PR TITLE
feat: add support for parsing emitted events

### DIFF
--- a/__tests__/cairo1v2.test.ts
+++ b/__tests__/cairo1v2.test.ts
@@ -1041,6 +1041,9 @@ describe('Cairo 1', () => {
             maker_source: 418413900385n,
             taker_source: 418413900385n,
           },
+          block_hash: '0x39f27ab4cd508ab99e818512b261a7e4ae01072eb4ec8bb86aeb64755f99f2c',
+          block_number: 69198,
+          transaction_hash: '0x4e38fcce79c115b6fe2c486e3514efc1bd4da386b91c104e97230177d0bf181',
         },
       ]);
       // From component `DepositComponent`, event `Deposit` (same event name than next)
@@ -1093,6 +1096,9 @@ describe('Cairo 1', () => {
             funder: 1466771120193999006693452314154095230636738457276435850562375218974960297344n,
             amount: 4956000000000000n,
           },
+          block_hash: '0x31afd649a5042cb1855ce820708a555eab62fe6ea07a2a538fa9100cdc80383',
+          block_number: 69198,
+          transaction_hash: '0x7768860d79bfb4c8463d215abea3c267899e373407c6882077f7447051c50de',
         },
       ]);
       const parsedEventNestedDeposit2 = events.parseEvents(
@@ -1109,6 +1115,9 @@ describe('Cairo 1', () => {
             funder: 1466771120193999006693452314154095230636738457276435850562375218974960297344n,
             amount: 4956000000000000n,
           },
+          block_hash: '0x39f27ab4cd508ab99e818512b261a7e4ae01072eb4ec8bb86aeb64755f99f2c',
+          block_number: 69198,
+          transaction_hash: '0x2d5210e5334a83306abe6f7f5e7e65cd1feed72ad3b8e359a2f4614fa948e1d',
         },
       ]);
 
@@ -1133,6 +1142,9 @@ describe('Cairo 1', () => {
             to: 2087021424722619777119509474943472645767659996348769578120564519014510906823n,
             value: 4956000000000000n,
           },
+          block_hash: '0x39f27ab4cd508ab99e818512b261a7e4ae01072eb4ec8bb86aeb64755f99f2c',
+          block_number: 69198,
+          transaction_hash: '0x2da31a929a9848e9630906275a75a531e1718d4830501e10b0bccacd55f6fe0',
         },
       ]);
     });

--- a/__tests__/cairo1v2.test.ts
+++ b/__tests__/cairo1v2.test.ts
@@ -872,7 +872,14 @@ describe('Cairo 1', () => {
       ];
       const tx = await provider.waitForTransaction(transaction_hash);
       const myEvents = eventContract.parseEvents(tx);
-      return expect(myEvents).toStrictEqual(shouldBe);
+      const event0 = myEvents[0];
+      expect(event0.block_hash).toBeDefined();
+      expect(event0.block_number).toBeDefined();
+      expect(event0.transaction_hash).toBeDefined();
+      delete event0.block_hash;
+      delete event0.block_number;
+      delete event0.transaction_hash;
+      return expect([event0]).toStrictEqual(shouldBe);
     });
 
     test('parse event returning a nested struct', async () => {
@@ -890,7 +897,14 @@ describe('Cairo 1', () => {
       ];
       const tx = await provider.waitForTransaction(transaction_hash);
       const myEvents = eventContract.parseEvents(tx);
-      return expect(myEvents).toStrictEqual(shouldBe);
+      const event0 = myEvents[0];
+      expect(event0.block_hash).toBeDefined();
+      expect(event0.block_number).toBeDefined();
+      expect(event0.transaction_hash).toBeDefined();
+      delete event0.block_hash;
+      delete event0.block_number;
+      delete event0.transaction_hash;
+      return expect([event0]).toStrictEqual(shouldBe);
     });
 
     test('parse tx returning multiple similar events', async () => {
@@ -936,7 +950,21 @@ describe('Cairo 1', () => {
       const { transaction_hash } = await account.execute([callData1, callData2]);
       const tx = await provider.waitForTransaction(transaction_hash);
       const myEvents = eventContract.parseEvents(tx);
-      return expect(myEvents).toStrictEqual(shouldBe);
+      const event0 = myEvents[0];
+      expect(event0.block_hash).toBeDefined();
+      expect(event0.block_number).toBeDefined();
+      expect(event0.transaction_hash).toBeDefined();
+      delete event0.block_hash;
+      delete event0.block_number;
+      delete event0.transaction_hash;
+      const event1 = myEvents[1];
+      expect(event1.block_hash).toBeDefined();
+      expect(event1.block_number).toBeDefined();
+      expect(event1.transaction_hash).toBeDefined();
+      delete event1.block_hash;
+      delete event1.block_number;
+      delete event1.transaction_hash;
+      return expect([event0, event1]).toStrictEqual(shouldBe);
     });
     test('parse tx returning multiple different events', async () => {
       const shouldBe: types.ParsedEvents = [
@@ -972,7 +1000,21 @@ describe('Cairo 1', () => {
       const { transaction_hash } = await account.execute([callData1, callData2]);
       const tx = await provider.waitForTransaction(transaction_hash);
       const myEvents = eventContract.parseEvents(tx);
-      return expect(myEvents).toStrictEqual(shouldBe);
+      const event0 = myEvents[0];
+      expect(event0.block_hash).toBeDefined();
+      expect(event0.block_number).toBeDefined();
+      expect(event0.transaction_hash).toBeDefined();
+      delete event0.block_hash;
+      delete event0.block_number;
+      delete event0.transaction_hash;
+      const event1 = myEvents[1];
+      expect(event1.block_hash).toBeDefined();
+      expect(event1.block_number).toBeDefined();
+      expect(event1.transaction_hash).toBeDefined();
+      delete event1.block_hash;
+      delete event1.block_number;
+      delete event1.transaction_hash;
+      return expect([event0, event1]).toStrictEqual(shouldBe);
     });
 
     test('parsing nested events from Cairo components', () => {

--- a/__tests__/cairo1v2.test.ts
+++ b/__tests__/cairo1v2.test.ts
@@ -1,5 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
+
 import {
   Account,
   BigNumberish,
@@ -872,14 +873,7 @@ describe('Cairo 1', () => {
       ];
       const tx = await provider.waitForTransaction(transaction_hash);
       const myEvents = eventContract.parseEvents(tx);
-      const event0 = myEvents[0];
-      expect(event0.block_hash).toBeDefined();
-      expect(event0.block_number).toBeDefined();
-      expect(event0.transaction_hash).toBeDefined();
-      delete event0.block_hash;
-      delete event0.block_number;
-      delete event0.transaction_hash;
-      return expect([event0]).toStrictEqual(shouldBe);
+      expect(myEvents[0]).toMatchEventStructure(shouldBe[0]);
     });
 
     test('parse event returning a nested struct', async () => {
@@ -897,14 +891,7 @@ describe('Cairo 1', () => {
       ];
       const tx = await provider.waitForTransaction(transaction_hash);
       const myEvents = eventContract.parseEvents(tx);
-      const event0 = myEvents[0];
-      expect(event0.block_hash).toBeDefined();
-      expect(event0.block_number).toBeDefined();
-      expect(event0.transaction_hash).toBeDefined();
-      delete event0.block_hash;
-      delete event0.block_number;
-      delete event0.transaction_hash;
-      return expect([event0]).toStrictEqual(shouldBe);
+      expect(myEvents[0]).toMatchEventStructure(shouldBe[0]);
     });
 
     test('parse tx returning multiple similar events', async () => {
@@ -950,21 +937,8 @@ describe('Cairo 1', () => {
       const { transaction_hash } = await account.execute([callData1, callData2]);
       const tx = await provider.waitForTransaction(transaction_hash);
       const myEvents = eventContract.parseEvents(tx);
-      const event0 = myEvents[0];
-      expect(event0.block_hash).toBeDefined();
-      expect(event0.block_number).toBeDefined();
-      expect(event0.transaction_hash).toBeDefined();
-      delete event0.block_hash;
-      delete event0.block_number;
-      delete event0.transaction_hash;
-      const event1 = myEvents[1];
-      expect(event1.block_hash).toBeDefined();
-      expect(event1.block_number).toBeDefined();
-      expect(event1.transaction_hash).toBeDefined();
-      delete event1.block_hash;
-      delete event1.block_number;
-      delete event1.transaction_hash;
-      return expect([event0, event1]).toStrictEqual(shouldBe);
+      expect(myEvents[0]).toMatchEventStructure(shouldBe[0]);
+      expect(myEvents[1]).toMatchEventStructure(shouldBe[1]);
     });
     test('parse tx returning multiple different events', async () => {
       const shouldBe: types.ParsedEvents = [
@@ -1000,21 +974,8 @@ describe('Cairo 1', () => {
       const { transaction_hash } = await account.execute([callData1, callData2]);
       const tx = await provider.waitForTransaction(transaction_hash);
       const myEvents = eventContract.parseEvents(tx);
-      const event0 = myEvents[0];
-      expect(event0.block_hash).toBeDefined();
-      expect(event0.block_number).toBeDefined();
-      expect(event0.transaction_hash).toBeDefined();
-      delete event0.block_hash;
-      delete event0.block_number;
-      delete event0.transaction_hash;
-      const event1 = myEvents[1];
-      expect(event1.block_hash).toBeDefined();
-      expect(event1.block_number).toBeDefined();
-      expect(event1.transaction_hash).toBeDefined();
-      delete event1.block_hash;
-      delete event1.block_number;
-      delete event1.transaction_hash;
-      return expect([event0, event1]).toStrictEqual(shouldBe);
+      expect(myEvents[0]).toMatchEventStructure(shouldBe[0]);
+      expect(myEvents[1]).toMatchEventStructure(shouldBe[1]);
     });
 
     test('parsing nested events from Cairo components', () => {

--- a/__tests__/cairo1v2_typed.test.ts
+++ b/__tests__/cairo1v2_typed.test.ts
@@ -815,14 +815,7 @@ describe('Cairo 1', () => {
       ];
       const tx = await provider.waitForTransaction(transaction_hash);
       const events = eventContract.parseEvents(tx);
-      const event0 = events[0];
-      expect(event0.block_hash).toBeDefined();
-      expect(event0.block_number).toBeDefined();
-      expect(event0.transaction_hash).toBeDefined();
-      delete event0.block_hash;
-      delete event0.block_number;
-      delete event0.transaction_hash;
-      return expect([event0]).toStrictEqual(shouldBe);
+      expect(events[0]).toMatchEventStructure(shouldBe[0]);
     });
 
     test('parse event returning a nested struct', async () => {
@@ -840,14 +833,7 @@ describe('Cairo 1', () => {
       ];
       const tx = await provider.waitForTransaction(transaction_hash);
       const events = eventContract.parseEvents(tx);
-      const event0 = events[0];
-      expect(event0.block_hash).toBeDefined();
-      expect(event0.block_number).toBeDefined();
-      expect(event0.transaction_hash).toBeDefined();
-      delete event0.block_hash;
-      delete event0.block_number;
-      delete event0.transaction_hash;
-      return expect([event0]).toStrictEqual(shouldBe);
+      expect(events[0]).toMatchEventStructure(shouldBe[0]);
     });
 
     test('parse tx returning multiple similar events', async () => {
@@ -893,21 +879,8 @@ describe('Cairo 1', () => {
       const { transaction_hash } = await account.execute([callData1, callData2]);
       const tx = await provider.waitForTransaction(transaction_hash);
       const events = eventContract.parseEvents(tx);
-      const event0 = events[0];
-      expect(event0.block_hash).toBeDefined();
-      expect(event0.block_number).toBeDefined();
-      expect(event0.transaction_hash).toBeDefined();
-      delete event0.block_hash;
-      delete event0.block_number;
-      delete event0.transaction_hash;
-      const event1 = events[1];
-      expect(event1.block_hash).toBeDefined();
-      expect(event1.block_number).toBeDefined();
-      expect(event1.transaction_hash).toBeDefined();
-      delete event1.block_hash;
-      delete event1.block_number;
-      delete event1.transaction_hash;
-      return expect([event0, event1]).toStrictEqual(shouldBe);
+      expect(events[0]).toMatchEventStructure(shouldBe[0]);
+      expect(events[1]).toMatchEventStructure(shouldBe[1]);
     });
     test('parse tx returning multiple different events', async () => {
       const shouldBe: types.ParsedEvents = [
@@ -943,21 +916,8 @@ describe('Cairo 1', () => {
       const { transaction_hash } = await account.execute([callData1, callData2]);
       const tx = await provider.waitForTransaction(transaction_hash);
       const events = eventContract.parseEvents(tx);
-      const event0 = events[0];
-      expect(event0.block_hash).toBeDefined();
-      expect(event0.block_number).toBeDefined();
-      expect(event0.transaction_hash).toBeDefined();
-      delete event0.block_hash;
-      delete event0.block_number;
-      delete event0.transaction_hash;
-      const event1 = events[1];
-      expect(event1.block_hash).toBeDefined();
-      expect(event1.block_number).toBeDefined();
-      expect(event1.transaction_hash).toBeDefined();
-      delete event1.block_hash;
-      delete event1.block_number;
-      delete event1.transaction_hash;
-      return expect([event0, event1]).toStrictEqual(shouldBe);
+      expect(events[0]).toMatchEventStructure(shouldBe[0]);
+      expect(events[1]).toMatchEventStructure(shouldBe[1]);
     });
   });
 

--- a/__tests__/cairo1v2_typed.test.ts
+++ b/__tests__/cairo1v2_typed.test.ts
@@ -815,7 +815,14 @@ describe('Cairo 1', () => {
       ];
       const tx = await provider.waitForTransaction(transaction_hash);
       const events = eventContract.parseEvents(tx);
-      return expect(events).toStrictEqual(shouldBe);
+      const event0 = events[0];
+      expect(event0.block_hash).toBeDefined();
+      expect(event0.block_number).toBeDefined();
+      expect(event0.transaction_hash).toBeDefined();
+      delete event0.block_hash;
+      delete event0.block_number;
+      delete event0.transaction_hash;
+      return expect([event0]).toStrictEqual(shouldBe);
     });
 
     test('parse event returning a nested struct', async () => {
@@ -833,8 +840,14 @@ describe('Cairo 1', () => {
       ];
       const tx = await provider.waitForTransaction(transaction_hash);
       const events = eventContract.parseEvents(tx);
-
-      return expect(events).toStrictEqual(shouldBe);
+      const event0 = events[0];
+      expect(event0.block_hash).toBeDefined();
+      expect(event0.block_number).toBeDefined();
+      expect(event0.transaction_hash).toBeDefined();
+      delete event0.block_hash;
+      delete event0.block_number;
+      delete event0.transaction_hash;
+      return expect([event0]).toStrictEqual(shouldBe);
     });
 
     test('parse tx returning multiple similar events', async () => {
@@ -880,7 +893,21 @@ describe('Cairo 1', () => {
       const { transaction_hash } = await account.execute([callData1, callData2]);
       const tx = await provider.waitForTransaction(transaction_hash);
       const events = eventContract.parseEvents(tx);
-      return expect(events).toStrictEqual(shouldBe);
+      const event0 = events[0];
+      expect(event0.block_hash).toBeDefined();
+      expect(event0.block_number).toBeDefined();
+      expect(event0.transaction_hash).toBeDefined();
+      delete event0.block_hash;
+      delete event0.block_number;
+      delete event0.transaction_hash;
+      const event1 = events[1];
+      expect(event1.block_hash).toBeDefined();
+      expect(event1.block_number).toBeDefined();
+      expect(event1.transaction_hash).toBeDefined();
+      delete event1.block_hash;
+      delete event1.block_number;
+      delete event1.transaction_hash;
+      return expect([event0, event1]).toStrictEqual(shouldBe);
     });
     test('parse tx returning multiple different events', async () => {
       const shouldBe: types.ParsedEvents = [
@@ -916,7 +943,21 @@ describe('Cairo 1', () => {
       const { transaction_hash } = await account.execute([callData1, callData2]);
       const tx = await provider.waitForTransaction(transaction_hash);
       const events = eventContract.parseEvents(tx);
-      return expect(events).toStrictEqual(shouldBe);
+      const event0 = events[0];
+      expect(event0.block_hash).toBeDefined();
+      expect(event0.block_number).toBeDefined();
+      expect(event0.transaction_hash).toBeDefined();
+      delete event0.block_hash;
+      delete event0.block_number;
+      delete event0.transaction_hash;
+      const event1 = events[1];
+      expect(event1.block_hash).toBeDefined();
+      expect(event1.block_number).toBeDefined();
+      expect(event1.transaction_hash).toBeDefined();
+      delete event1.block_hash;
+      delete event1.block_number;
+      delete event1.transaction_hash;
+      return expect([event0, event1]).toStrictEqual(shouldBe);
     });
   });
 

--- a/__tests__/config/customMatchers.ts
+++ b/__tests__/config/customMatchers.ts
@@ -1,0 +1,32 @@
+// @ts-nocheck
+
+declare global {
+  namespace jest {
+    interface Matchers<R> {
+      toMatchEventStructure(expected: any): R;
+    }
+  }
+}
+
+const customMatchers = {
+  toMatchEventStructure(received: any, expected: any): any {
+    const { block_hash, block_number, transaction_hash, ...eventData } = received;
+
+    // Check if required properties exist
+    const hasRequiredProps = block_hash && block_number && transaction_hash;
+
+    // Check if event data matches
+    const eventDataMatches = this.equals(eventData, expected);
+
+    return {
+      actual: received,
+      pass: hasRequiredProps && eventDataMatches,
+      message: () =>
+        `Expected event to match structure with dynamic properties.\n\n` +
+        `Expected: ${this.utils.printExpected(expected)}\n` +
+        `Received: ${this.utils.printReceived(eventData)}`,
+    };
+  },
+};
+
+export default customMatchers;

--- a/__tests__/config/jest.setup.ts
+++ b/__tests__/config/jest.setup.ts
@@ -9,6 +9,12 @@ import 'isomorphic-fetch';
 /* eslint-disable no-console */
 import { register } from 'fetch-intercept';
 
+import customMatchers from './customMatchers';
+
+beforeAll(() => {
+  expect.extend(customMatchers);
+});
+
 const util = require('util');
 
 jest.setTimeout(50 * 60 * 1000);

--- a/__tests__/contract.test.ts
+++ b/__tests__/contract.test.ts
@@ -4,10 +4,10 @@ import {
   ContractFactory,
   ParsedEvents,
   RawArgs,
+  SuccessfulTransactionReceiptResponse,
   json,
   shortString,
   stark,
-  SuccessfulTransactionReceiptResponse,
 } from '../src';
 import { CallData } from '../src/utils/calldata';
 import { felt, isCairo1Abi, tuple, uint256 } from '../src/utils/calldata/cairo';
@@ -152,14 +152,7 @@ describe('contract module', () => {
             },
           },
         ];
-        const event0 = events[0];
-        expect(event0.block_hash).toBeDefined();
-        expect(event0.block_number).toBeDefined();
-        expect(event0.transaction_hash).toBeDefined();
-        delete event0.block_hash;
-        delete event0.block_number;
-        delete event0.transaction_hash;
-        return expect([event0]).toStrictEqual(shouldBe);
+        expect(events[0]).toMatchEventStructure(shouldBe[0]);
       });
     });
 

--- a/__tests__/contract.test.ts
+++ b/__tests__/contract.test.ts
@@ -152,7 +152,14 @@ describe('contract module', () => {
             },
           },
         ];
-        return expect(events).toStrictEqual(shouldBe);
+        const event0 = events[0];
+        expect(event0.block_hash).toBeDefined();
+        expect(event0.block_number).toBeDefined();
+        expect(event0.transaction_hash).toBeDefined();
+        delete event0.block_hash;
+        delete event0.block_number;
+        delete event0.transaction_hash;
+        return expect([event0]).toStrictEqual(shouldBe);
       });
     });
 

--- a/__tests__/utils/events.test.ts
+++ b/__tests__/utils/events.test.ts
@@ -212,6 +212,91 @@ describe('parseEvents', () => {
     expect(parsedEvents).toStrictEqual(result);
   });
 
+  test('should return parsed  emitted events', () => {
+    const abiEventAndVariantName = 'cairo_event_struct';
+    const abiCairoEventStruct: AbiEvent = {
+      kind: 'struct',
+      members: [
+        {
+          name: 'test_name',
+          type: 'test_type',
+          kind: 'data',
+        },
+      ],
+      name: abiEventAndVariantName,
+      type: 'event',
+    };
+
+    const abiCairoEventEnum: CairoEventVariant = {
+      kind: 'enum',
+      variants: [
+        {
+          name: 'test_name',
+          type: abiEventAndVariantName,
+          kind: 'data',
+        },
+      ],
+      name: 'test_cairo_event',
+      type: 'event',
+    };
+
+    const abiEvents = getAbiEvents([getInterfaceAbi(), abiCairoEventStruct, abiCairoEventEnum]);
+
+    const abiStructs: AbiStructs = {
+      abi_structs: {
+        members: [
+          {
+            name: 'test_name',
+            type: 'test_type',
+            offset: 1,
+          },
+        ],
+        size: 2,
+        name: 'cairo_event_struct',
+        type: 'struct',
+      },
+    };
+
+    const abiEnums: AbiEnums = {
+      abi_enums: {
+        variants: [
+          {
+            name: 'test_name',
+            type: 'cairo_event_struct_variant',
+            offset: 1,
+          },
+        ],
+        size: 2,
+        name: 'test_cairo_event',
+        type: 'enum',
+      },
+    };
+
+    const event: RPC.EmittedEvent = {
+      from_address: 'test_address',
+      keys: ['0x3c719ce4f57dd2d9059b9ffed65417d694a29982d35b188574144d6ae6c3f87'],
+      data: ['0x3c719ce4f57dd2d9059b9ffed65417d694a29982d35b188574144d6ae6c3f87'],
+      block_hash: '0x26b160f10156dea0639bec90696772c640b9706a47f5b8c52ea1abe5858b34d',
+      block_number: 1,
+      transaction_hash: '0x26b160f10156dea0639bec90696772c640b9706a47f5b8c52ea1abe5858b34c',
+    };
+
+    const parsedEvents = parseEvents([event], abiEvents, abiStructs, abiEnums);
+
+    const result = [
+      {
+        cairo_event_struct: {
+          test_name: 1708719217404197029088109386680815809747762070431461851150711916567020191623n,
+        },
+        block_hash: '0x26b160f10156dea0639bec90696772c640b9706a47f5b8c52ea1abe5858b34d',
+        block_number: 1,
+        transaction_hash: '0x26b160f10156dea0639bec90696772c640b9706a47f5b8c52ea1abe5858b34c',
+      },
+    ];
+
+    expect(parsedEvents).toStrictEqual(result);
+  });
+
   test('should throw if ABI events has not enough data in "keys" property', () => {
     const abiEventAndVariantName = 'cairo_event_struct';
     const abiCairoEventStruct: AbiEvent = {

--- a/__tests__/utils/events.test.ts
+++ b/__tests__/utils/events.test.ts
@@ -193,10 +193,13 @@ describe('parseEvents', () => {
       },
     };
 
-    const event: RPC.Event = {
+    const event: RPC.EmittedEvent = {
       from_address: 'test_address',
       keys: ['0x3c719ce4f57dd2d9059b9ffed65417d694a29982d35b188574144d6ae6c3f87'],
       data: ['0x3c719ce4f57dd2d9059b9ffed65417d694a29982d35b188574144d6ae6c3f87'],
+      block_hash: '0x1234',
+      block_number: 567,
+      transaction_hash: '0x789',
     };
 
     const parsedEvents = parseEvents([event], abiEvents, abiStructs, abiEnums);
@@ -206,6 +209,9 @@ describe('parseEvents', () => {
         cairo_event_struct: {
           test_name: 1708719217404197029088109386680815809747762070431461851150711916567020191623n,
         },
+        block_hash: '0x1234',
+        block_number: 567,
+        transaction_hash: '0x789',
       },
     ];
 
@@ -357,10 +363,13 @@ describe('parseEvents', () => {
       },
     };
 
-    const event: RPC.Event = {
+    const event: RPC.EmittedEvent = {
       from_address: 'test_address',
       keys: ['0x3c719ce4f57dd2d9059b9ffed65417d694a29982d35b188574144d6ae6c3f87'],
       data: ['0x3c719ce4f57dd2d9059b9ffed65417d694a29982d35b188574144d6ae6c3f87'],
+      block_hash: '0x1234',
+      block_number: 567,
+      transaction_hash: '0x789',
     };
 
     abiEvents['0x3c719ce4f57dd2d9059b9ffed65417d694a29982d35b188574144d6ae6c3f87'].name = '';

--- a/src/types/contract.ts
+++ b/src/types/contract.ts
@@ -1,7 +1,9 @@
+import { BlockHash, TransactionHash } from 'starknet-types-07';
 import { CairoEnum } from './cairoEnum';
 import {
   BigNumberish,
   BlockIdentifier,
+  BlockNumber,
   Calldata,
   ParsedStruct,
   RawArgsArray,
@@ -44,6 +46,10 @@ export type InvokeOptions = Pick<
   'maxFee' | 'nonce' | 'signature' | 'parseRequest'
 >;
 
-export type ParsedEvent = { [name: string]: ParsedStruct };
+export type ParsedEvent = { [name: string]: ParsedStruct } & {
+  block_hash?: BlockHash;
+  block_number?: BlockNumber;
+  transaction_hash?: TransactionHash;
+};
 
 export type ParsedEvents = Array<ParsedEvent>;

--- a/src/utils/events/index.ts
+++ b/src/utils/events/index.ts
@@ -194,7 +194,7 @@ function mergeAbiEvents(target: any, source: any): Object {
  * ```
  */
 export function parseEvents(
-  providerReceivedEvents: RPC.EmittedEvent[] | RPC.Event[],
+  providerReceivedEvents: RPC.EmittedEvent[],
   abiEvents: AbiEvents,
   abiStructs: AbiStructs,
   abiEnums: AbiEnums

--- a/src/utils/events/index.ts
+++ b/src/utils/events/index.ts
@@ -194,57 +194,62 @@ function mergeAbiEvents(target: any, source: any): Object {
  * ```
  */
 export function parseEvents(
-  providerReceivedEvents: RPC.Event[],
+  providerReceivedEvents: RPC.EmittedEvent[] | RPC.Event[],
   abiEvents: AbiEvents,
   abiStructs: AbiStructs,
   abiEnums: AbiEnums
 ): ParsedEvents {
-  const ret = providerReceivedEvents.flat().reduce((acc, recEvent: RPC.Event) => {
-    let abiEvent: AbiEvent | AbiEvents = abiEvents[recEvent.keys.shift() ?? 0];
-    if (!abiEvent) {
+  const ret = providerReceivedEvents
+    .flat()
+    .reduce((acc, recEvent: RPC.EmittedEvent | RPC.Event) => {
+      let abiEvent: AbiEvent | AbiEvents = abiEvents[recEvent.keys.shift() ?? 0];
+      if (!abiEvent) {
+        return acc;
+      }
+      while (!abiEvent.name) {
+        const hashName = recEvent.keys.shift();
+        assert(!!hashName, 'Not enough data in "keys" property of this event.');
+        abiEvent = (abiEvent as AbiEvents)[hashName];
+      }
+      // Create our final event object
+      const parsedEvent: ParsedEvent = {};
+      parsedEvent[abiEvent.name as string] = {};
+      // Remove the event's name hashed from the keys array
+      const keysIter = recEvent.keys[Symbol.iterator]();
+      const dataIter = recEvent.data[Symbol.iterator]();
+
+      const abiEventKeys =
+        (abiEvent as CairoEventDefinition).members?.filter((it) => it.kind === 'key') ||
+        (abiEvent as LegacyEvent).keys;
+      const abiEventData =
+        (abiEvent as CairoEventDefinition).members?.filter((it) => it.kind === 'data') ||
+        (abiEvent as LegacyEvent).data;
+
+      abiEventKeys.forEach((key) => {
+        parsedEvent[abiEvent.name as string][key.name] = responseParser(
+          keysIter,
+          key,
+          abiStructs,
+          abiEnums,
+          parsedEvent[abiEvent.name as string]
+        );
+      });
+
+      abiEventData.forEach((data) => {
+        parsedEvent[abiEvent.name as string][data.name] = responseParser(
+          dataIter,
+          data,
+          abiStructs,
+          abiEnums,
+          parsedEvent[abiEvent.name as string]
+        );
+      });
+      if ('block_hash' in recEvent) parsedEvent.block_hash = recEvent.block_hash;
+      if ('block_number' in recEvent) parsedEvent.block_number = recEvent.block_number;
+      if ('transaction_hash' in recEvent) parsedEvent.transaction_hash = recEvent.transaction_hash;
+      acc.push(parsedEvent);
       return acc;
-    }
-    while (!abiEvent.name) {
-      const hashName = recEvent.keys.shift();
-      assert(!!hashName, 'Not enough data in "keys" property of this event.');
-      abiEvent = (abiEvent as AbiEvents)[hashName];
-    }
-    // Create our final event object
-    const parsedEvent: ParsedEvent = {};
-    parsedEvent[abiEvent.name as string] = {};
-    // Remove the event's name hashed from the keys array
-    const keysIter = recEvent.keys[Symbol.iterator]();
-    const dataIter = recEvent.data[Symbol.iterator]();
-
-    const abiEventKeys =
-      (abiEvent as CairoEventDefinition).members?.filter((it) => it.kind === 'key') ||
-      (abiEvent as LegacyEvent).keys;
-    const abiEventData =
-      (abiEvent as CairoEventDefinition).members?.filter((it) => it.kind === 'data') ||
-      (abiEvent as LegacyEvent).data;
-
-    abiEventKeys.forEach((key) => {
-      parsedEvent[abiEvent.name as string][key.name] = responseParser(
-        keysIter,
-        key,
-        abiStructs,
-        abiEnums,
-        parsedEvent[abiEvent.name as string]
-      );
-    });
-
-    abiEventData.forEach((data) => {
-      parsedEvent[abiEvent.name as string][data.name] = responseParser(
-        dataIter,
-        data,
-        abiStructs,
-        abiEnums,
-        parsedEvent[abiEvent.name as string]
-      );
-    });
-    acc.push(parsedEvent);
-    return acc;
-  }, [] as ParsedEvents);
+    }, [] as ParsedEvents);
   return ret;
 }
 


### PR DESCRIPTION
## Motivation and Resolution

`provider.getEvents` method returns list of `EmittedEvents` which contains fields for block number, block hash and transaction hash. Parsing list of those events with `parseEvents` would drop those fields. This PR adds them back to the returned array if they are available.

### RPC version (if applicable)

...

## Usage related changes

<!-- How the changes from this PR affect users. -->

Users now use additional data from parsed events structure.

## Development related changes

N/A

## Checklist:

- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [ ] Linked the issues which this PR resolves
- [ ] Documented the changes in code (API docs will be generated automatically)
- [x] Updated the tests
- [x] All tests are passing
