### PR TITLE
WalletAccount guide: correction of lib name

### DIFF
--- a/www/docs/guides/walletAccount.md
+++ b/www/docs/guides/walletAccount.md
@@ -32,7 +32,7 @@ Using the `get-starknet-core` v4 library, you can create your own UI and logic t
 So, you instantiate a new WalletAccount with :
 
 ```typescript
-import { connect } from 'get-starknet'; // v4.0.0 min
+import { connect } from '@starknet-io/get-starknet'; // v4.0.3 min
 import { WalletAccount } from 'starknet'; // v6.10.0 min
 const myFrontendProviderUrl = 'https://free-rpc.nethermind.io/sepolia-juno/v0_7';
 // standard UI to select a wallet :


### PR DESCRIPTION
## Motivation and Resolution
Just 2 little corrections in the WalletAccount guide
- missing `@starknet-io/` in lib name
- use at least v4.0.3 to be able to handle Metamask Snap.

## Usage related changes

## Development related changes

