### PR TITLE
Fix: correct typos in documentation

### DIFF
--- a/www/docs/guides/automatic_cairo_ABI_parsing.md
+++ b/www/docs/guides/automatic_cairo_ABI_parsing.md
@@ -14,7 +14,7 @@ Please take a look on the Abi-Wan [documentation](https://github.com/keep-starkn
 
 ## Usage
 
-First, you need to wrap your ABI in a array and export it as a `const`.
+First, you need to wrap your ABI in an array and export it as a `const`.
 
 Example:
 

--- a/www/docs/guides/cairo_enum.md
+++ b/www/docs/guides/cairo_enum.md
@@ -86,7 +86,7 @@ const res2 = (await myTestContract.call('test5', [
 
 ## Cairo Result
 
-Cairo v2.1.0 introduces an other core Enum: `Result`.  
+Cairo v2.1.0 introduces another core Enum: `Result`.  
 This Enum has 2 variants (`Ok` and `Err`) and both variants can contain data.
 
 ### Receive Cairo Result

--- a/www/docs/guides/estimate_fees.md
+++ b/www/docs/guides/estimate_fees.md
@@ -4,7 +4,7 @@ sidebar_position: 11
 
 # Estimate fees
 
-By default, all nonfree Starknet commands (declare, deploy, invoke) work without any limitation of cost.
+By default, all non-free Starknet commands (declare, deploy, invoke) work without any limitation of cost.
 
 Nevertheless, you might want to inform the DAPP user of the cost of the incoming transaction before proceeding and requesting its validation.
 


### PR DESCRIPTION
## Motivation and Resolution

This PR corrects minor typographical errors in the documentation files, enhancing readability and accuracy. 

### Details of Typo Corrections:

1. **automatic_cairo_ABI_parsing.md**
   - Changed "wrap your ABI in a array" to "wrap your ABI in an array".

2. **cairo_enum.md**
   - Corrected "an other core Enum" to "another core Enum".

3. **estimate_fees.md**
   - Changed "nonfree Starknet commands" to "non-free Starknet commands".

## Usage related changes

These changes improve the documentation by fixing minor errors, making the documentation clearer for users without altering any functional content.

## Development related changes

There are no code changes; this PR only updates the documentation.

## Checklist

- [x] Performed a self-review of the documentation changes.
- [x] Linked the issues this PR resolves (if applicable).
- [x] Ensured changes in `/www/docs` are correct (for future documentation release).
- [x] All checks and tests have passed (as applicable).