### PR TITLE
Typo Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ _[Use GitHub interface](https://blog.sapegin.me/all/open-source-for-everyone/) f
 
 > :warning: IMPORTANT NOTE :warning:
 >
-> All contributions are expected to be of the highest possible quality! That means the PR is thoroughly tested and documented, and without blindly generated ChatGPT code and documentation! We will not consider nor merge PR-s that do not comply to these rules!
+> All contributions are expected to be of the highest possible quality! That means the PR is thoroughly tested and documented, and without blindly generated ChatGPT code and documentation! We will not consider or merge PR-s that do not comply to these rules!
 
 ## Prerequisites
 


### PR DESCRIPTION
**Description:**

This pull request fixes a typo found in the contributing guidelines. In the sentence:  
**"We will not consider nor merge PR-s that do not comply to these rules!"**  
the word **"nor"** is used incorrectly.

The correct phrasing should be **"or"**, as it follows a negation ("not") in the sentence. In English, when there is a negation ("not"), the proper conjunction to use is **"or"**, not **"nor"**.

**Change:**

- Replaced **"nor"** with **"or"** in the sentence:  
  **"We will not consider or merge PRs that do not comply with these rules!"**

**Reason for the Change:**

The use of **"nor"** after a negation is grammatically incorrect in this context. The sentence should use **"or"** instead, following the standard English grammar rules where **"not"** is followed by **"or"**. This change ensures the sentence is grammatically correct and improves clarity.

**Impact:**

- Ensures proper English grammar in the contribution guidelines.
- Improves clarity and readability of the documentation for contributors.
- Aligns with standard language conventions, making the document more professional and easier to understand.