### PR TITLE
test: stabilize websocket tests

### DIFF
--- a/__tests__/utils/stark.browser.test.ts
+++ b/__tests__/utils/stark.browser.test.ts
@@ -8,9 +8,14 @@ import * as json from '../../src/utils/json';
 
 const { IS_BROWSER } = constants;
 
+// isows has faulty module resolution in the browser emulation environment which prevents test execution
+// it is not required for these tests so removing it with a mock circumvents the issue
+jest.mock('isows', () => jest.fn());
+
 test('isBrowser', () => {
   expect(IS_BROWSER).toBe(true);
 });
+
 describe('compressProgram()', () => {
   // the @noble/curves dependency that is included in this file through utils/stark executes precomputations
   // that rely on TextEncoder. The jsdom environment does not expose TextEncoder and it also overrides


### PR DESCRIPTION
## Motivation and Resolution

This PR contains small tweaks to stabilize the tests:
- moving the `WebSocketChannel` initializations into setup hooks ensures they are bound to their respective `describe` scopes and properly followed by the teardown hooks, without the change they are treated as if they were in the same higher scope causing one of them to be orphaned in case of errors
- removing the underlying `isows` dependency with a mock allows the tests from `utils/stark.browser.test.ts` to run
