### PR TITLE
feat: units utils

### DIFF
--- a/__tests__/utils/utils.test.ts
+++ b/__tests__/utils/utils.test.ts
@@ -1,7 +1,30 @@
 import * as starkCurve from '@scure/starknet';
-import { constants, ec, hash, num, stark } from '../../src';
+
+import { constants, ec, hash, num, stark, units } from '../../src';
 
 const { IS_BROWSER } = constants;
+
+test('units', () => {
+  expect(units(1n, 'fri')).toEqual('0.000000000000000001');
+  expect(units(1000n, 'fri')).toEqual('0.000000000000001');
+  expect(units(123123123n, 'fri')).toEqual('0.000000000123123123');
+  expect(units('123123123', 'fri')).toEqual('0.000000000123123123');
+  expect(units(10n ** 18n, 'fri')).toEqual('1');
+  expect(units(30n * 10n ** 16n, 'fri')).toEqual('0.3');
+  expect(units(30n * 10n ** 22n, 'fri')).toEqual('300000');
+  expect(units('0x40ff', 'fri')).toEqual('0.000000000000016639');
+
+  expect(units('0.3', 'strk')).toEqual('300000000000000000');
+  expect(units('1', 'strk')).toEqual('1000000000000000000');
+  expect(units('1000', 'strk')).toEqual('1000000000000000000000');
+  expect(units('123123123.123', 'strk')).toEqual('123123123123000000000000000');
+  expect(units('0x40ff', 'strk')).toEqual('16639000000000000000000');
+
+  const toTest = ['0.333', '123123123.123', '1000.1', '123123123.123123', '0.0000003'];
+  toTest.forEach((element) => {
+    expect(units(units(element, 'strk'), 'fri')).toEqual(element);
+  });
+});
 
 test('isNode', () => {
   expect(IS_BROWSER).toBe(false);

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,6 +45,7 @@ export * from './utils/calldata';
 export * from './utils/calldata/enum';
 export * from './utils/contract';
 export * from './utils/transactionReceipt';
+export * from './utils/units';
 export * as wallet from './wallet/connect';
 
 /**

--- a/src/utils/units.ts
+++ b/src/utils/units.ts
@@ -1,0 +1,37 @@
+import { isHex } from './num';
+
+/**
+ * Convert strk to fri or fri to strk
+ * @example
+ * ```typescript
+ * units(1000n, 'fri') // '0.000000000000001' strk
+ * units('1', 'strk') // '1000000000000000000' fri
+ * ```
+ */
+export function units(amount: string | bigint, simbol: 'fri' | 'strk' = 'fri') {
+  if (simbol === 'strk') {
+    let numStr = '';
+    if (typeof amount === 'bigint') numStr = amount.toString();
+    else if (typeof amount === 'string') {
+      if (isHex(amount)) {
+        numStr = BigInt(amount).toString();
+      } else {
+        numStr = amount;
+      }
+    }
+
+    const [integer, decimal = '0'] = numStr.split('.');
+    const pdec = decimal.padEnd(18, '0');
+    return `${integer}${pdec}`.replace(/\b0+/g, '');
+  }
+
+  const bis = BigInt(amount).toString();
+  let strk;
+  if (bis.length <= 18) {
+    strk = `0.${bis.padStart(18, '0')}`;
+  } else {
+    strk = `${bis.slice(0, bis.length - 18)}.${bis.slice(bis.length - 18)}`;
+  }
+
+  return strk.replace(/(\.[0-9]*[1-9])0+$|\.0*$/, '$1');
+}


### PR DESCRIPTION
## Motivation and Resolution
Requested by dev from HH Bangkok similar to https://viem.sh/docs/utilities/formatUnits

Convert fri to strk
```ts
units(1n, 'fri')
```

convert strk to fri
```ts
units('0.3', 'strk')
```

## Checklist:

- [ ] Performed a self-review of the code
- [ ] Rebased to the last commit of the target branch (or merged it into my branch)
- [ ] Linked the issues which this PR resolves
- [ ] Documented the changes in code (API docs will be generated automatically)
- [ ] Updated the tests
- [ ] All tests are passing
