### PR TITLE
fix: preserve value for numeric arguments within address padding utility

### DIFF
--- a/__tests__/utils/address.test.ts
+++ b/__tests__/utils/address.test.ts
@@ -20,6 +20,22 @@ describe('addAddressPadding', () => {
 
     return expect(addAddressPadding(addr)).toBe(padded);
   });
+
+  test('should pad a number value', () => {
+    const addr1 = 31;
+    const addr2 = 0x1f;
+    const padded = '0x000000000000000000000000000000000000000000000000000000000000001f';
+
+    expect(addAddressPadding(addr1)).toBe(padded);
+    expect(addAddressPadding(addr2)).toBe(padded);
+  });
+
+  test('should pad a bigint value', () => {
+    const addr = constants.ADDR_BOUND;
+    const padded = '0x07ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00';
+
+    expect(addAddressPadding(addr)).toBe(padded);
+  });
 });
 
 describe('validateAndParseAddress', () => {

--- a/src/utils/address.ts
+++ b/src/utils/address.ts
@@ -6,36 +6,47 @@ import { BigNumberish } from '../types';
 import { addHexPrefix, removeHexPrefix } from './encode';
 import { keccakBn } from './hash';
 import { assertInRange, toHex } from './num';
+import { isString } from './typed';
 
 /**
  * Format a hex number to '0x' and 64 characters, adding leading zeros if necessary.
  *
  * @param {BigNumberish} address
- * @returns {string} Hex string : 0x followed by 64 characters. No upper case characters in the response.
+ * @returns {string} Hex string: 0x followed by 64 characters. No upper case characters in the response.
  * @example
  * ```typescript
- * const address = "0x90591d9fa3efc87067d95a643f8455e0b8190eb8cb7bfd39e4fb7571fdf";
- * const result = addAddressPadding(address);
- * // result = "0x0000090591d9fa3efc87067d95a643f8455e0b8190eb8cb7bfd39e4fb7571fdf"
+ * const result = [31, 0x1f, '31', '0x1f', '0x90591d9fa3efc87067d95a643f8455e0b8190eb8cb7bfd39e4fb7571fdf'].map(addAddressPadding);
+ * // result = [
+ * //   '0x000000000000000000000000000000000000000000000000000000000000001f',
+ * //   '0x000000000000000000000000000000000000000000000000000000000000001f',
+ * //   '0x0000000000000000000000000000000000000000000000000000000000000031',
+ * //   '0x000000000000000000000000000000000000000000000000000000000000001f',
+ * //   '0x0000090591d9fa3efc87067d95a643f8455e0b8190eb8cb7bfd39e4fb7571fdf'
+ * // ]
  * ```
  */
 export function addAddressPadding(address: BigNumberish): string {
-  const hex = toHex(addHexPrefix(address.toString()));
+  const hex = toHex(isString(address) ? addHexPrefix(address) : address);
   const padded = removeHexPrefix(hex).padStart(64, '0');
   return addHexPrefix(padded);
 }
 
 /**
- * Check the validity of a Starknet address, and format it as a hex number : '0x' and 64 characters, adding leading zeros if necessary.
+ * Check the validity of a Starknet address, and format it as a hex number: '0x' and 64 characters, adding leading zeros if necessary.
  *
  * @param {BigNumberish} address
- * @returns {string} Hex string : 0x followed by 64 characters. No upper case characters in the response.
+ * @returns {string} Hex string: 0x followed by 64 characters. No upper case characters in the response.
  * @throws address argument must be a valid address inside the address range bound
  * @example
  * ```typescript
- * const address = "0x90591d9fa3efc87067d95a643f8455e0b8190eb8cb7bfd39e4fb7571fdf";
- * const result = validateAndParseAddress(address);
- * // result = "0x0000090591d9fa3efc87067d95a643f8455e0b8190eb8cb7bfd39e4fb7571fdf"
+ * const result = [31, 0x1f, '31', '0x1f', '0x90591d9fa3efc87067d95a643f8455e0b8190eb8cb7bfd39e4fb7571fdf'].map(addAddressPadding);
+ * // result = [
+ * //   '0x000000000000000000000000000000000000000000000000000000000000001f',
+ * //   '0x000000000000000000000000000000000000000000000000000000000000001f',
+ * //   '0x0000000000000000000000000000000000000000000000000000000000000031',
+ * //   '0x000000000000000000000000000000000000000000000000000000000000001f',
+ * //   '0x0000090591d9fa3efc87067d95a643f8455e0b8190eb8cb7bfd39e4fb7571fdf'
+ * // ]
  * ```
  */
 export function validateAndParseAddress(address: BigNumberish): string {


### PR DESCRIPTION
## Motivation and Resolution

Resolves #1258 

## Usage related changes

The `addAddressPadding` utility is adjusted to use numeric inputs as values rather than their string equivalents.

## Checklist:

- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Linked the issues which this PR resolves
- [x] Documented the changes in code (API docs will be generated automatically)
- [x] Updated the tests
- [x] All tests are passing
