### PR TITLE
fix: pass signerDetails to fix estimateFeeBulk

### DIFF
--- a/src/account/default.ts
+++ b/src/account/default.ts
@@ -990,6 +990,7 @@ export class Account extends Provider implements AccountInterface {
           return {
             ...common,
             ...payload,
+            ...signerDetails,
           };
         }
         if (transaction.type === TransactionType.DEPLOY) {
@@ -1003,6 +1004,7 @@ export class Account extends Provider implements AccountInterface {
           return {
             ...common,
             ...payload,
+            ...signerDetails,
             type: TransactionType.INVOKE,
           };
         }
@@ -1016,6 +1018,7 @@ export class Account extends Provider implements AccountInterface {
           return {
             ...common,
             ...payload,
+            ...signerDetails,
           };
         }
         if (transaction.type === TransactionType.DEPLOY_ACCOUNT) {
@@ -1028,6 +1031,7 @@ export class Account extends Provider implements AccountInterface {
           return {
             ...common,
             ...payload,
+            ...signerDetails,
           };
         }
         throw Error(`accountInvocationsFactory: unsupported transaction type: ${transaction}`);


### PR DESCRIPTION
## Motivation and Resolution

There is a bug in current bulk fee estimation or simulation because of accountInvocationsFactory not passing signerDetails.

It throws error when buildTransaction is called here

https://github.com/starknet-io/starknet.js/blob/698461950333c1df6cef302e1947e1012c3097f4/src/channel/rpc_0_7.ts#L435

Because `tip` was `undefined`

https://github.com/starknet-io/starknet.js/blob/698461950333c1df6cef302e1947e1012c3097f4/src/channel/rpc_0_7.ts#L664

### RPC version (if applicable)

...

## Usage related changes

<!-- How the changes from this PR affect users. -->

- Change 1.
- ...

## Development related changes

<!-- How these changes affect the developers of this project - e.g. changes in testing or CI/CD. -->

- Change 1.
- ...

## Checklist:

- [ ] Performed a self-review of the code
- [ ] Rebased to the last commit of the target branch (or merged it into my branch)
- [ ] Linked the issues which this PR resolves
- [ ] Documented the changes in code (API docs will be generated automatically)
- [ ] Updated the tests
- [ ] All tests are passing
