### PR TITLE
fix: add starkid improvements

### DIFF
--- a/__tests__/account.starknetId.test.ts
+++ b/__tests__/account.starknetId.test.ts
@@ -86,7 +86,7 @@ describe('deploy and test Wallet', () => {
   });
 
   test('Should throw error when invalid stark domain is provided', async () => {
-    await expect(account.getAddressFromStarkName('invalid-domain', namingAddress)).rejects.toThrow(
+    await expect(account.getAddressFromStarkName('invalid_domain', namingAddress)).rejects.toThrow(
       'Invalid domain, must be a valid .stark domain'
     );
   });

--- a/__tests__/account.starknetId.test.ts
+++ b/__tests__/account.starknetId.test.ts
@@ -85,6 +85,12 @@ describe('deploy and test Wallet', () => {
     expect(hexToDecimalString(address)).toEqual(hexToDecimalString(account.address));
   });
 
+  test('Should throw error when invalid stark domain is provided', async () => {
+    await expect(account.getAddressFromStarkName('invalid-domain', namingAddress)).rejects.toThrow(
+      'Invalid domain, must be a valid .stark domain'
+    );
+  });
+
   test('Get the account from a stark name of the account (using starknet.id)', async () => {
     const name = await account.getStarkName(undefined, namingAddress);
     expect(name).toEqual('fricoben.stark');

--- a/src/provider/extensions/starknetId.ts
+++ b/src/provider/extensions/starknetId.ts
@@ -12,6 +12,7 @@ import {
   getStarknetIdPfpContract,
   getStarknetIdPopContract,
   getStarknetIdVerifierContract,
+  isStarkDomain,
   useDecoded,
   useEncoded,
 } from '../../utils/starknetId';
@@ -97,11 +98,17 @@ export class StarknetId {
     name: string,
     StarknetIdContract?: string
   ): Promise<string> {
+    const starkName = name.endsWith('.stark') ? name : `${name}.stark`;
+
+    if (!isStarkDomain(starkName)) {
+      throw new Error('Invalid domain, must be a valid .stark domain');
+    }
+
     const chainId = await provider.getChainId();
     const contract = StarknetIdContract ?? getStarknetIdContract(chainId);
 
     try {
-      const encodedDomain = name
+      const encodedDomain = starkName
         .replace('.stark', '')
         .split('.')
         .map((part) => useEncoded(part).toString(10));

--- a/src/utils/starknetId.ts
+++ b/src/utils/starknetId.ts
@@ -393,3 +393,21 @@ export function dynamicCallData(
     ArrayReference: arrayReference ? tuple(arrayReference[0], arrayReference[1]) : undefined,
   });
 }
+
+/**
+ * Check if a given string is a valid Starknet.id domain.
+ *
+ * @param {string} domain - The domain string to validate.
+ * @returns {boolean} - True if the domain is a valid Starknet.id domain, false otherwise.
+ * @example
+ * ```typescript
+ * const result = starknetId.isStarkDomain("example.stark");
+ * // result = true
+ *
+ * const result2 = starknetId.isStarkDomain("invalid-domain");
+ * // result2 = false
+ * ```
+ */
+export function isStarkDomain(domain: string): boolean {
+  return /^(?:[a-z0-9-]{1,48}(?:[a-z0-9-]{1,48}[a-z0-9-])?\.)*[a-z0-9-]{1,48}\.stark$/.test(domain);
+}


### PR DESCRIPTION
## Motivation and Resolution

Argent ran into a problem using `useDecoded` when decoding the domain `Grug.stark`, this should have been passed as `grug.stark` but they didn't have the `isStarkDomain` to do so easily. 
 
## Usage related changes

I'm addding two things to help wallet and devs in general:

1. Adding `isStarkDomain` to permit manual verification
2. Refactoring `getAddressFromStarkName` to make the function detect this kind of name errors in the future