### PR TITLE
WIP: feat(provider): Add Brother ID domain resolution support

### DIFF
--- a/src/provider/extensions/brotherId.ts
+++ b/src/provider/extensions/brotherId.ts
@@ -1,0 +1,228 @@
+import { BigNumberish } from '../../types';
+import { CallData } from '../../utils/calldata';
+import { decodeShortString, encodeShortString } from '../../utils/shortString';
+import type { ProviderInterface } from '..';
+import { StarknetChainId } from '../../global/constants';
+
+/**
+ * Validates if a domain is a valid .brother domain
+ * @param domain - Domain name to validate
+ * @returns true if the domain is valid
+ */
+export function isBrotherDomain(domain: string): boolean {
+  return domain.endsWith('.brother');
+}
+
+/**
+ * Get the Brother ID contract address for the specified network
+ * @param chainId - The Starknet chain ID
+ * @returns The Brother ID contract address for the network
+ */
+export function getBrotherIdContract(chainId: StarknetChainId): string {
+  switch (chainId) {
+    case StarknetChainId.SN_MAIN:
+      return '0x0212f1c57700f5a3913dd11efba540196aad4cf67772f7090c62709dd804fa74';
+    default:
+      return '0x0212f1c57700f5a3913dd11efba540196aad4cf67772f7090c62709dd804fa74'; // Default to mainnet address
+  }
+}
+
+/**
+ * Interface representing a Brother domain profile
+ * @property name - The domain name without .brother suffix
+ * @property resolver - The address that resolves to this domain
+ * @property tokenId - The unique identifier of the domain NFT
+ * @property expiryDate - Unix timestamp when the domain expires
+ * @property lastTransferTime - Unix timestamp of the last transfer
+ */
+export interface BrotherProfile {
+  name: string;
+  resolver: string;
+  tokenId: string;
+  expiryDate: number;
+  lastTransferTime: number;
+}
+
+/**
+ * Class providing methods to interact with Brother Identity contracts
+ */
+export class BrotherId {
+  /**
+   * Gets the primary Brother domain name for an address
+   * @param address - The address to get the domain for
+   * @param BrotherIdContract - Optional contract address
+   * @returns The domain name with .brother suffix
+   */
+  async getBrotherName(address: BigNumberish, BrotherIdContract?: string) {
+    return BrotherId.getBrotherName(
+      // After Mixin, this is ProviderInterface
+      (<unknown>this) as ProviderInterface,
+      address,
+      BrotherIdContract
+    );
+  }
+
+  /**
+   * Gets the address associated with a Brother domain name
+   * @param name - The domain name (with or without .brother suffix)
+   * @param BrotherIdContract - Optional contract address
+   * @returns The resolver address for the domain
+   */
+  public async getAddressFromBrotherName(
+    name: string,
+    BrotherIdContract?: string
+  ): Promise<string> {
+    return BrotherId.getAddressFromBrotherName(
+      // After Mixin, this is ProviderInterface
+      (<unknown>this) as ProviderInterface,
+      name,
+      BrotherIdContract
+    );
+  }
+
+  /**
+   * Gets the complete profile information for a Brother domain
+   * @param address - The address to get the profile for
+   * @param BrotherIdContract - Optional contract address
+   * @returns The complete Brother profile information
+   */
+  async getBrotherProfile(address: BigNumberish, BrotherIdContract?: string) {
+    return BrotherId.getBrotherProfile(
+      // After Mixin, this is ProviderInterface
+      (<unknown>this) as ProviderInterface,
+      address,
+      BrotherIdContract
+    );
+  }
+
+  /**
+   * Static implementation of getBrotherName
+   * @param provider - The provider interface
+   * @param address - The address to get the domain for
+   * @param BrotherIdContract - Optional contract address
+   * @returns The domain name with .brother suffix
+   */
+  static async getBrotherName(
+    provider: ProviderInterface,
+    address: BigNumberish,
+    BrotherIdContract?: string
+  ): Promise<string> {
+    const chainId = await provider.getChainId();
+    const contract = BrotherIdContract ?? getBrotherIdContract(chainId);
+
+    try {
+      const primaryDomain = await provider.callContract({
+        contractAddress: contract,
+        entrypoint: 'getPrimary',
+        calldata: CallData.compile({
+          user: address,
+        }),
+      });
+
+      if (!primaryDomain[0] || primaryDomain[0] === '0x0') {
+        throw Error('Brother name not found');
+      }
+
+      const domain = decodeShortString(primaryDomain[0]);
+      return `${domain}.brother`;
+    } catch (e) {
+      if (e instanceof Error && e.message === 'Brother name not found') {
+        throw e;
+      }
+      throw Error('Could not get brother name');
+    }
+  }
+
+  /**
+   * Static implementation of getAddressFromBrotherName
+   * @param provider - The provider interface
+   * @param name - The domain name
+   * @param BrotherIdContract - Optional contract address
+   * @returns The resolver address
+   */
+  static async getAddressFromBrotherName(
+    provider: ProviderInterface,
+    name: string,
+    BrotherIdContract?: string
+  ): Promise<string> {
+    const brotherName = name.endsWith('.brother') ? name : `${name}.brother`;
+
+    if (!isBrotherDomain(brotherName)) {
+      throw new Error('Invalid domain, must be a valid .brother domain');
+    }
+
+    const chainId = await provider.getChainId();
+    const contract = BrotherIdContract ?? getBrotherIdContract(chainId);
+
+    try {
+      const domainDetails = await provider.callContract({
+        contractAddress: contract,
+        entrypoint: 'get_details_by_domain',
+        calldata: CallData.compile({
+          domain: encodeShortString(brotherName.replace('.brother', '')),
+        }),
+      });
+
+      if (!domainDetails[0] || domainDetails[1] === '0x0') {
+        throw Error('Could not get address from brother name');
+      }
+
+      return domainDetails[1]; // resolver address
+    } catch {
+      throw Error('Could not get address from brother name');
+    }
+  }
+
+  /**
+   * Static implementation of getBrotherProfile
+   * @param provider - The provider interface
+   * @param address - The address to get the profile for
+   * @param BrotherIdContract - Optional contract address
+   * @returns The complete Brother profile
+   */
+  static async getBrotherProfile(
+    provider: ProviderInterface,
+    address: BigNumberish,
+    BrotherIdContract?: string
+  ): Promise<BrotherProfile> {
+    const chainId = await provider.getChainId();
+    const contract = BrotherIdContract ?? getBrotherIdContract(chainId);
+
+    try {
+      const primaryDomain = await provider.callContract({
+        contractAddress: contract,
+        entrypoint: 'getPrimary',
+        calldata: CallData.compile({
+          user: address,
+        }),
+      });
+
+      if (!primaryDomain[0] || primaryDomain[0] === '0x0') {
+        throw Error('Brother profile not found');
+      }
+
+      const domain = decodeShortString(primaryDomain[0]);
+
+      const domainDetails = await provider.callContract({
+        contractAddress: contract,
+        entrypoint: 'get_details_by_domain',
+        calldata: CallData.compile({
+          domain: encodeShortString(domain),
+        }),
+      });
+
+      return {
+        name: domain,
+        resolver: domainDetails[1],
+        tokenId: domainDetails[2],
+        expiryDate: parseInt(domainDetails[3], 16),
+        lastTransferTime: parseInt(domainDetails[4], 16),
+      };
+    } catch (e) {
+      if (e instanceof Error && e.message === 'Brother profile not found') {
+        throw e;
+      }
+      throw Error('Could not get brother profile');
+    }
+  }
+}

--- a/src/provider/extensions/default.ts
+++ b/src/provider/extensions/default.ts
@@ -3,5 +3,6 @@ import { Mixin } from 'ts-mixer';
 
 import { RpcProvider as BaseRpcProvider } from '../rpc';
 import { StarknetId } from './starknetId';
+import { BrotherId } from './brotherId';
 
-export class RpcProvider extends Mixin(BaseRpcProvider, StarknetId) {}
+export class RpcProvider extends Mixin(BaseRpcProvider, StarknetId, BrotherId) {}


### PR DESCRIPTION
## Motivation and Resolution
This PR introduces Brother ID integration into Starknet.js, providing methods to interact with .brother domain names. This addition allows developers to easily resolve .brother domains to addresses and vice versa, similar to existing StarknetId functionality.

### RPC version
N/A - This feature works with existing RPC implementations.

## Usage related changes
- Added new `BrotherId` class with methods to interact with Brother Identity contracts
- Introduced methods to resolve .brother domains:
  - `getBrotherName`: Get the primary Brother domain for an address
  - `getAddressFromBrotherName`: Resolve a Brother domain to its address
  - `getBrotherProfile`: Get complete profile information for a Brother domain
- Added utility function `isBrotherDomain` to validate .brother domains
- Extended the RPC Provider to include Brother ID functionality by default

## Development related changes
- Added new source file `src/provider/extensions/brotherId.ts` with Brother ID implementation
- Updated `src/provider/extensions/default.ts` to include BrotherId in the RPC Provider mixin
- Added TypeScript interface `BrotherProfile` for structured domain information

## Checklist:
- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [ ] Linked the issues which this PR resolves
- [x] Documented the changes in code (All methods include JSDoc documentation)
- [ ] Updated the tests (Tests need to be added)
- [ ] All tests are passing