### PR TITLE
feat: outside execution: add estimate fees and simulate

### DIFF
--- a/__tests__/account.outsideExecution.test.ts
+++ b/__tests__/account.outsideExecution.test.ts
@@ -10,16 +10,20 @@ import {
   constants,
   Contract,
   ec,
+  num,
   outsideExecution,
   OutsideExecutionVersion,
   Provider,
   src5,
   stark,
+  TransactionType,
   type Call,
   type Calldata,
+  type Invocations,
   type OutsideExecutionOptions,
   type OutsideTransaction,
   type TypedData,
+  type WeierstrassSignatureType,
 } from '../src';
 import { getSelectorFromName } from '../src/utils/hash';
 import { getDecimalString } from '../src/utils/num';
@@ -35,6 +39,25 @@ describe('Account and OutsideExecution', () => {
   // For ERC20 transfer outside call
   const recipientAccount = executorAccount;
   const ethContract = new Contract(contracts.Erc20OZ.sierra.abi, ethAddress, provider);
+  const call1: Call = {
+    contractAddress: ethAddress,
+    entrypoint: 'transfer',
+    calldata: {
+      recipient: recipientAccount.address,
+      amount: cairo.uint256(100),
+    },
+  };
+  const call2: Call = {
+    contractAddress: ethAddress,
+    entrypoint: 'transfer',
+    calldata: {
+      recipient: recipientAccount.address,
+      amount: cairo.uint256(200),
+    },
+  };
+  const now_seconds = Math.floor(Date.now() / 1000);
+  const hour_ago = (now_seconds - 3600).toString();
+  const hour_later = (now_seconds + 3600).toString();
 
   beforeAll(async () => {
     // Deploy the SNIP-9 signer account (ArgentX v 0.4.0, using SNIP-9 v2):
@@ -60,7 +83,7 @@ describe('Account and OutsideExecution', () => {
       entrypoint: 'transfer',
       calldata: {
         recipient: signerAccount.address,
-        amount: cairo.uint256(1000),
+        amount: cairo.uint256(1300),
       },
     };
     const { transaction_hash } = await executorAccount.execute(transferCall);
@@ -68,30 +91,14 @@ describe('Account and OutsideExecution', () => {
   });
 
   test('getOutsideCall', async () => {
-    const call1: Call = {
-      contractAddress: '0x0123',
-      entrypoint: 'transfer',
-      calldata: {
-        recipient: '0xabcd',
-        amount: cairo.uint256(10),
-      },
-    };
     expect(outsideExecution.getOutsideCall(call1)).toEqual({
-      to: '0x0123',
+      to: ethAddress,
       selector: getSelectorFromName(call1.entrypoint),
-      calldata: ['43981', '10', '0'],
+      calldata: [num.hexToDecimalString(recipientAccount.address), '100', '0'],
     });
   });
 
   test('Build SNIP-9 v2 TypedData', async () => {
-    const call1: Call = {
-      contractAddress: '0x0123',
-      entrypoint: 'transfer',
-      calldata: {
-        recipient: '0xabcd',
-        amount: cairo.uint256(10),
-      },
-    };
     const callOptions: OutsideExecutionOptions = {
       caller: '0x1234',
       execute_after: 100,
@@ -115,9 +122,9 @@ describe('Account and OutsideExecution', () => {
         Caller: '0x1234',
         Calls: [
           {
-            Calldata: ['43981', '10', '0'],
-            Selector: '0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e',
-            To: '0x0123',
+            Calldata: [num.hexToDecimalString(recipientAccount.address), '100', '0'],
+            Selector: getSelectorFromName(call1.entrypoint),
+            To: ethAddress,
           },
         ],
         'Execute After': 100,
@@ -216,6 +223,48 @@ describe('Account and OutsideExecution', () => {
     ]);
   });
 
+  test('buildExecuteFromOutsideCall', async () => {
+    const callOptions: OutsideExecutionOptions = {
+      caller: executorAccount.address,
+      execute_after: hour_ago,
+      execute_before: hour_later,
+    };
+    const outsideTransaction1: OutsideTransaction = await signerAccount.getOutsideTransaction(
+      callOptions,
+      [call1, call2]
+    );
+    const outsideExecutionCall: Call[] =
+      outsideExecution.buildExecuteFromOutsideCall(outsideTransaction1);
+    expect(outsideExecutionCall).toEqual([
+      {
+        calldata: [
+          '2846891009026995430665703316224827616914889274105712248413538305735679628945',
+          num.hexToDecimalString(outsideTransaction1.outsideExecution.nonce as string),
+          outsideTransaction1.outsideExecution.execute_after.toString(),
+          outsideTransaction1.outsideExecution.execute_before.toString(),
+          '2',
+          '2087021424722619777119509474943472645767659996348769578120564519014510906823',
+          '232670485425082704932579856502088130646006032362877466777181098476241604910',
+          '3',
+          '2846891009026995430665703316224827616914889274105712248413538305735679628945',
+          '100',
+          '0',
+          '2087021424722619777119509474943472645767659996348769578120564519014510906823',
+          '232670485425082704932579856502088130646006032362877466777181098476241604910',
+          '3',
+          '2846891009026995430665703316224827616914889274105712248413538305735679628945',
+          '200',
+          '0',
+          '2',
+          (outsideTransaction1.signature as WeierstrassSignatureType).r.toString(),
+          (outsideTransaction1.signature as WeierstrassSignatureType).s.toString(),
+        ],
+        contractAddress: signerAccount.address,
+        entrypoint: 'execute_from_outside_v2',
+      },
+    ]);
+  });
+
   test('Signer account should support SNIP-9 v2', async () => {
     expect(await signerAccount.getSnip9Version()).toBe(OutsideExecutionVersion.V2);
   });
@@ -227,9 +276,6 @@ describe('Account and OutsideExecution', () => {
   });
 
   test('should build and execute outside transactions', async () => {
-    const now_seconds = Math.floor(Date.now() / 1000);
-    const hour_ago = (now_seconds - 3600).toString();
-    const hour_later = (now_seconds + 3600).toString();
     const callOptions: OutsideExecutionOptions = {
       caller: executorAccount.address,
       execute_after: hour_ago,
@@ -238,22 +284,6 @@ describe('Account and OutsideExecution', () => {
     const callOptions4: OutsideExecutionOptions = {
       ...callOptions,
       caller: 'ANY_CALLER',
-    };
-    const call1: Call = {
-      contractAddress: ethAddress,
-      entrypoint: 'transfer',
-      calldata: {
-        recipient: recipientAccount.address,
-        amount: cairo.uint256(100),
-      },
-    };
-    const call2: Call = {
-      contractAddress: ethAddress,
-      entrypoint: 'transfer',
-      calldata: {
-        recipient: recipientAccount.address,
-        amount: cairo.uint256(200),
-      },
     };
     const call3: Call = {
       contractAddress: ethAddress,
@@ -325,6 +355,49 @@ describe('Account and OutsideExecution', () => {
     expect(bal1 - bal2).toBe(700n);
     expect(await signerAccount.isValidSnip9Nonce(outsideTransaction3.outsideExecution.nonce)).toBe(
       false
+    );
+  });
+
+  test('estimate fees / simulate outsideExecution', async () => {
+    const callOptions: OutsideExecutionOptions = {
+      caller: executorAccount.address,
+      execute_after: hour_ago,
+      execute_before: hour_later,
+    };
+    const outsideTransaction: OutsideTransaction = await signerAccount.getOutsideTransaction(
+      callOptions,
+      [call1, call2]
+    );
+    const outsideExecutionCall: Call[] =
+      outsideExecution.buildExecuteFromOutsideCall(outsideTransaction);
+    const estimateFee = await executorAccount.estimateFee(outsideExecutionCall);
+    expect(Object.keys(estimateFee)).toEqual(
+      Object.keys({
+        overall_fee: 0,
+        gas_consumed: 0,
+        gas_price: 0,
+        unit: 0,
+        suggestedMaxFee: 0,
+        resourceBounds: 0,
+        data_gas_consumed: 0,
+        data_gas_price: 0,
+      })
+    );
+
+    const invocations: Invocations = [
+      {
+        type: TransactionType.INVOKE,
+        payload: outsideExecutionCall,
+      },
+    ];
+    const responseSimulate = await executorAccount.simulateTransaction(invocations);
+    expect(Object.keys(responseSimulate[0])).toEqual(
+      Object.keys({
+        transaction_trace: 0,
+        fee_estimation: 0,
+        suggestedMaxFee: 0,
+        resourceBounds: 0,
+      })
     );
   });
 

--- a/__tests__/account.outsideExecution.test.ts
+++ b/__tests__/account.outsideExecution.test.ts
@@ -238,7 +238,7 @@ describe('Account and OutsideExecution', () => {
     expect(outsideExecutionCall).toEqual([
       {
         calldata: [
-          '2846891009026995430665703316224827616914889274105712248413538305735679628945',
+          num.hexToDecimalString(recipientAccount.address),
           num.hexToDecimalString(outsideTransaction1.outsideExecution.nonce as string),
           outsideTransaction1.outsideExecution.execute_after.toString(),
           outsideTransaction1.outsideExecution.execute_before.toString(),
@@ -246,13 +246,13 @@ describe('Account and OutsideExecution', () => {
           '2087021424722619777119509474943472645767659996348769578120564519014510906823',
           '232670485425082704932579856502088130646006032362877466777181098476241604910',
           '3',
-          '2846891009026995430665703316224827616914889274105712248413538305735679628945',
+          num.hexToDecimalString(recipientAccount.address),
           '100',
           '0',
           '2087021424722619777119509474943472645767659996348769578120564519014510906823',
           '232670485425082704932579856502088130646006032362877466777181098476241604910',
           '3',
-          '2846891009026995430665703316224827616914889274105712248413538305735679628945',
+          num.hexToDecimalString(recipientAccount.address),
           '200',
           '0',
           '2',

--- a/src/account/default.ts
+++ b/src/account/default.ts
@@ -59,7 +59,7 @@ import { calculateContractAddressFromHash } from '../utils/hash';
 import { isUndefined, isString } from '../utils/typed';
 import { isHex, toBigInt, toCairoBool, toHex } from '../utils/num';
 import {
-  buildExecuteFromOutsideCallData,
+  buildExecuteFromOutsideCall,
   getOutsideCall,
   getTypedData,
 } from '../utils/outsideExecution';
@@ -754,24 +754,7 @@ export class Account extends Provider implements AccountInterface {
     outsideTransaction: AllowArray<OutsideTransaction>,
     opts?: UniversalDetails
   ): Promise<InvokeFunctionResponse> {
-    const myOutsideTransactions = Array.isArray(outsideTransaction)
-      ? outsideTransaction
-      : [outsideTransaction];
-    const multiCall: Call[] = myOutsideTransactions.map((outsideTx: OutsideTransaction) => {
-      let entrypoint: string;
-      if (outsideTx.version === OutsideExecutionVersion.V1) {
-        entrypoint = 'execute_from_outside';
-      } else if (outsideTx.version === OutsideExecutionVersion.V2) {
-        entrypoint = 'execute_from_outside_v2';
-      } else {
-        throw new Error('Unsupported OutsideExecution version');
-      }
-      return {
-        contractAddress: toHex(outsideTx.signerAddress),
-        entrypoint,
-        calldata: buildExecuteFromOutsideCallData(outsideTx),
-      };
-    });
+    const multiCall = buildExecuteFromOutsideCall(outsideTransaction);
     return this.execute(multiCall, opts);
   }
 

--- a/www/docs/guides/outsideExecution.md
+++ b/www/docs/guides/outsideExecution.md
@@ -269,3 +269,29 @@ The balances are finally :
 :::info
 The complete code of this example is available [here](https://github.com/PhilippeR26/starknet.js-workshop-typescript/blob/main/src/scripts/Starknet131/Starknet131-devnet/17.outsideExecuteLedger.ts).
 :::
+
+## Estimate fees for an outside execution:
+
+On executor side, if you want to estimate how many fees you will pay:
+
+```typescript
+const outsideExecutionCall: Call[] =
+  outsideExecution.buildExecuteFromOutsideCall(outsideTransaction1);
+const estimateFee = await executorAccount.estimateFee(outsideExecutionCall);
+```
+
+## Simulate an outside execution:
+
+On executor side, if you want to simulate the transaction:
+
+```typescript
+const outsideExecutionCall: Call[] =
+  outsideExecution.buildExecuteFromOutsideCall(outsideTransaction1);
+const invocations: Invocations = [
+  {
+    type: TransactionType.INVOKE,
+    payload: outsideExecutionCall,
+  },
+];
+const responseSimulate = await executorAccount.simulateTransaction(invocations);
+```


### PR DESCRIPTION
## Motivation and Resolution
Solves issue #1263 .
User are requesting to add functions for executors of SNIP-9 outside executions, allowing them to estimate the fees they will have to pay and to simulate a SNIP-9 transaction.

## Usage related changes

### Estimate fees for an outside execution:
On executor side, if you want to estimate how many fees you will pay:

```typescript
const outsideExecutionCall: Call[] =
  outsideExecution.buildExecuteFromOutsideCall(outsideTransaction1);
const estimateFee = await executorAccount.estimateFee(outsideExecutionCall);
```

### Simulate an outside execution:
On executor side, if you want to simulate the transaction:

```typescript
const outsideExecutionCall: Call[] =
  outsideExecution.buildExecuteFromOutsideCall(outsideTransaction1);
const invocations: Invocations = [
  {
    type: TransactionType.INVOKE,
    payload: outsideExecutionCall,
  },
];
const responseSimulate = await executorAccount.simulateTransaction(invocations);
```

## Development related changes

- a function `outsideExecution.buildExecuteFromOutsideCall()` has been added to create a `Call`. Then this Call can be used in the standard functions for estimateFee and simulate.
- this new function allows some refactors in code & tests.

## Checklist:

- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Linked the issues which this PR resolves
- [x] Documented the changes in code (API docs will be generated automatically)
- [x] Updated the tests
- [x] All tests are passing
