### PR TITLE
Fix typo in CairoUint256 class documentation

### DIFF
--- a/src/utils/cairoDataTypes/uint256.ts
+++ b/src/utils/cairoDataTypes/uint256.ts
@@ -55,7 +55,7 @@ export class CairoUint256 {
   }
 
   /**
-   * Validate if BigNumberish can be represented as Unit256
+   * Validate if BigNumberish can be represented as Uint256
    */
   static validate(bigNumberish: BigNumberish) {
     const bigInt = BigInt(bigNumberish);
@@ -65,7 +65,7 @@ export class CairoUint256 {
   }
 
   /**
-   * Validate if low and high can be represented as Unit256
+   * Validate if low and high can be represented as Uint256
    */
   static validateProps(low: BigNumberish, high: BigNumberish) {
     const bigIntLow = BigInt(low);
@@ -80,7 +80,7 @@ export class CairoUint256 {
   }
 
   /**
-   * Check if BigNumberish can be represented as Unit256
+   * Check if BigNumberish can be represented as Uint256
    */
   static is(bigNumberish: BigNumberish) {
     try {


### PR DESCRIPTION
Fixed typo in the documentation comments of the CairoUint256 class where "uin256" was incorrectly used instead of "uint256" in the constructor documentation.