### PR TITLE
Replace `#[external(v0)]` with `#[abi(embed_v0)]` to fix deprecation warning

### DIFF
--- a/__mocks__/cairo/cairo210/cairo210.cairo
+++ b/__mocks__/cairo/cairo210/cairo210.cairo
@@ -13,7 +13,7 @@ mod MyTestFelt {
         counter: u128,
     }
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl TestFelt of super::ITestC210<ContractState> {
         fn test_felt(self: @ContractState, p1: felt252, p2: u128, p3: u8) -> u128 {
             p2 + 1


### PR DESCRIPTION
## Motivation and Resolution
The `#[external(v0)]` attribute has been deprecated in favor of `#[abi(embed_v0)]` or `#[abi(per_item)]`, as indicated by the following warning during compilation:

![Pasted Graphic](https://github.com/user-attachments/assets/43d16c07-d2c7-4f15-b70a-62b68d6c4497)



## Usage related changes

Users no longer see the deprecation warning related to `#[external(v0)]` during compilation.
Contracts now use `#[abi(embed_v0)]` as per the latest Cairo/Starknet standards.


## Development related changes

Removed deprecated `#[external(v0)]` and replaced it with `#[abi(embed_v0)]`.
Ensured that all modified files still compile successfully with `scarb build`.
Verified that no additional errors or warnings appear.
Confirmed that this change aligns with similar updates in the repository.

## Test Result

![hinesseSenih-MacBook-Air test virgul   scarb build](https://github.com/user-attachments/assets/0813a0cb-1fa3-493c-ae95-73f7d2758551)



