### PR TITLE
feat: prune deprecated functionalities

### DIFF
--- a/__tests__/account.starknetId.test.ts
+++ b/__tests__/account.starknetId.test.ts
@@ -46,39 +46,36 @@ describe('deploy and test Wallet', () => {
     });
     multicallAddress = multicallResponse.deploy.contract_address;
 
-    const { transaction_hash } = await account.execute(
-      [
-        {
-          contractAddress: devnetERC20Address,
-          entrypoint: 'approve',
-          calldata: [namingAddress, 0, 1], // Price of domain
-        },
-        {
-          contractAddress: identityAddress,
-          entrypoint: 'mint',
-          calldata: ['1'], // TokenId
-        },
-        {
-          contractAddress: namingAddress,
-          entrypoint: 'buy',
-          calldata: [
-            '1', // Starknet id linked
-            '1499554868251', // Domain encoded "fricoben"
-            '62', // days
-            '0', // resolver
-            0, // sponsor
-            0,
-            0,
-          ],
-        },
-        {
-          contractAddress: identityAddress,
-          entrypoint: 'set_main_id',
-          calldata: ['1'],
-        },
-      ],
-      undefined
-    );
+    const { transaction_hash } = await account.execute([
+      {
+        contractAddress: devnetERC20Address,
+        entrypoint: 'approve',
+        calldata: [namingAddress, 0, 1], // Price of domain
+      },
+      {
+        contractAddress: identityAddress,
+        entrypoint: 'mint',
+        calldata: ['1'], // TokenId
+      },
+      {
+        contractAddress: namingAddress,
+        entrypoint: 'buy',
+        calldata: [
+          '1', // Starknet id linked
+          '1499554868251', // Domain encoded "fricoben"
+          '62', // days
+          '0', // resolver
+          0, // sponsor
+          0,
+          0,
+        ],
+      },
+      {
+        contractAddress: identityAddress,
+        entrypoint: 'set_main_id',
+        calldata: ['1'],
+      },
+    ]);
 
     await provider.waitForTransaction(transaction_hash);
   });
@@ -102,21 +99,18 @@ describe('deploy and test Wallet', () => {
   describe('Test getStarkProfile', () => {
     beforeAll(async () => {
       // Add verifier data
-      const { transaction_hash: transaction_hash_verifier } = await account.execute(
-        [
-          {
-            contractAddress: identityAddress,
-            entrypoint: 'set_verifier_data',
-            calldata: [
-              '1', // token_id
-              shortString.encodeShortString('discord'), // field
-              123, // value
-              0,
-            ],
-          },
-        ],
-        undefined
-      );
+      const { transaction_hash: transaction_hash_verifier } = await account.execute([
+        {
+          contractAddress: identityAddress,
+          entrypoint: 'set_verifier_data',
+          calldata: [
+            '1', // token_id
+            shortString.encodeShortString('discord'), // field
+            123, // value
+            0,
+          ],
+        },
+      ]);
       await provider.waitForTransaction(transaction_hash_verifier);
     });
 

--- a/__tests__/cairov24onward.test.ts
+++ b/__tests__/cairov24onward.test.ts
@@ -176,8 +176,8 @@ describe('Cairo v2.4 onwards', () => {
 
     test('Tuple ((u256,(u16,Order2)), u8)', async () => {
       type Order2 = {
-        p1: num.BigNumberish;
-        p2: num.BigNumberish[];
+        p1: BigNumberish;
+        p2: BigNumberish[];
       };
       const myOrder2: Order2 = { p1: 100, p2: [5, 6, 7] };
       const calldata9 = myCallData.compile('get_tuple9', {

--- a/__tests__/rpcProvider.test.ts
+++ b/__tests__/rpcProvider.test.ts
@@ -326,11 +326,6 @@ describeIfRpc('RPCProvider', () => {
       expect(transaction).toHaveProperty('transaction_hash');
     });
 
-    test('getPendingTransactions', async () => {
-      const transactions = await rpcProvider.getPendingTransactions();
-      expect(Array.isArray(transactions)).toBe(true);
-    });
-
     test('getSyncingStats', async () => {
       const syncingStats = await rpcProvider.getSyncingStats();
       expect(syncingStats).toMatchSchemaRef('GetSyncingStatsResponse');

--- a/__tests__/transactionReceipt.test.ts
+++ b/__tests__/transactionReceipt.test.ts
@@ -33,7 +33,7 @@ describe('Transaction receipt utility - RPC 0.7 - V2', () => {
 
   test('test for Success variant', async () => {
     const myCall: Call = contract.populate('test_fail', { p1: 100 });
-    const res = await account.execute(myCall, undefined, { maxFee: 1 * 10 ** 15 }); // maxFee needed to not throw error in getEstimateFee
+    const res = await account.execute(myCall, { maxFee: 1 * 10 ** 15 }); // maxFee needed to not throw error in getEstimateFee
     const txR = await provider.waitForTransaction(res.transaction_hash);
     expect(txR.value).toHaveProperty('execution_status', TransactionExecutionStatus.SUCCEEDED);
     expect(txR.statusReceipt).toBe('success');
@@ -54,7 +54,7 @@ describe('Transaction receipt utility - RPC 0.7 - V2', () => {
 
   test('test for Reverted variant', async () => {
     const myCall: Call = contract.populate('test_fail', { p1: 10 }); // reverted if not 100
-    const res = await account.execute(myCall, undefined, { maxFee: 1 * 10 ** 15 }); // maxFee needed to not throw error in getEstimateFee
+    const res = await account.execute(myCall, { maxFee: 1 * 10 ** 15 }); // maxFee needed to not throw error in getEstimateFee
     const txR = await provider.waitForTransaction(res.transaction_hash);
     expect(txR.value).toHaveProperty('execution_status', TransactionExecutionStatus.REVERTED);
     expect(txR.statusReceipt).toBe('reverted');

--- a/__tests__/utils/ellipticalCurve.test.ts
+++ b/__tests__/utils/ellipticalCurve.test.ts
@@ -2,7 +2,7 @@ import { constants, ec } from '../../src';
 import { StarknetChainId } from '../../src/global/constants';
 import { computeHashOnElements } from '../../src/utils/hash';
 import { calculateTransactionHash } from '../../src/utils/hash/transactionHash/v2';
-import { fromCallsToExecuteCalldataWithNonce } from '../../src/utils/transaction';
+import { fromCallsToExecuteCalldata } from '../../src/utils/transaction';
 
 test('getKeyPair()', () => {
   const privateKey = '0x019800ea6a9a73f94aee6a3d2edf018fc770443e90c7ba121e8303ec6b349279';
@@ -46,7 +46,7 @@ test('hashMessage()', () => {
   ];
   const nonce = '3';
   const maxFee = '0';
-  const calldata = fromCallsToExecuteCalldataWithNonce(transactions, nonce);
+  const calldata = [...fromCallsToExecuteCalldata(transactions), nonce];
 
   const hashMsg = calculateTransactionHash(
     account,

--- a/__tests__/utils/ethSigner.test.ts
+++ b/__tests__/utils/ethSigner.test.ts
@@ -286,7 +286,7 @@ describe('Ethereum signer', () => {
         cairo.uint256(1 * 10 ** 4),
       ]);
       const feeTransfer = await ethAccount.estimateInvokeFee(txCallData);
-      const respTransfer = await ethAccount.execute(txCallData, undefined, {
+      const respTransfer = await ethAccount.execute(txCallData, {
         resourceBounds: {
           l2_gas: { max_amount: '0x0', max_price_per_unit: '0x0' },
           l1_gas: {

--- a/__tests__/utils/merkle.test.ts
+++ b/__tests__/utils/merkle.test.ts
@@ -1,6 +1,6 @@
+import { BigNumberish } from '../../src';
 import { computePedersenHash, computePoseidonHash } from '../../src/utils/hash';
 import { MerkleTree, proofMerklePath } from '../../src/utils/merkle';
-import { BigNumberish } from '../../src/utils/num';
 
 type RawHashMethod = (a: BigNumberish, b: BigNumberish) => string;
 

--- a/__tests__/utils/transaction.test.ts
+++ b/__tests__/utils/transaction.test.ts
@@ -1,42 +1,5 @@
-import { Call, CallStruct } from '../../src/types';
-import {
-  fromCallsToExecuteCalldata_cairo1,
-  transformCallsToMulticallArrays_cairo1,
-} from '../../src/utils/transaction';
-
-describe('transformCallsToMulticallArrays_cairo1', () => {
-  it('should return an empty array when given an empty input', () => {
-    expect(transformCallsToMulticallArrays_cairo1([])).toEqual([]);
-  });
-
-  it('should transform a list of calls into an array of call structs', () => {
-    const calls: Call[] = [
-      {
-        contractAddress: '0x123',
-        entrypoint: 'transfer',
-        calldata: [10],
-      },
-      {
-        contractAddress: '0x456',
-        entrypoint: 'mint',
-        calldata: ['0x2000', BigInt(10000000)],
-      },
-    ];
-    const expected: CallStruct[] = [
-      {
-        to: '291',
-        selector: '232670485425082704932579856502088130646006032362877466777181098476241604910',
-        calldata: ['10'],
-      },
-      {
-        to: '1110',
-        selector: '1329909728320632088402217562277154056711815095720684343816173432540100887380',
-        calldata: ['8192', '10000000'],
-      },
-    ];
-    expect(transformCallsToMulticallArrays_cairo1(calls)).toEqual(expected);
-  });
-});
+import { Call } from '../../src/types';
+import { fromCallsToExecuteCalldata_cairo1 } from '../../src/utils/transaction';
 
 describe('fromCallsToExecuteCalldata_cairo1', () => {
   it('should return an array with a length of one when given an empty input', () => {

--- a/__tests__/utils/typedData.test.ts
+++ b/__tests__/utils/typedData.test.ts
@@ -12,6 +12,7 @@ import {
   Account,
   BigNumberish,
   StarknetDomain,
+  TypedDataRevision,
   num,
   stark,
   typedData,
@@ -22,7 +23,6 @@ import { PRIME } from '../../src/global/constants';
 import { getSelectorFromName } from '../../src/utils/hash';
 import { MerkleTree } from '../../src/utils/merkle';
 import {
-  TypedDataRevision,
   encodeType,
   encodeValue,
   getMessageHash,

--- a/__tests__/utils/uint256.test.ts
+++ b/__tests__/utils/uint256.test.ts
@@ -1,6 +1,6 @@
-import { cairo, uint256 as u256 } from '../../src';
+import { cairo, uint256 as u256, UINT_128_MAX, UINT_256_MAX } from '../../src';
 
-const { bnToUint256, UINT_128_MAX, UINT_256_MAX, uint256ToBN } = u256;
+const { bnToUint256, uint256ToBN } = u256;
 
 describe('cairo uint256', () => {
   test('bnToUint256 should not convert -1 from BN to uint256 hex-string struct', () => {

--- a/__tests__/utils/utils.test.ts
+++ b/__tests__/utils/utils.test.ts
@@ -45,16 +45,6 @@ describe('cleanHex()', () => {
   });
 });
 
-describe('makeAddress()', () => {
-  test('test on eth address', () => {
-    const ethAddress = '0xdFD0F27FCe99b50909de0bDD328Aed6eAbe76BC5';
-
-    const starkAddress = stark.makeAddress(ethAddress);
-
-    expect(starkAddress).toBe('0xdfd0f27fce99b50909de0bdd328aed6eabe76bc5');
-  });
-});
-
 describe('getSelectorFromName()', () => {
   test('hash works for value="test"', () => {
     expect(hash.getSelectorFromName('test')).toBe(

--- a/src/account/interface.ts
+++ b/src/account/interface.ts
@@ -1,7 +1,6 @@
 import { ProviderInterface } from '../provider';
 import { SignerInterface } from '../signer';
 import {
-  Abi,
   AllowArray,
   BlockIdentifier,
   CairoVersion,
@@ -208,22 +207,6 @@ export abstract class AccountInterface extends ProviderInterface {
    */
   public abstract execute(
     transactions: AllowArray<Call>,
-    transactionsDetail?: InvocationsDetails
-  ): Promise<InvokeFunctionResponse>;
-  /**
-   * @deprecated
-   * @param transactions the invocation object or an array of them, containing:
-   * - contractAddress - the address of the contract
-   * - entrypoint - the entrypoint of the contract
-   * - calldata - (defaults to []) the calldata
-   * - signature - (defaults to []) the signature
-   * @param abis (optional) the abi of the contract for better displaying
-   * @param {InvocationsDetails} transactionsDetail Additional optional parameters for the transaction
-   * * @returns response from addTransaction
-   */
-  public abstract execute(
-    transactions: AllowArray<Call>,
-    abis?: Abi[],
     transactionsDetail?: InvocationsDetails
   ): Promise<InvokeFunctionResponse>;
 

--- a/src/contract/default.ts
+++ b/src/contract/default.ts
@@ -275,7 +275,7 @@ export class Contract implements ContractInterface {
       entrypoint: method,
     };
     if ('execute' in this.providerOrAccount) {
-      return this.providerOrAccount.execute(invocation, undefined, {
+      return this.providerOrAccount.execute(invocation, {
         maxFee,
         nonce,
       });

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,12 +51,3 @@ export * as wallet from './wallet/connect';
 export * from './global/config';
 export * from './global/logger';
 export * from './global/logger.type';
-
-/**
- * Deprecated
- */
-/* eslint-disable import/first */
-import * as num from './utils/num';
-
-/** @deprecated prefer the 'num' naming */
-export const number = num;

--- a/src/provider/interface.ts
+++ b/src/provider/interface.ts
@@ -177,7 +177,6 @@ export abstract class ProviderInterface {
 
   /**
    * Invokes a function on starknet
-   * @deprecated This method won't be supported as soon as fees are mandatory. Should not be used outside of Account class
    *
    * @param invocation the invocation object containing:
    * - contractAddress - the address of the contract
@@ -211,29 +210,6 @@ export abstract class ProviderInterface {
     transaction: DeclareContractTransaction,
     details: InvocationsDetailsWithNonce
   ): Promise<DeclareContractResponse>;
-
-  /**
-   * Estimates the fee for a given INVOKE transaction
-   * @deprecated Please use getInvokeEstimateFee or getDeclareEstimateFee instead. Should not be used outside of Account class
-   *
-   * @param invocation the invocation object containing:
-   * - contractAddress - the address of the contract
-   * - entrypoint - the entrypoint of the contract
-   * - calldata - (defaults to []) the calldata
-   * - signature - (defaults to []) the signature
-   * @param details - optional details containing:
-   * - nonce - optional nonce
-   * - version - optional version
-   * @param blockIdentifier - (optional) block identifier
-   * @param skipValidate - (optional) skip cairo __validate__ method
-   * @returns the estimated fee
-   */
-  public abstract getEstimateFee(
-    invocation: Invocation,
-    details: InvocationsDetailsWithNonce,
-    blockIdentifier?: BlockIdentifier,
-    skipValidate?: boolean
-  ): Promise<EstimateFeeResponse>;
 
   /**
    * Estimates the fee for a given INVOKE transaction

--- a/src/provider/rpc.ts
+++ b/src/provider/rpc.ts
@@ -254,16 +254,6 @@ export class RpcProvider implements ProviderInterface {
     return this.channel.getBlockTransactionCount(blockIdentifier);
   }
 
-  /**
-   * Return transactions from pending block
-   * @deprecated Instead use getBlock(BlockTag.PENDING); (will be removed in next minor version)
-   * Utility method, same result can be achieved using getBlockWithTxHashes(BlockTag.pending);
-   */
-  public async getPendingTransactions() {
-    const { transactions } = await this.getBlockWithTxHashes(BlockTag.PENDING);
-    return Promise.all(transactions.map((it: any) => this.getTransactionByHash(it)));
-  }
-
   public async getTransaction(txHash: BigNumberish) {
     return this.channel.getTransactionByHash(txHash);
   }
@@ -387,18 +377,6 @@ export class RpcProvider implements ProviderInterface {
       return { cairo: '1', compiler: undefined };
     }
     return { cairo: '0', compiler: '0' };
-  }
-
-  /**
-   * @deprecated use get*type*EstimateFee (will be refactored based on type after sequencer deprecation)
-   */
-  public async getEstimateFee(
-    invocation: Invocation,
-    invocationDetails: InvocationsDetailsWithNonce,
-    blockIdentifier?: BlockIdentifier,
-    skipValidate?: boolean
-  ) {
-    return this.getInvokeEstimateFee(invocation, invocationDetails, blockIdentifier, skipValidate);
   }
 
   public async getInvokeEstimateFee(

--- a/src/types/lib/index.ts
+++ b/src/types/lib/index.ts
@@ -301,12 +301,6 @@ export type getEstimateFeeBulkOptions = {
   skipValidate?: boolean;
 };
 
-export interface CallStruct {
-  to: string;
-  selector: string;
-  calldata: string[];
-}
-
 /**
  * Represent Contract version
  */

--- a/src/utils/cairoDataTypes/felt.ts
+++ b/src/utils/cairoDataTypes/felt.ts
@@ -1,6 +1,7 @@
 // TODO Convert to CairoFelt base on CairoUint256 and implement it in the codebase in the backward compatible manner
 
-import { BigNumberish, isHex, isStringWholeNumber } from '../num';
+import { BigNumberish } from '../../types';
+import { isHex, isStringWholeNumber } from '../num';
 import { encodeShortString, isShortString, isText } from '../shortString';
 import { isBoolean, isString, isBigInt } from '../typed';
 

--- a/src/utils/encode.ts
+++ b/src/utils/encode.ts
@@ -50,15 +50,6 @@ export function utf8ToArray(str: string): Uint8Array {
 }
 
 /**
- * Convert utf8-string to Uint8Array
- *
- * @deprecated equivalent to 'utf8ToArray', alias will be removed
- */
-export function stringToArrayBuffer(str: string): Uint8Array {
-  return utf8ToArray(str);
-}
-
-/**
  * Convert string to array buffer (browser and node compatible)
  *
  * @param {string} a The Base64 encoded string to convert.

--- a/src/utils/json.ts
+++ b/src/utils/json.ts
@@ -65,6 +65,3 @@ export const stringify = (
   space?: string | number | undefined,
   numberStringifiers?: json.NumberStringifier[] | undefined
 ): string => json.stringify(value, replacer, space, numberStringifiers)!;
-
-/** @deprecated equivalent to 'stringify', alias will be removed */
-export const stringifyAlwaysAsBig = stringify;

--- a/src/utils/num.ts
+++ b/src/utils/num.ts
@@ -7,9 +7,6 @@ import assert from './assert';
 import { addHexPrefix, buf2hex, removeHexPrefix } from './encode';
 import { isBigInt, isNumber, isString } from './typed';
 
-/** @deprecated prefer importing from 'types' over 'num' */
-export type { BigNumberish };
-
 /**
  * Test if string is hex-string
  *

--- a/src/utils/stark/index.ts
+++ b/src/utils/stark/index.ts
@@ -121,15 +121,6 @@ export function randomAddress(): string {
 }
 
 /**
- * Lowercase and hex prefix string
- *
- * @deprecated Not used internally, naming is confusing based on functionality
- */
-export function makeAddress(input: string): string {
-  return addHexPrefix(input).toLowerCase();
-}
-
-/**
  * Format Signature to standard type (hex array)
  * @param {Signature} [sig]
  * @returns {ArraySignatureType} Custom hex string array

--- a/src/utils/transaction.ts
+++ b/src/utils/transaction.ts
@@ -4,7 +4,6 @@ import {
   BigNumberish,
   CairoVersion,
   Call,
-  CallStruct,
   Calldata,
   ParsedStruct,
   RawArgs,
@@ -95,27 +94,6 @@ export const fromCallsToExecuteCalldata = (calls: Call[]) => {
   const { callArray, calldata } = transformCallsToMulticallArrays(calls);
   const compiledCalls = CallData.compile({ callArray });
   return [...compiledCalls, ...calldata] as Calldata;
-};
-
-/**
- * Transforms a list of calls into the Cairo 0 `__execute__` calldata including nonce.
- * @deprecated
- */
-export const fromCallsToExecuteCalldataWithNonce = (calls: Call[], nonce: BigNumberish) => {
-  return [...fromCallsToExecuteCalldata(calls), toBigInt(nonce).toString()] as Calldata;
-};
-
-/**
- * Format Data inside Calls
- * @deprecated Not required for getting execute Calldata
- */
-export const transformCallsToMulticallArrays_cairo1 = (calls: Call[]) => {
-  const callArray = calls.map<CallStruct>((call) => ({
-    to: toBigInt(call.contractAddress).toString(10),
-    selector: toBigInt(getSelectorFromName(call.entrypoint)).toString(10),
-    calldata: CallData.compile(call.calldata || []),
-  }));
-  return callArray;
 };
 
 /**

--- a/src/utils/typedData.ts
+++ b/src/utils/typedData.ts
@@ -24,9 +24,6 @@ import { isBigNumberish, isHex, toHex } from './num';
 import { encodeShortString } from './shortString';
 import { isBoolean, isString } from './typed';
 
-/** @deprecated prefer importing from 'types' over 'typedData' */
-export * from '../types/typedData';
-
 interface Context {
   parent?: string;
   key?: string;

--- a/src/utils/uint256.ts
+++ b/src/utils/uint256.ts
@@ -1,11 +1,6 @@
 /* eslint-disable no-bitwise */
 import { BigNumberish, Uint256 } from '../types';
-import { CairoUint256, UINT_128_MAX, UINT_256_MAX } from './cairoDataTypes/uint256';
-
-/**
- * @deprecated Legacy support Export
- */
-export { UINT_128_MAX, UINT_256_MAX };
+import { CairoUint256 } from './cairoDataTypes/uint256';
 
 /**
  * Convert Uint256 to bigint

--- a/src/wallet/account.ts
+++ b/src/wallet/account.ts
@@ -36,32 +36,16 @@ import {
   watchAsset,
 } from './connect';
 import { StarknetWalletProvider } from './types';
-import { logger } from '../global/logger';
 
-// TODO: Remove non address constructor in next major version
 // Represent 'Selected Active' Account inside Connected Wallet
 export class WalletAccount extends Account implements AccountInterface {
   public walletProvider: StarknetWalletProvider;
 
-  /**
-   * @deprecated Use static method WalletAccount.connect or WalletAccount.connectSilent instead. Constructor {@link WalletAccount.(format:2)}.
-   */
   constructor(
     providerOrOptions: ProviderOptions | ProviderInterface,
     walletProvider: StarknetWalletProvider,
+    address: string,
     cairoVersion?: CairoVersion
-  );
-  constructor(
-    providerOrOptions: ProviderOptions | ProviderInterface,
-    walletProvider: StarknetWalletProvider,
-    cairoVersion?: CairoVersion,
-    address?: string
-  );
-  constructor(
-    providerOrOptions: ProviderOptions | ProviderInterface,
-    walletProvider: StarknetWalletProvider,
-    cairoVersion?: CairoVersion,
-    address: string = ''
   ) {
     super(providerOrOptions, address, '', cairoVersion); // At this point unknown address
     this.walletProvider = walletProvider;
@@ -79,15 +63,6 @@ export class WalletAccount extends Account implements AccountInterface {
       // At the moment channel is stateless but it could change
       this.channel.setChainId(res as StarknetChainId);
     });
-
-    if (!address.length) {
-      logger.warn(
-        '@deprecated Use static method WalletAccount.connect or WalletAccount.connectSilent instead. Constructor {@link WalletAccount.(format:2)}.'
-      );
-      requestAccounts(this.walletProvider).then(([accountAddress]) => {
-        this.address = accountAddress.toLowerCase();
-      });
-    }
   }
 
   /**
@@ -190,7 +165,7 @@ export class WalletAccount extends Account implements AccountInterface {
     silentMode: boolean = false
   ) {
     const [accountAddress] = await requestAccounts(walletProvider, silentMode);
-    return new WalletAccount(provider, walletProvider, cairoVersion, accountAddress);
+    return new WalletAccount(provider, walletProvider, accountAddress, cairoVersion);
   }
 
   static async connectSilent(


### PR DESCRIPTION
## Motivation and Resolution

Removes long-standing deprecated functionalities and aliases.

Notes:
- the `ProviderInterface. invokeFunction()` deprecation seems to have been based on traits stemming from before the RPC support was introduced, it seems to have been made obsolete by the introduction of the `details` parameter - it is internally used so just the deprecation mark is removed
- the `WalletAccount` change could be made stricter by making the constructor private and introducing an optional `address` parameter to the `connect` methods to potentially skip the address retrieval