### PR TITLE
fix: make the provider create method generic to enable it when mixins are applied

### DIFF
--- a/src/account/default.ts
+++ b/src/account/default.ts
@@ -6,7 +6,7 @@ import {
   UDC,
   ZERO,
 } from '../global/constants';
-import { Provider, ProviderInterface } from '../provider';
+import { LibraryError, Provider, ProviderInterface } from '../provider';
 import { Signer, SignerInterface } from '../signer';
 import {
   AccountInvocations,
@@ -117,6 +117,13 @@ export class Account extends Provider implements AccountInterface {
       cairoVersion: this.cairoVersion,
       channel: this.channel.id,
     });
+  }
+
+  /** @deprecated @hidden */
+  // The deprecation tag is meant to discourage use, not to signal future removal
+  // it should only be removed if the relationship with the corresponding Provider.create(...) method changes
+  static async create(): Promise<never> {
+    throw new LibraryError('Not supported');
   }
 
   // provided version or contract based preferred transactionVersion

--- a/src/provider/rpc.ts
+++ b/src/provider/rpc.ts
@@ -92,18 +92,22 @@ export class RpcProvider implements ProviderInterface {
    * auto configure channel based on provided node
    * leave space for other async before constructor
    */
-  static async create(optionsOrProvider?: RpcProviderOptions) {
+  // NOTE: the generic T and 'this' reference are used so that the expanded class is generated when a mixin is applied
+  static async create<T extends RpcProvider>(
+    this: { new (...args: ConstructorParameters<typeof RpcProvider>): T },
+    optionsOrProvider?: RpcProviderOptions
+  ): Promise<T> {
     const channel = new RPC07.RpcChannel({ ...optionsOrProvider });
     const spec = await channel.getSpecVersion();
 
     if (isVersion('0.7', spec)) {
-      return new RpcProvider({ ...optionsOrProvider, specVersion: '0.7' });
+      return new this({ ...optionsOrProvider, specVersion: '0.7' }) as T;
     }
     if (isVersion('0.8', spec)) {
-      return new RpcProvider({ ...optionsOrProvider, specVersion: '0.8' });
+      return new this({ ...optionsOrProvider, specVersion: '0.8' }) as T;
     }
 
-    throw new Error('unable to detect specification version');
+    throw new LibraryError('Unable to detect specification version');
   }
 
   public fetch(method: string, params?: object, id: string | number = 0) {


### PR DESCRIPTION
## Motivation and Resolution

Ensures that `RpcProvider.create(...)` generates the chosen class with the appropriate TypeScript type for both the base class and extended classes after mixins are added. Also disables it for the `Account` class inheritance chain.

## Checklist:

- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [ ] Linked the issues which this PR resolves
- [x] Documented the changes in code (API docs will be generated automatically)
- [x] Updated the tests
- [ ] All tests are passing
