### PR TITLE
fix: broken messaging mechanism link in `L1message.md`

### DIFF
--- a/www/docs/guides/L1message.md
+++ b/www/docs/guides/L1message.md
@@ -10,7 +10,7 @@ You can exchange messages between L1 & L2 networks:
 - L2 Starknet testnet ↔️ L1 Sepolia ETH testnet.
 - L2 local Starknet devnet ↔️ L1 local ETH testnet (anvil, ...).
 
-You can find an explanation of the global mechanism [here](https://docs.starknet.io/documentation/architecture_and_concepts/L1-L2_Communication/messaging-mechanism/).
+You can find an explanation of the global mechanism [here](https://docs.starknet.io/architecture-and-concepts/network-architecture/messaging-mechanism/).
 
 Most of the code for this messaging process will be written in Cairo, but Starknet.js provides some functionalities for this subject.
 


### PR DESCRIPTION
## 🔗 Fix broken messaging mechanism link in `L1message.md`

This pull request updates the outdated link to the L1-L2 messaging mechanism documentation in the `L1message.md` guide.

### 🔧 Changes
- Replaced the broken link: https://docs.starknet.io/documentation/architecture_and_concepts/L1-L2_Communication/messaging-mechanism/ 
- with the updated working link: https://docs.starknet.io/architecture-and-concepts/network-architecture/messaging-mechanism/

### ✅ Why
The old URL was no longer accessible and led to a 404 page. The new link points to the correct and current section of the Starknet documentation regarding L1 ↔ L2 messaging.

---

Please let me know if any additional updates are needed.

