### PR TITLE
test: remove duplicated Ethereum address test block

### DIFF
--- a/__tests__/utils/ethSigner.test.ts
+++ b/__tests__/utils/ethSigner.test.ts
@@ -352,20 +352,6 @@ describe('Ethereum signer', () => {
       );
     });
   });
-  describe('Ethereum address', () => {
-    test('Eth address format', async () => {
-      const ethAddr = '0x8359E4B0152ed5A731162D3c7B0D8D56edB165'; // not a valid 20 bytes ETh address
-      expect(validateAndParseEthAddress(ethAddr)).toBe(
-        '0x008359e4b0152ed5a731162d3c7b0d8d56edb165'
-      );
-      expect(validateAndParseEthAddress(BigInt(ethAddr))).toBe(
-        '0x008359e4b0152ed5a731162d3c7b0d8d56edb165'
-      );
-      expect(validateAndParseEthAddress(BigInt(ethAddr).toString(10))).toBe(
-        '0x008359e4b0152ed5a731162d3c7b0d8d56edb165'
-      );
-    });
-  });
 });
 
 describe('Ledger Signer', () => {


### PR DESCRIPTION
## Motivation and Resolution

This pull request removes a duplicate `describe('Ethereum address')` block in the test suite. Having two identical test blocks is redundant.

### RPC version (if applicable)

N/A

## Usage related changes

No changes to the public API or user interface. This change only has internal testing implications.

## Development related changes

- Removed a test copy block, less redundant and clearer in the test suite.

## Checklist:

- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [ ] Linked the issues which this PR resolves
- [x] Documented the changes in code (API docs will be generated automatically)
- [x] Updated the tests
- [x] All tests are passing
