### PR TITLE
fix: ensure enum replacement objects are reachable for type resolution

### DIFF
--- a/src/global/constants.ts
+++ b/src/global/constants.ts
@@ -90,6 +90,8 @@ export { _TransactionHashPrefix as TransactionHashPrefix };
 const _SupportedRpcVersion = {
   0.7: '0.7',
   0.8: '0.8',
+  v07: '0.7',
+  v08: '0.8',
 } as const;
 type _SupportedRpcVersion = ValuesType<typeof _SupportedRpcVersion>;
 export { _SupportedRpcVersion as SupportedRpcVersion };

--- a/src/global/constants.ts
+++ b/src/global/constants.ts
@@ -1,5 +1,7 @@
+/* eslint-disable no-underscore-dangle */
 import type { FeeMarginPercentage } from '../types';
 import { ETransactionVersion, RPCSPEC08 } from '../types/api';
+import { ValuesType } from '../types/helpers/valuesType';
 import type { LogLevel } from './logger.type';
 
 export { IS_BROWSER } from '../utils/encode';
@@ -32,29 +34,6 @@ export const RANGE_FELT = range(ZERO, PRIME - 1n);
 export const RANGE_I128 = range(-(2n ** 127n), 2n ** 127n - 1n);
 export const RANGE_U128 = range(ZERO, 2n ** 128n - 1n);
 
-export enum BaseUrl {
-  SN_MAIN = 'https://alpha-mainnet.starknet.io',
-  SN_SEPOLIA = 'https://alpha-sepolia.starknet.io',
-}
-
-export enum NetworkName {
-  SN_MAIN = 'SN_MAIN',
-  SN_SEPOLIA = 'SN_SEPOLIA',
-}
-
-export enum StarknetChainId {
-  SN_MAIN = '0x534e5f4d41494e', // encodeShortString('SN_MAIN'),
-  SN_SEPOLIA = '0x534e5f5345504f4c4941', // encodeShortString('SN_SEPOLIA')
-}
-
-export enum TransactionHashPrefix {
-  DECLARE = '0x6465636c617265', // encodeShortString('declare'),
-  DEPLOY = '0x6465706c6f79', // encodeShortString('deploy'),
-  DEPLOY_ACCOUNT = '0x6465706c6f795f6163636f756e74', // encodeShortString('deploy_account'),
-  INVOKE = '0x696e766f6b65', // encodeShortString('invoke'),
-  L1_HANDLER = '0x6c315f68616e646c6572', // encodeShortString('l1_handler'),
-}
-
 export const UDC = {
   ADDRESS: '0x041a78e741e5af2fec34b695679bc6891742439f7afb8484ecd7766661ad02bf',
   ENTRYPOINT: 'deployContract',
@@ -72,14 +51,48 @@ export const HARDENING_BYTE = 128;
 // 0x80000000
 export const HARDENING_4BYTES = 2147483648n;
 
+// NOTE: the enum alias exports are made so both the 'const' and 'type' are reachable in the published '.d.ts' file,
+// otherwise the last export hides the preceding export with the same name in this file
+const _BaseUrl = {
+  SN_MAIN: 'https://alpha-mainnet.starknet.io',
+  SN_SEPOLIA: 'https://alpha-sepolia.starknet.io',
+} as const;
+type _BaseUrl = ValuesType<typeof _BaseUrl>;
+export { _BaseUrl as BaseUrl };
+
+const _NetworkName = {
+  SN_MAIN: 'SN_MAIN',
+  SN_SEPOLIA: 'SN_SEPOLIA',
+} as const;
+type _NetworkName = ValuesType<typeof _NetworkName>;
+export { _NetworkName as NetworkName };
+
+const _StarknetChainId = {
+  SN_MAIN: '0x534e5f4d41494e', // encodeShortString('SN_MAIN'),
+  SN_SEPOLIA: '0x534e5f5345504f4c4941', // encodeShortString('SN_SEPOLIA')
+} as const;
+type _StarknetChainId = ValuesType<typeof _StarknetChainId>;
+export { _StarknetChainId as StarknetChainId };
+
+const _TransactionHashPrefix = {
+  DECLARE: '0x6465636c617265', // encodeShortString('declare'),
+  DEPLOY: '0x6465706c6f79', // encodeShortString('deploy'),
+  DEPLOY_ACCOUNT: '0x6465706c6f795f6163636f756e74', // encodeShortString('deploy_account'),
+  INVOKE: '0x696e766f6b65', // encodeShortString('invoke'),
+  L1_HANDLER: '0x6c315f68616e646c6572', // encodeShortString('l1_handler'),
+} as const;
+type _TransactionHashPrefix = ValuesType<typeof _TransactionHashPrefix>;
+export { _TransactionHashPrefix as TransactionHashPrefix };
+
 /**
- * dot formate rpc versions
+ * dot format rpc versions
  */
-export const SupportedRpcVersion = {
+const _SupportedRpcVersion = {
   0.7: '0.7',
   0.8: '0.8',
 } as const;
-export type SupportedRpcVersion = (typeof SupportedRpcVersion)[keyof typeof SupportedRpcVersion];
+type _SupportedRpcVersion = ValuesType<typeof _SupportedRpcVersion>;
+export { _SupportedRpcVersion as SupportedRpcVersion };
 
 export type SupportedTransactionVersion =
   | typeof ETransactionVersion.V2
@@ -89,7 +102,7 @@ export type SupportedTransactionVersion =
 export const DEFAULT_GLOBAL_CONFIG: {
   legacyMode: boolean;
   logLevel: LogLevel;
-  rpcVersion: SupportedRpcVersion;
+  rpcVersion: _SupportedRpcVersion;
   transactionVersion: SupportedTransactionVersion;
   feeMarginPercentage: FeeMarginPercentage;
 } = {

--- a/src/types/outsideExecution.ts
+++ b/src/types/outsideExecution.ts
@@ -1,3 +1,4 @@
+import { ValuesType } from './helpers/valuesType';
 import { BigNumberish, RawArgs, type Signature } from './lib';
 
 export interface OutsideExecutionOptions {
@@ -74,8 +75,9 @@ export const OutsideExecutionTypesV2 = {
   ],
 };
 
-export enum OutsideExecutionVersion {
-  UNSUPPORTED = '0',
-  V1 = '1',
-  V2 = '2',
-}
+export const OutsideExecutionVersion = {
+  UNSUPPORTED: '0',
+  V1: '1',
+  V2: '2',
+} as const;
+export type OutsideExecutionVersion = ValuesType<typeof OutsideExecutionVersion>;


### PR DESCRIPTION
## Motivation and Resolution

Completes the transition from TS enums into their companion pattern replacements. Also repairs the reachability of the `SupportedRpcVersion` object that was being hidden by the type in the distribution build.

## Checklist:

- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [ ] Linked the issues which this PR resolves
- [ ] Documented the changes in code (API docs will be generated automatically)
- [ ] Updated the tests
- [ ] All tests are passing
