### PR TITLE
fix: add Lava RPC node to default Free RPC Nodes 

### DIFF
--- a/src/global/constants.ts
+++ b/src/global/constants.ts
@@ -135,10 +135,12 @@ export const RPC_DEFAULT_NODES = {
   SN_MAIN: [
     `https://starknet-mainnet.public.blastapi.io/rpc/`,
     `https://free-rpc.nethermind.io/mainnet-juno/`,
+    `https://rpc.starknet.lava.build:443`,
   ],
   SN_SEPOLIA: [
     `https://starknet-sepolia.public.blastapi.io/rpc/`,
     `https://free-rpc.nethermind.io/sepolia-juno/`,
+    `https://rpc.starknet-testnet.lava.build:443`,
   ],
 } as const;
 

--- a/src/global/constants.ts
+++ b/src/global/constants.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-underscore-dangle */
 import type { FeeMarginPercentage } from '../types';
-import { ETransactionVersion, RPCSPEC08 } from '../types/api';
+import { ETransactionVersion, RPCSPEC08, RPC_DEFAULT_VERSION } from '../types/api';
 import { ValuesType } from '../types/helpers/valuesType';
 import type { LogLevel } from './logger.type';
 
@@ -135,12 +135,12 @@ export const RPC_DEFAULT_NODES = {
   SN_MAIN: [
     `https://starknet-mainnet.public.blastapi.io/rpc/`,
     `https://free-rpc.nethermind.io/mainnet-juno/`,
-    `https://rpc.starknet.lava.build:443`,
+    `https://rpc.starknet.lava.build:443/${RPC_DEFAULT_VERSION}`,
   ],
   SN_SEPOLIA: [
     `https://starknet-sepolia.public.blastapi.io/rpc/`,
     `https://free-rpc.nethermind.io/sepolia-juno/`,
-    `https://rpc.starknet-testnet.lava.build:443`,
+    `https://rpc.starknet-testnet.lava.build:443/${RPC_DEFAULT_VERSION}`,
   ],
 } as const;
 


### PR DESCRIPTION
## REOPENING #1335 

## Motivation and Resolution

This PR adds Lava RPC node (https://www.lavanet.xyz/) as one of the default RPC providers for both Mainnet and Sepolia networks. This addition increases the reliability and availability of RPC nodes for StarkNet.js users by providing an additional fallback option.

Resolves #1331

### RPC version (if applicable)

Using default RPC version (v0_7) consistent with other providers

## Usage related changes

- Added Lava RPC node (`https://starknet.lava.build/rpc/v0_7`) to the default RPC nodes list for both SN_MAIN and SN_SEPOLIA networks
- Users will automatically get access to Lava RPC node when using default provider configuration
- No breaking changes - existing code will continue to work as before

## Development related changes

- Updated `constants.ts` to include new RPC endpoint
- No changes to testing infrastructure required as existing provider tests will automatically cover the new endpoint

## Checklist:

- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch
- [x] Linked the issues which this PR resolves (#1331)
- [x] Documented the changes in code
- [x] No test updates needed as existing tests cover provider functionality
- [x] All tests are passing