### PR TITLE
Fix crash on ReferenceError when run in service worker

### DIFF
--- a/src/utils/fetch.ts
+++ b/src/utils/fetch.ts
@@ -1,9 +1,6 @@
-import { IS_BROWSER } from './encode';
 import { LibraryError } from './errors';
-import { isUndefined } from './typed';
 
-export default (IS_BROWSER && window.fetch.bind(window)) || // use built-in fetch in browser if available
-  (!isUndefined(global) && global.fetch) || // use built-in fetch in node, react-native and service worker if available
+export default (typeof fetch === 'function' && fetch) ||
   // throw with instructions when no fetch is detected
   ((() => {
     throw new LibraryError(


### PR DESCRIPTION
## Motivation and Resolution

Resolves #1385 .

## Usage related changes

None

## Development related changes

Removes extraneous check for IS_BROWSER as fetch being defined in the window (or there even being a window object) implies its global availability.

## Checklist:

- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Linked the issues which this PR resolves
- [ ] Documented the changes in code (API docs will be generated automatically)
- [ ] Updated the tests
- [x] All tests are passing
