### PR TITLE
fix: new rpc08 methods are not accessible in RpcProvider

### DIFF
--- a/src/provider/rpc.ts
+++ b/src/provider/rpc.ts
@@ -663,9 +663,9 @@ export class RpcProvider implements ProviderInterface {
   /**
    * Given an l1 tx hash, returns the associated l1_handler tx hashes and statuses for all L1 -> L2 messages sent by the l1 transaction, ordered by the l1 tx sending order
    */
-  public getL1MessagesStatus(transactionHash: BigNumberish) {
+  public async getL1MessagesStatus(transactionHash: BigNumberish): Promise<RPC.L1L2MessagesStatus> {
     if (this.channel instanceof RPC08.RpcChannel) {
-      this.channel.getMessagesStatus(transactionHash);
+      return this.channel.getMessagesStatus(transactionHash);
     }
 
     throw new LibraryError('Unsupported method for RPC version');
@@ -674,14 +674,14 @@ export class RpcProvider implements ProviderInterface {
   /**
    * Get merkle paths in one of the state tries: global state, classes, individual contract
    */
-  public getStorageProof(
+  public async getStorageProof(
     classHashes: BigNumberish[],
     contractAddresses: BigNumberish[],
     contractsStorageKeys: RPC.CONTRACT_STORAGE_KEYS[],
     blockIdentifier?: BlockIdentifier
-  ) {
+  ): Promise<RPC.StorageProof> {
     if (this.channel instanceof RPC08.RpcChannel) {
-      this.channel.getStorageProof(
+      return this.channel.getStorageProof(
         classHashes,
         contractAddresses,
         contractsStorageKeys,
@@ -695,9 +695,9 @@ export class RpcProvider implements ProviderInterface {
   /**
    * Get the contract class definition in the given block associated with the given hash
    */
-  public getCompiledCasm(classHash: BigNumberish) {
+  public async getCompiledCasm(classHash: BigNumberish): Promise<RPC.CASM_COMPILED_CONTRACT_CLASS> {
     if (this.channel instanceof RPC08.RpcChannel) {
-      this.channel.getCompiledCasm(classHash);
+      return this.channel.getCompiledCasm(classHash);
     }
 
     throw new LibraryError('Unsupported method for RPC version');


### PR DESCRIPTION
## Motivation and Resolution
We have 3 new methods in Rpc 0.8:
- `getL1MessagesStatus()`
- `getStorageProof()`
- `getCompiledCasm()`

Methods have been created, but are not accessible in `RpcProvider` instance.
This is not working:
```typescript
myProvider.getStorageProof();
```

A workaround is:
```typescript
(myProvider.channel as RPC08.RpcChannel).getStorageProof();
```

## Usage related changes
Now these methods are working:
- `myProvider.getL1MessagesStatus()`
- `myProvider.getStorageProof()`
- `myProvider.getCompiledCasm()`

## Development related changes
Several problems solved in `src/provider/rpc.ts`.

## Checklist:

- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Documented the changes in code (API docs will be generated automatically)
- [ ] All tests are passing
