### PR TITLE
fix: isSuccess, isError, isReverted type predicate of ReceiptTx, GetTransactionReceiptResponse

### DIFF
--- a/src/utils/transactionReceipt/transactionReceipt.ts
+++ b/src/utils/transactionReceipt/transactionReceipt.ts
@@ -6,10 +6,10 @@ import {
   TransactionExecutionStatus,
 } from '../../types';
 import type {
+  GetTransactionReceiptResponse,
   TransactionReceiptCallbacks,
   TransactionReceiptCallbacksDefault,
   TransactionReceiptStatus,
-  GetTransactionReceiptResponse,
   TransactionReceiptValue,
 } from './transactionReceipt.type';
 
@@ -63,11 +63,11 @@ export class ReceiptTx implements GetTransactionReceiptResponse {
     return (callbacks as TransactionReceiptCallbacksDefault)._();
   }
 
-  isSuccess(): this is SuccessfulTransactionReceiptResponse {
+  isSuccess(): this is GetTransactionReceiptResponse<'success'> {
     return this.statusReceipt === 'success';
   }
 
-  isReverted(): this is RevertedTransactionReceiptResponse {
+  isReverted(): this is GetTransactionReceiptResponse<'reverted'> {
     return this.statusReceipt === 'reverted';
   }
 
@@ -78,7 +78,7 @@ export class ReceiptTx implements GetTransactionReceiptResponse {
     return this.statusReceipt === 'rejected';
   } */
 
-  isError() {
+  isError(): this is GetTransactionReceiptResponse<'error'> {
     return this.statusReceipt === 'error';
   }
 

--- a/src/utils/transactionReceipt/transactionReceipt.type.ts
+++ b/src/utils/transactionReceipt/transactionReceipt.type.ts
@@ -22,10 +22,17 @@ export type TransactionReceiptCallbacks =
   | TransactionReceiptCallbacksDefined
   | TransactionReceiptCallbacksDefault;
 
-export type GetTransactionReceiptResponse = {
-  readonly statusReceipt: TransactionReceiptStatus;
-  readonly value: TransactionReceiptValue;
+type TransactionReceiptStatusFromMethod<T extends `is${Capitalize<TransactionReceiptStatus>}`> =
+  T extends `is${infer R}` ? Uncapitalize<R> : never;
+
+export type GetTransactionReceiptResponse<
+  T extends TransactionReceiptStatus = TransactionReceiptStatus,
+> = {
+  readonly statusReceipt: T;
+  readonly value: TransactionStatusReceiptSets[T];
   match(callbacks: TransactionReceiptCallbacks): void;
 } & {
-  [key in `is${Capitalize<TransactionReceiptStatus>}`]: () => boolean;
+  [key in `is${Capitalize<TransactionReceiptStatus>}`]: () => this is GetTransactionReceiptResponse<
+    TransactionReceiptStatusFromMethod<key>
+  >;
 };

--- a/www/docs/guides/events.md
+++ b/www/docs/guides/events.md
@@ -60,7 +60,7 @@ You can recover all the events related to this transaction hash:
 
 ```typescript
 if (txReceipt.isSuccess()) {
-  const listEvents = txReceipt.events;
+  const listEvents = txReceipt.value.events;
 }
 ```
 


### PR DESCRIPTION
## Motivation & Resolution

- `GetTransactionReceiptResponse`'s methods `isSuccess()`, `isError()`, `isReverted()` is no longer narrow the right type.
- Documentation wrongly quotes usage of `txReceipt`

=> update proper type predicates for `GetTransactionReceiptResponse` and `ReceiptTx`

## Usage related changes

No changes

## Development related changes

No changes

## Checklist:

- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [ ] Linked the issues which this PR resolves
- [x] Documented the changes in code (API docs will be generated automatically)
- [ ] Updated the tests
- [ ] All tests are passing