### PR TITLE
fix: add max_fee warning to v3 tx, remove discontinued nethermind fre…

### DIFF
--- a/src/channel/rpc_0_7_1.ts
+++ b/src/channel/rpc_0_7_1.ts
@@ -38,6 +38,7 @@ import { decompressProgram, signatureToHexArray } from '../utils/stark';
 import { getVersionsByType } from '../utils/transaction';
 import { logger } from '../global/logger';
 import { config } from '../global/config';
+import { assertX } from '../utils/assert';
 
 const defaultOptions = {
   headers: { 'Content-Type': 'application/json' },
@@ -535,6 +536,12 @@ export class RpcChannel {
           fee_data_availability_mode: details.feeDataAvailabilityMode,
         },
       });
+
+      assertX(!(details as any).max_fee, () => {
+        logger.warn(SYSTEM_MESSAGES.maxFeeInV3, {
+          type: RPC.ETransactionType.INVOKE,
+        });
+      });
     }
 
     return this.waitMode ? this.waitForTransaction((await promise).transaction_hash) : promise;
@@ -615,6 +622,12 @@ export class RpcChannel {
           fee_data_availability_mode: details.feeDataAvailabilityMode,
         },
       });
+
+      assertX(!(details as any).max_fee, () => {
+        logger.warn(SYSTEM_MESSAGES.maxFeeInV3, {
+          type: RPC.ETransactionType.DECLARE,
+        });
+      });
     } else {
       throw Error('declare unspotted parameters');
     }
@@ -663,6 +676,12 @@ export class RpcChannel {
           nonce_data_availability_mode: details.nonceDataAvailabilityMode,
           fee_data_availability_mode: details.feeDataAvailabilityMode,
         },
+      });
+
+      assertX(!(details as any).max_fee, () => {
+        logger.warn(SYSTEM_MESSAGES.maxFeeInV3, {
+          type: RPC.ETransactionType.DEPLOY_ACCOUNT,
+        });
       });
     }
 
@@ -751,6 +770,13 @@ export class RpcChannel {
         fee_data_availability_mode: invocation.feeDataAvailabilityMode,
         account_deployment_data: invocation.accountDeploymentData.map((it) => toHex(it)),
       };
+
+      assertX(!(invocation as any).maxFee, () => {
+        logger.warn(SYSTEM_MESSAGES.maxFeeInV3, {
+          type: invocation.type,
+          versionType,
+        });
+      });
     }
 
     if (invocation.type === TransactionType.INVOKE) {

--- a/src/channel/rpc_0_7_1.ts
+++ b/src/channel/rpc_0_7_1.ts
@@ -537,7 +537,7 @@ export class RpcChannel {
         },
       });
 
-      assertX(!(details as any).max_fee, () => {
+      assertX(!(details as any).maxFee, () => {
         logger.warn(SYSTEM_MESSAGES.maxFeeInV3, {
           type: RPC.ETransactionType.INVOKE,
         });
@@ -623,7 +623,7 @@ export class RpcChannel {
         },
       });
 
-      assertX(!(details as any).max_fee, () => {
+      assertX(!(details as any).maxFee, () => {
         logger.warn(SYSTEM_MESSAGES.maxFeeInV3, {
           type: RPC.ETransactionType.DECLARE,
         });
@@ -678,7 +678,7 @@ export class RpcChannel {
         },
       });
 
-      assertX(!(details as any).max_fee, () => {
+      assertX(!(details as any).maxFee, () => {
         logger.warn(SYSTEM_MESSAGES.maxFeeInV3, {
           type: RPC.ETransactionType.DEPLOY_ACCOUNT,
         });

--- a/src/global/constants.ts
+++ b/src/global/constants.ts
@@ -136,14 +136,8 @@ export const DEFAULT_GLOBAL_CONFIG: {
 };
 
 export const RPC_DEFAULT_NODES = {
-  SN_MAIN: [
-    `https://starknet-mainnet.public.blastapi.io/rpc/`,
-    `https://free-rpc.nethermind.io/mainnet-juno/`,
-  ],
-  SN_SEPOLIA: [
-    `https://starknet-sepolia.public.blastapi.io/rpc/`,
-    `https://free-rpc.nethermind.io/sepolia-juno/`,
-  ],
+  SN_MAIN: [`https://starknet-mainnet.public.blastapi.io/rpc/`],
+  SN_SEPOLIA: [`https://starknet-sepolia.public.blastapi.io/rpc/`],
 } as const;
 
 export const PAYMASTER_RPC_NODES = {
@@ -161,4 +155,5 @@ export const SYSTEM_MESSAGES = {
     'Channel specification version is not compatible with the connected node Specification Version',
   unsupportedSpecVersion:
     'The connected node specification version is not supported by this library',
+  maxFeeInV3: 'maxFee is not supported in V3 transactions, use resourceBounds instead',
 };

--- a/src/utils/assert.ts
+++ b/src/utils/assert.ts
@@ -1,7 +1,7 @@
 /**
  * Asserts that the given condition is true, otherwise throws an error with an optional message.
  * @param {boolean} condition - The condition to check.
- * @param {string} [message] - The optional message to include in the error or method to call.
+ * @param {string} [message] - The optional message to include in the error.
  * @throws {Error} Throws an error if the condition is false.
  * @example
  * ```typescript

--- a/src/utils/assert.ts
+++ b/src/utils/assert.ts
@@ -1,7 +1,7 @@
 /**
  * Asserts that the given condition is true, otherwise throws an error with an optional message.
  * @param {boolean} condition - The condition to check.
- * @param {string} [message] - The optional message to include in the error.
+ * @param {string} [message] - The optional message to include in the error or method to call.
  * @throws {Error} Throws an error if the condition is false.
  * @example
  * ```typescript
@@ -12,5 +12,20 @@
 export default function assert(condition: boolean, message?: string): asserts condition {
   if (!condition) {
     throw new Error(message || 'Assertion failure');
+  }
+}
+
+/**
+ * Asserts that the given condition is true, otherwise call the method.
+ * @param condition
+ * @param method
+ */
+export function assertX(condition: boolean, method: () => void): asserts condition {
+  if (!condition) {
+    if (method.length === 0) {
+      method(); // Call the method if it's a function with no arguments
+    } else {
+      throw new Error('AssertionX failure: message function should not require arguments');
+    }
   }
 }


### PR DESCRIPTION
## Motivation and Resolution
- Add warning if maxFee is provided but it is v3 tx. (instead of just ignoring the parameter)
- Removed deprecated nethermind free RPC endpoint

## Checklist:

- [ ] Performed a self-review of the code
- [ ] Rebased to the last commit of the target branch (or merged it into my branch)
- [ ] Linked the issues which this PR resolves
- [ ] Documented the changes in code (API docs will be generated automatically)
- [ ] Updated the tests
- [ ] All tests are passing
