### PR TITLE
feat: snip29 safety checks

### DIFF
--- a/__tests__/accountPaymaster.test.ts
+++ b/__tests__/accountPaymaster.test.ts
@@ -1,13 +1,20 @@
-import { Account, Signature, Call, PaymasterDetails, PaymasterRpc } from '../src';
+import { Account, Signature, Call, PaymasterDetails, OutsideExecutionVersion } from '../src';
 
 jest.mock('../src/paymaster/rpc');
 
 describe('Account - Paymaster integration', () => {
+  let account: Account | null = null;
   const mockBuildTransaction = jest.fn();
+  const mockMaliciousBuildTransactionChangeFees = jest.fn();
+  const mockMaliciousBuildTransactionAddedCalls = jest.fn();
   const mockExecuteTransaction = jest.fn();
+  const mockGetSnip9Version = jest.fn();
   const mockSignMessage = jest.fn();
 
-  const fakeTypedData = {
+  const fakeSignature: Signature = ['0x1', '0x2'];
+  const calls: Call[] = [{ contractAddress: '0x123', entrypoint: 'transfer', calldata: [] }];
+
+  const typedData = {
     types: {},
     domain: {},
     primaryType: '',
@@ -16,17 +23,17 @@ describe('Account - Paymaster integration', () => {
       nonce: '0xnonce',
       execute_after: '0x1',
       execute_before: '0x2',
-      calls_len: '0x0',
-      calls: [],
+      calls_len: `0x${(calls.length + 1).toString(16)}`,
+      calls: [
+        ...calls,
+        { contractAddress: '0x456', entrypoint: 'transfer', calldata: ['0xcaller', 1200, 0] },
+      ],
     },
   };
 
-  const fakeSignature: Signature = ['0x1', '0x2'];
-  const calls: Call[] = [{ contractAddress: '0x123', entrypoint: 'transfer', calldata: [] }];
-
   const paymasterResponse = {
     type: 'invoke',
-    typed_data: fakeTypedData,
+    typed_data: typedData,
     parameters: {
       version: '0x1',
       feeMode: { mode: 'default', gasToken: '0x456' },
@@ -40,34 +47,68 @@ describe('Account - Paymaster integration', () => {
     },
   };
 
-  const mockPaymaster = () =>
-    ({
-      buildTransaction: mockBuildTransaction,
-      executeTransaction: mockExecuteTransaction,
-    }) as unknown as PaymasterRpc;
+  const maliciousTypedDataChangeFees = {
+    ...typedData,
+    message: {
+      ...typedData.message,
+      calls: [
+        ...calls,
+        { contractAddress: '0x456', entrypoint: 'transfer', calldata: ['0xcaller', 13000, 0] },
+      ],
+    },
+  };
 
-  const setupAccount = () =>
-    new Account(
-      {},
-      '0xabc',
-      { signMessage: mockSignMessage.mockResolvedValue(fakeSignature) } as any,
-      undefined,
-      undefined,
-      mockPaymaster()
-    );
+  const maliciousTypedDataAddedCalls = {
+    ...typedData,
+    message: {
+      ...typedData.message,
+      calls: [
+        ...calls,
+        { contractAddress: '0x456', entrypoint: 'transfer', calldata: ['0xcaller', 13000, 0] },
+        { contractAddress: '0x456', entrypoint: 'transfer', calldata: ['0xcaller', 13000, 0] },
+      ],
+    },
+  };
+
+  const maliciousPaymasterResponseChangeFees = {
+    ...paymasterResponse,
+    typed_data: maliciousTypedDataChangeFees,
+  };
+  const maliciousPaymasterResponseAddedCalls = {
+    ...paymasterResponse,
+    typed_data: maliciousTypedDataAddedCalls,
+  };
+
+  const getAccount = () => {
+    if (!account) {
+      account = new Account(
+        {},
+        '0xabc',
+        { signMessage: mockSignMessage.mockResolvedValue(fakeSignature) } as any,
+        undefined,
+        undefined,
+        undefined
+      );
+      // account object is instanciate in the constructor, we need to mock the paymaster methods after paymaster object is instanciate
+      account.paymaster.buildTransaction = mockBuildTransaction;
+      account.paymaster.executeTransaction = mockExecuteTransaction;
+    }
+    return account;
+  };
 
   beforeEach(() => {
     jest.clearAllMocks();
-    (PaymasterRpc as jest.Mock).mockImplementation(mockPaymaster);
+    jest.spyOn(getAccount(), 'getSnip9Version').mockImplementation(mockGetSnip9Version);
     mockBuildTransaction.mockResolvedValue(paymasterResponse);
+    mockMaliciousBuildTransactionChangeFees.mockResolvedValue(maliciousPaymasterResponseChangeFees);
+    mockMaliciousBuildTransactionAddedCalls.mockResolvedValue(maliciousPaymasterResponseAddedCalls);
     mockExecuteTransaction.mockResolvedValue({ transaction_hash: '0x123' });
+    mockGetSnip9Version.mockResolvedValue(OutsideExecutionVersion.V2);
   });
 
   describe('estimatePaymasterTransactionFee', () => {
     it('should return estimated transaction fee from paymaster', async () => {
-      const account = setupAccount();
-
-      const result = await account.estimatePaymasterTransactionFee(calls, {
+      const result = await getAccount().estimatePaymasterTransactionFee(calls, {
         feeMode: { mode: 'default', gasToken: '0x456' },
       });
 
@@ -88,33 +129,21 @@ describe('Account - Paymaster integration', () => {
   });
 
   describe('executePaymasterTransaction', () => {
-    it('should throw if token price exceeds maxPriceInStrk', async () => {
-      const account = setupAccount();
-      const details: PaymasterDetails = {
-        feeMode: { mode: 'default', gasToken: '0x456' },
-      };
-
-      await expect(account.executePaymasterTransaction(calls, details, 100n)).rejects.toThrow(
-        'Gas token price is too high'
-      );
-    });
-
     it('should sign and execute transaction via paymaster', async () => {
-      const account = setupAccount();
       const details: PaymasterDetails = {
         feeMode: { mode: 'default', gasToken: '0x456' },
       };
 
-      const result = await account.executePaymasterTransaction(calls, details);
+      const result = await getAccount().executePaymasterTransaction(calls, details);
 
       expect(mockBuildTransaction).toHaveBeenCalledTimes(1);
-      expect(mockSignMessage).toHaveBeenCalledWith(fakeTypedData, '0xabc');
+      expect(mockSignMessage).toHaveBeenCalledWith(typedData, '0xabc');
       expect(mockExecuteTransaction).toHaveBeenCalledWith(
         {
           type: 'invoke',
           invoke: {
             userAddress: '0xabc',
-            typedData: fakeTypedData,
+            typedData,
             signature: ['0x1', '0x2'],
           },
         },
@@ -125,6 +154,58 @@ describe('Account - Paymaster integration', () => {
         }
       );
       expect(result).toEqual({ transaction_hash: '0x123' });
+    });
+  });
+
+  describe('safeExecutePaymasterTransaction', () => {
+    it('should sign and execute transaction via paymaster', async () => {
+      const details: PaymasterDetails = {
+        feeMode: { mode: 'default', gasToken: '0x456' },
+      };
+
+      const result = await getAccount().safeExecutePaymasterTransaction(calls, details, '0x123456');
+      expect(result).toEqual({ transaction_hash: '0x123' });
+    });
+
+    it('should not throw if token price exceeds maxPriceInGasToken but transaction is sponsored', async () => {
+      const details: PaymasterDetails = {
+        feeMode: { mode: 'sponsored' },
+      };
+      const result = await getAccount().safeExecutePaymasterTransaction(calls, details, '0x123');
+      expect(result).toEqual({
+        transaction_hash: '0x123',
+      });
+    });
+
+    it('should throw if token price exceeds maxPriceInGasToken', async () => {
+      const details: PaymasterDetails = {
+        feeMode: { mode: 'default', gasToken: '0x456' },
+      };
+
+      await expect(
+        getAccount().safeExecutePaymasterTransaction(calls, details, '0x123')
+      ).rejects.toThrow('Gas token price is too high');
+    });
+
+    it('should throw if Gas token value is not equal to the provided gas fees', async () => {
+      const details: PaymasterDetails = {
+        feeMode: { mode: 'default', gasToken: '0x456' },
+      };
+      getAccount().paymaster.buildTransaction = mockMaliciousBuildTransactionChangeFees;
+      await expect(
+        getAccount().safeExecutePaymasterTransaction(calls, details, '0x123456')
+      ).rejects.toThrow('Gas token value is not equal to the provided gas fees');
+    });
+
+    it('should throw if provided calls are not strictly equal to the returned calls', async () => {
+      const details: PaymasterDetails = {
+        feeMode: { mode: 'default', gasToken: '0x456' },
+      };
+      getAccount().paymaster.buildTransaction = mockMaliciousBuildTransactionAddedCalls;
+
+      await expect(
+        getAccount().safeExecutePaymasterTransaction(calls, details, '0x123456')
+      ).rejects.toThrow('Provided calls are not strictly equal to the returned calls');
     });
   });
 });

--- a/src/account/default.ts
+++ b/src/account/default.ts
@@ -460,7 +460,7 @@ export class Account extends Provider implements AccountInterface {
     return preparedTransaction.fee;
   }
 
-  private async postBuildPaymasterTransaction(
+  private async preparePaymasterTransaction(
     preparedTransaction: PreparedTransaction
   ): Promise<ExecutableUserTransaction> {
     let transaction: ExecutableUserTransaction;
@@ -530,7 +530,7 @@ export class Account extends Provider implements AccountInterface {
     }
   }
 
-  private async internalexecutePaymasterTransaction(
+  private async executePaymasterTransactionWithSafetyChecksIfNeeded(
     calls: Call[],
     paymasterDetails: PaymasterDetails,
     maxFeeInGasToken?: BigNumberish
@@ -558,8 +558,6 @@ export class Account extends Provider implements AccountInterface {
               ? (preparedTransaction.typed_data.message as any).calls
               : (preparedTransaction.typed_data.message as any).Calls;
 
-          console.log(calls, unsafeCalls);
-
           // Here there is always 1 more call in the returned calls -> Transfer of the gas token
           this.assertCallsAreStrictlyEqual(calls, unsafeCalls);
 
@@ -579,7 +577,7 @@ export class Account extends Provider implements AccountInterface {
     }
 
     const transaction: ExecutableUserTransaction =
-      await this.postBuildPaymasterTransaction(preparedTransaction);
+      await this.preparePaymasterTransaction(preparedTransaction);
 
     return this.paymaster
       .executeTransaction(transaction, preparedTransaction.parameters)
@@ -590,7 +588,7 @@ export class Account extends Provider implements AccountInterface {
     calls: Call[],
     paymasterDetails: PaymasterDetails
   ): Promise<InvokeFunctionResponse> {
-    return this.internalexecutePaymasterTransaction(calls, paymasterDetails);
+    return this.executePaymasterTransactionWithSafetyChecksIfNeeded(calls, paymasterDetails);
   }
 
   public async safeExecutePaymasterTransaction(
@@ -598,7 +596,11 @@ export class Account extends Provider implements AccountInterface {
     paymasterDetails: PaymasterDetails,
     maxFeeInGasToken: BigNumberish
   ): Promise<InvokeFunctionResponse> {
-    return this.internalexecutePaymasterTransaction(calls, paymasterDetails, maxFeeInGasToken);
+    return this.executePaymasterTransactionWithSafetyChecksIfNeeded(
+      calls,
+      paymasterDetails,
+      maxFeeInGasToken
+    );
   }
 
   /**

--- a/src/account/interface.ts
+++ b/src/account/interface.ts
@@ -22,6 +22,9 @@ import {
   InvokeFunctionResponse,
   MultiDeployContractResponse,
   Nonce,
+  PaymasterDetails,
+  PaymasterFeeEstimate,
+  PreparedTransaction,
   Signature,
   SimulateTransactionDetails,
   SimulateTransactionResponse,
@@ -209,6 +212,46 @@ export abstract class AccountInterface extends ProviderInterface {
     transactions: AllowArray<Call>,
     transactionsDetail?: InvocationsDetails
   ): Promise<InvokeFunctionResponse>;
+
+  /**
+   * Estimate Fee for executing a paymaster transaction on starknet
+   *
+   * @param calls the invocation object containing:
+   * - contractAddress - the address of the contract
+   * - entrypoint - the entrypoint of the contract
+   * - calldata - (defaults to []) the calldata
+   *
+   * @param paymasterDetails the paymaster details containing:
+   * - feeMode - the fee mode
+   * - deploymentData - the deployment data (optional)
+   * - timeBounds - the time bounds (optional)
+   *
+   * @returns response extracting fee from buildPaymasterTransaction
+   */
+  public abstract estimatePaymasterTransactionFee(
+    calls: Call[],
+    paymasterDetails: PaymasterDetails
+  ): Promise<PaymasterFeeEstimate>;
+
+  /**
+   * Build a paymaster transaction
+   *
+   * @param calls the invocation object containing:
+   * - contractAddress - the address of the contract
+   * - entrypoint - the entrypoint of the contract
+   * - calldata - (defaults to []) the calldata
+   *
+   * @param paymasterDetails the paymaster details containing:
+   * - feeMode - the fee mode
+   * - deploymentData - the deployment data (optional)
+   * - timeBounds - the time bounds (optional)
+   *
+   * @returns the prepared transaction
+   */
+  public abstract buildPaymasterTransaction(
+    calls: Call[],
+    paymasterDetails: PaymasterDetails
+  ): Promise<PreparedTransaction>;
 
   /**
    * Declares a given compiled contract (json) to starknet

--- a/src/account/interface.ts
+++ b/src/account/interface.ts
@@ -2,6 +2,7 @@ import { ProviderInterface } from '../provider';
 import { SignerInterface } from '../signer';
 import {
   AllowArray,
+  BigNumberish,
   BlockIdentifier,
   CairoVersion,
   Call,
@@ -252,6 +253,54 @@ export abstract class AccountInterface extends ProviderInterface {
     calls: Call[],
     paymasterDetails: PaymasterDetails
   ): Promise<PreparedTransaction>;
+
+  /**
+   * Execute a paymaster transaction
+   *
+   * @param calls the invocation object containing:
+   * - contractAddress - the address of the contract
+   * - entrypoint - the entrypoint of the contract
+   * - calldata - (defaults to []) the calldata
+   *
+   * @param paymasterDetails the paymaster details containing:
+   * - feeMode - the fee mode
+   * - deploymentData - the deployment data (optional)
+   * - timeBounds - the time bounds (optional)
+   *
+   * @returns the tarnsaction hash if successful, otherwise an error is thrown
+   */
+  public abstract executePaymasterTransaction(
+    calls: Call[],
+    paymasterDetails: PaymasterDetails
+  ): Promise<InvokeFunctionResponse>;
+
+  /**
+   * Execute a safe paymaster transaction
+   *
+   * Assert that the gas token value is equal to the provided gas fees.
+   * Assert that the calls are strictly equal to the returned calls.
+   * Assert that the gas token (in gas token) price is not too high.
+   * Assert that typedData to signed is strictly equal to the provided typedData.
+   *
+   * @param calls the invocation object containing:
+   * - contractAddress - the address of the contract
+   * - entrypoint - the entrypoint of the contract
+   * - calldata - (defaults to []) the calldata
+   *
+   * @param paymasterDetails the paymaster details containing:
+   * - feeMode - the fee mode
+   * - deploymentData - the deployment data (optional)
+   * - timeBounds - the time bounds (optional)
+   *
+   * @param maxFeeInGasToken - the max fee acceptable to pay in gas token
+   *
+   * @returns the tarnsaction hash if successful, otherwise an error is thrown
+   */
+  public abstract safeExecutePaymasterTransaction(
+    calls: Call[],
+    paymasterDetails: PaymasterDetails,
+    maxFeeInGasToken: BigNumberish
+  ): Promise<InvokeFunctionResponse>;
 
   /**
    * Declares a given compiled contract (json) to starknet


### PR DESCRIPTION
## Motivation and Resolution

Related to [snip29 implementation](https://github.com/starknet-io/starknet.js/pull/1377)
Resolved #1400

- Improving DX 
- Add a "safeExecutePaymaster" adding security checks

## Usage related changes

Using an Account, you now have access to:
- estimatePaymasterTransactionFee
- buildPaymasterTransaction
- executePaymasterTransaction
- safeExecutePaymaster
   - Assertion on gas token value transfer
   - Assertion on calls equality with signed typedData
   - Add a maxFeeInGasToken, asserting the max allowed gas token to be spend

## Development related changes

- Add related tests
- Code is retro-compatible

## Checklist:

- [ x] Performed a self-review of the code
- [ x] Rebased to the last commit of the target branch (or merged it into my branch)
- [ x] Linked the issues which this PR resolves
- [ x] Documented the changes in code (API docs will be generated automatically)
- [ x] Updated the tests
- [ x] All tests are passing
