### PR TITLE
Update/snip29

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "lossless-json": "^4.0.1",
         "pako": "^2.0.4",
         "starknet-types-07": "npm:@starknet-io/types-js@~0.7.10",
-        "starknet-types-08": "npm:@starknet-io/types-js@~0.8.3",
+        "starknet-types-08": "npm:@starknet-io/types-js@~0.8.4",
         "ts-mixer": "^6.0.3"
       },
       "devDependencies": {
@@ -18011,9 +18011,9 @@
     },
     "node_modules/starknet-types-08": {
       "name": "@starknet-io/types-js",
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/@starknet-io/types-js/-/types-js-0.8.3.tgz",
-      "integrity": "sha512-L9/NKH0k2rIEDcYuB8r8fjgVaCXrXaju/JVOn8/EzuffNFWArHwQfz38dpwOuN05vHO+KykpeQW73Ro/HoR9xA=="
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/@starknet-io/types-js/-/types-js-0.8.4.tgz",
+      "integrity": "sha512-0RZ3TZHcLsUTQaq1JhDSCM8chnzO4/XNsSCozwDET64JK5bjFDIf2ZUkta+tl5Nlbf4usoU7uZiDI/Q57kt2SQ=="
     },
     "node_modules/stream-combiner2": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "lossless-json": "^4.0.1",
     "pako": "^2.0.4",
     "starknet-types-07": "npm:@starknet-io/types-js@~0.7.10",
-    "starknet-types-08": "npm:@starknet-io/types-js@~0.8.3",
+    "starknet-types-08": "npm:@starknet-io/types-js@~0.8.4",
     "ts-mixer": "^6.0.3"
   },
   "engines": {

--- a/src/account/default.ts
+++ b/src/account/default.ts
@@ -455,7 +455,7 @@ export class Account extends Provider implements AccountInterface {
     return preparedTransaction.fee;
   }
 
-  private async preparePaymasterTransaction(
+  public async preparePaymasterTransaction(
     preparedTransaction: PreparedTransaction
   ): Promise<ExecutableUserTransaction> {
     let transaction: ExecutableUserTransaction;

--- a/src/account/interface.ts
+++ b/src/account/interface.ts
@@ -268,9 +268,9 @@ export abstract class AccountInterface extends ProviderInterface {
    * - calldata - (defaults to []) the calldata
    *
    * @param paymasterDetails the paymaster details containing:
-   * - feeMode - the fee mode
+   * - feeMode - the fee mode (sponsored or default)
    * - deploymentData - the deployment data (optional)
-   * - timeBounds - the time bounds (optional)
+   * - timeBounds - the time bounds when the transaction is valid (optional) - executeAfter and executeBefore expected to be in seconds (BLOCK_TIMESTAMP)
    *
    * @param maxFeeInGasToken - the max fee acceptable to pay in gas token (optional)
    *

--- a/src/paymaster/rpc.ts
+++ b/src/paymaster/rpc.ts
@@ -45,15 +45,15 @@ const convertFEE_MODE = (feeMode: PAYMASTER_API.FEE_MODE): FeeMode => {
 };
 
 const convertTimeBounds = (timeBounds?: PaymasterTimeBounds): TIME_BOUNDS | undefined =>
-  timeBounds && timeBounds.executeAfter && timeBounds.executeBefore
+  timeBounds
     ? {
-        execute_after: timeBounds.executeAfter,
+        execute_after: timeBounds.executeAfter || 1, // If executeAfter is not provided, set it to 1, meaning the transaction can be executed immediately
         execute_before: timeBounds.executeBefore,
       }
     : undefined;
 
 const convertTIME_BOUNDS = (timeBounds?: TIME_BOUNDS): PaymasterTimeBounds | undefined =>
-  timeBounds && timeBounds.execute_after && timeBounds.execute_before
+  timeBounds
     ? {
         executeAfter: timeBounds.execute_after,
         executeBefore: timeBounds.execute_before,

--- a/src/paymaster/rpc.ts
+++ b/src/paymaster/rpc.ts
@@ -47,16 +47,16 @@ const convertFEE_MODE = (feeMode: PAYMASTER_API.FEE_MODE): FeeMode => {
 const convertTimeBounds = (timeBounds?: PaymasterTimeBounds): TIME_BOUNDS | undefined =>
   timeBounds && timeBounds.executeAfter && timeBounds.executeBefore
     ? {
-        execute_after: timeBounds.executeAfter.getTime().toString(),
-        execute_before: timeBounds.executeBefore.getTime().toString(),
+        execute_after: timeBounds.executeAfter,
+        execute_before: timeBounds.executeBefore,
       }
     : undefined;
 
 const convertTIME_BOUNDS = (timeBounds?: TIME_BOUNDS): PaymasterTimeBounds | undefined =>
   timeBounds && timeBounds.execute_after && timeBounds.execute_before
     ? {
-        executeAfter: new Date(timeBounds.execute_after),
-        executeBefore: new Date(timeBounds.execute_before),
+        executeAfter: timeBounds.execute_after,
+        executeBefore: timeBounds.execute_before,
       }
     : undefined;
 

--- a/src/types/lib/contract/legacy.ts
+++ b/src/types/lib/contract/legacy.ts
@@ -55,7 +55,8 @@ export interface Program {
   }>;
   compiler_version?: string;
   main_scope?: string;
-  identifiers?: Record<string, 
+  identifiers?: Record<
+    string,
     | {
         destination: string;
         type: 'alias';
@@ -66,19 +67,25 @@ export interface Program {
         type: 'function';
         implicit_args?: {
           full_name: string;
-          members: Record<string, {
-            cairo_type: string;
-            offset: number;
-          }>;
+          members: Record<
+            string,
+            {
+              cairo_type: string;
+              offset: number;
+            }
+          >;
           size: number;
           type: 'struct';
         };
         explicit_args?: {
           full_name: string;
-          members: Record<string, {
-            cairo_type: string;
-            offset: number;
-          }>;
+          members: Record<
+            string,
+            {
+              cairo_type: string;
+              offset: number;
+            }
+          >;
           size: number;
           type: 'struct';
         };
@@ -89,10 +96,15 @@ export interface Program {
       }
     | {
         full_name: string;
-        members: Record<string, {
-          cairo_type: string;
-          offset: number;
-        }> | Record<string, never>;
+        members:
+          | Record<
+              string,
+              {
+                cairo_type: string;
+                offset: number;
+              }
+            >
+          | Record<string, never>;
         size: number;
         type: 'struct';
       }
@@ -125,11 +137,17 @@ export interface Program {
         type: 'reference';
       }
   >;
-  reference_manager?: Record<string, {
-    references: unknown[];
-  }>;
-  debug_info?: Record<string, {
-    file_contents?: Record<string, string>;
-    instruction_locations?: Record<string, unknown[]>;
-  }>;
+  reference_manager?: Record<
+    string,
+    {
+      references: unknown[];
+    }
+  >;
+  debug_info?: Record<
+    string,
+    {
+      file_contents?: Record<string, string>;
+      instruction_locations?: Record<string, unknown[]>;
+    }
+  >;
 }

--- a/src/types/paymaster/response.ts
+++ b/src/types/paymaster/response.ts
@@ -93,7 +93,8 @@ export type ExecutionParameters = {
   timeBounds?: PaymasterTimeBounds;
 };
 
+// executeBefore & executeAfter are in seconds, and is compared to the current block timestamp (see https://docs.starknet.io/architecture-and-concepts/network-architecture/block-structure/)
 export interface PaymasterTimeBounds {
-  executeAfter?: number;
-  executeBefore?: number;
+  executeAfter?: number; // executeAfter is optional, if not provided, it will be set to 1, meaning the transaction can be executed immediately
+  executeBefore: number; // executeBefore is mandatory if timeBounds is provided
 }

--- a/src/types/paymaster/response.ts
+++ b/src/types/paymaster/response.ts
@@ -94,6 +94,6 @@ export type ExecutionParameters = {
 };
 
 export interface PaymasterTimeBounds {
-  executeAfter?: Date;
-  executeBefore?: Date;
+  executeAfter?: number;
+  executeBefore?: number;
 }


### PR DESCRIPTION
## Motivation and Resolution

Improve SNIP-29 related Dev experience

## Usage related changes

- preparePaymasterTransaction is now public
- timeBounds 'executeAfter' & 'executeBefore' are now expressed in seconds (BLOCK_TIMESTAMP)

Also see https://github.com/starknet-io/types-js/pull/40