### PR TITLE
feat: rename internal type-js alias to organization

### DIFF
--- a/__tests__/accountPaymaster.test.ts
+++ b/__tests__/accountPaymaster.test.ts
@@ -1,4 +1,4 @@
-import { OutsideCallV2, OutsideExecutionTypedDataV2 } from 'starknet-types-08';
+import { OutsideCallV2, OutsideExecutionTypedDataV2 } from '@starknet-io/starknet-types-08';
 import { Account, Signature, Call, PaymasterDetails, OutsideExecutionVersion } from '../src';
 import { getSelectorFromName } from '../src/utils/hash';
 

--- a/__tests__/defaultPaymaster.test.ts
+++ b/__tests__/defaultPaymaster.test.ts
@@ -1,4 +1,4 @@
-import { OutsideExecutionTypedData } from 'starknet-types-08';
+import { OutsideExecutionTypedData } from '@starknet-io/starknet-types-08';
 import {
   RpcError,
   PaymasterRpc,

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,11 +13,11 @@
         "@noble/hashes": "1.6.0",
         "@scure/base": "1.2.1",
         "@scure/starknet": "1.1.0",
+        "@starknet-io/starknet-types-07": "npm:@starknet-io/types-js@~0.7.10",
+        "@starknet-io/starknet-types-08": "npm:@starknet-io/types-js@~0.8.3",
         "abi-wan-kanabi": "2.2.4",
         "lossless-json": "^4.0.1",
         "pako": "^2.0.4",
-        "starknet-types-07": "npm:@starknet-io/types-js@~0.7.10",
-        "starknet-types-08": "npm:@starknet-io/types-js@~0.8.3",
         "ts-mixer": "^6.0.3"
       },
       "devDependencies": {
@@ -4876,6 +4876,19 @@
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
       }
+    },
+    "node_modules/@starknet-io/starknet-types-07": {
+      "name": "@starknet-io/types-js",
+      "version": "0.7.10",
+      "resolved": "https://registry.npmjs.org/@starknet-io/types-js/-/types-js-0.7.10.tgz",
+      "integrity": "sha512-1VtCqX4AHWJlRRSYGSn+4X1mqolI1Tdq62IwzoU2vUuEE72S1OlEeGhpvd6XsdqXcfHmVzYfj8k1XtKBQqwo9w=="
+    },
+    "node_modules/@starknet-io/starknet-types-08": {
+      "name": "@starknet-io/types-js",
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/@starknet-io/types-js/-/types-js-0.8.3.tgz",
+      "integrity": "sha512-L9/NKH0k2rIEDcYuB8r8fjgVaCXrXaju/JVOn8/EzuffNFWArHwQfz38dpwOuN05vHO+KykpeQW73Ro/HoR9xA==",
+      "license": "MIT"
     },
     "node_modules/@tootallnate/once": {
       "version": "2.0.0",
@@ -18001,19 +18014,6 @@
       "engines": {
         "node": ">=12"
       }
-    },
-    "node_modules/starknet-types-07": {
-      "name": "@starknet-io/types-js",
-      "version": "0.7.10",
-      "resolved": "https://registry.npmjs.org/@starknet-io/types-js/-/types-js-0.7.10.tgz",
-      "integrity": "sha512-1VtCqX4AHWJlRRSYGSn+4X1mqolI1Tdq62IwzoU2vUuEE72S1OlEeGhpvd6XsdqXcfHmVzYfj8k1XtKBQqwo9w==",
-      "license": "MIT"
-    },
-    "node_modules/starknet-types-08": {
-      "name": "@starknet-io/types-js",
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/@starknet-io/types-js/-/types-js-0.8.3.tgz",
-      "integrity": "sha512-L9/NKH0k2rIEDcYuB8r8fjgVaCXrXaju/JVOn8/EzuffNFWArHwQfz38dpwOuN05vHO+KykpeQW73Ro/HoR9xA=="
     },
     "node_modules/stream-combiner2": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -105,8 +105,8 @@
     "abi-wan-kanabi": "2.2.4",
     "lossless-json": "^4.0.1",
     "pako": "^2.0.4",
-    "starknet-types-07": "npm:@starknet-io/types-js@~0.7.10",
-    "starknet-types-08": "npm:@starknet-io/types-js@~0.8.3",
+    "@starknet-io/starknet-types-07": "npm:@starknet-io/types-js@~0.7.10",
+    "@starknet-io/starknet-types-08": "npm:@starknet-io/types-js@~0.8.3",
     "ts-mixer": "^6.0.3"
   },
   "engines": {

--- a/src/channel/ws_0_8.ts
+++ b/src/channel/ws_0_8.ts
@@ -7,7 +7,7 @@ import type {
   SubscriptionTransactionsStatusResponse,
   WebSocketEvents,
   WebSocketMethods,
-} from 'starknet-types-08';
+} from '@starknet-io/starknet-types-08';
 
 import { BigNumberish, SubscriptionBlockIdentifier } from '../types';
 import { JRPC } from '../types/api';

--- a/src/provider/types/response.type.ts
+++ b/src/provider/types/response.type.ts
@@ -10,7 +10,7 @@ import {
   IsSucceeded,
   IsType,
   PENDING_BLOCK_WITH_TX_HASHES,
-} from 'starknet-types-08';
+} from '@starknet-io/starknet-types-08';
 import { CompiledSierra, LegacyContractClass } from '../../types/lib';
 import {
   FELT,

--- a/src/provider/types/spec.type.ts
+++ b/src/provider/types/spec.type.ts
@@ -1,7 +1,7 @@
 // this file aims to unify the RPC specification types used by the common Provider class
 
-import * as RPCSPEC07 from 'starknet-types-07';
-import * as RPCSPEC08 from 'starknet-types-08';
+import * as RPCSPEC07 from '@starknet-io/starknet-types-07';
+import * as RPCSPEC08 from '@starknet-io/starknet-types-08';
 
 import { SimpleOneOf } from '../../types/helpers';
 

--- a/src/types/api/index.ts
+++ b/src/types/api/index.ts
@@ -1,9 +1,9 @@
 export * as JRPC from './jsonrpc';
 
-export * as RPCSPEC07 from 'starknet-types-07';
-export * as RPCSPEC08 from 'starknet-types-08';
-export { PAYMASTER_API } from 'starknet-types-08';
+export * as RPCSPEC07 from '@starknet-io/starknet-types-07';
+export * as RPCSPEC08 from '@starknet-io/starknet-types-08';
+export { PAYMASTER_API } from '@starknet-io/starknet-types-08';
 
-export * from 'starknet-types-08';
+export * from '@starknet-io/starknet-types-08';
 // TODO: Should this be default export type as RPCSPEC07 & RPCSPEC08 are sued only in channel rest of the code do not know what rpc version it works with and it can be both.
 // export * from '../../provider/types/spec.type';

--- a/src/types/contract.ts
+++ b/src/types/contract.ts
@@ -1,4 +1,4 @@
-import { BlockHash, TransactionHash } from 'starknet-types-07';
+import { BlockHash, TransactionHash } from '@starknet-io/starknet-types-07';
 import { CairoEnum } from './cairoEnum';
 import {
   BigNumberish,

--- a/src/types/errors.ts
+++ b/src/types/errors.ts
@@ -1,5 +1,5 @@
-import * as Errors from 'starknet-types-08';
-import { PAYMASTER_API } from 'starknet-types-08';
+import * as Errors from '@starknet-io/starknet-types-08';
+import { PAYMASTER_API } from '@starknet-io/starknet-types-08';
 
 // NOTE: generated with scripts/generateRpcErrorMap.js
 export type RPC_ERROR_SET = {

--- a/src/types/lib/contract/abi.ts
+++ b/src/types/lib/contract/abi.ts
@@ -1,4 +1,4 @@
-import type { ENUM_EVENT, EVENT_FIELD, STRUCT_EVENT } from 'starknet-types-07';
+import type { ENUM_EVENT, EVENT_FIELD, STRUCT_EVENT } from '@starknet-io/starknet-types-07';
 
 /** ABI */
 export type Abi = ReadonlyArray<FunctionAbi | AbiEvent | AbiStruct | InterfaceAbi | any>;

--- a/src/types/lib/contract/legacy.ts
+++ b/src/types/lib/contract/legacy.ts
@@ -55,7 +55,8 @@ export interface Program {
   }>;
   compiler_version?: string;
   main_scope?: string;
-  identifiers?: Record<string, 
+  identifiers?: Record<
+    string,
     | {
         destination: string;
         type: 'alias';
@@ -66,19 +67,25 @@ export interface Program {
         type: 'function';
         implicit_args?: {
           full_name: string;
-          members: Record<string, {
-            cairo_type: string;
-            offset: number;
-          }>;
+          members: Record<
+            string,
+            {
+              cairo_type: string;
+              offset: number;
+            }
+          >;
           size: number;
           type: 'struct';
         };
         explicit_args?: {
           full_name: string;
-          members: Record<string, {
-            cairo_type: string;
-            offset: number;
-          }>;
+          members: Record<
+            string,
+            {
+              cairo_type: string;
+              offset: number;
+            }
+          >;
           size: number;
           type: 'struct';
         };
@@ -89,10 +96,15 @@ export interface Program {
       }
     | {
         full_name: string;
-        members: Record<string, {
-          cairo_type: string;
-          offset: number;
-        }> | Record<string, never>;
+        members:
+          | Record<
+              string,
+              {
+                cairo_type: string;
+                offset: number;
+              }
+            >
+          | Record<string, never>;
         size: number;
         type: 'struct';
       }
@@ -125,11 +137,17 @@ export interface Program {
         type: 'reference';
       }
   >;
-  reference_manager?: Record<string, {
-    references: unknown[];
-  }>;
-  debug_info?: Record<string, {
-    file_contents?: Record<string, string>;
-    instruction_locations?: Record<string, unknown[]>;
-  }>;
+  reference_manager?: Record<
+    string,
+    {
+      references: unknown[];
+    }
+  >;
+  debug_info?: Record<
+    string,
+    {
+      file_contents?: Record<string, string>;
+      instruction_locations?: Record<string, unknown[]>;
+    }
+  >;
 }

--- a/src/types/lib/index.ts
+++ b/src/types/lib/index.ts
@@ -1,4 +1,4 @@
-import { SUBSCRIPTION_BLOCK_TAG } from 'starknet-types-08';
+import { SUBSCRIPTION_BLOCK_TAG } from '@starknet-io/starknet-types-08';
 import { StarknetChainId } from '../../global/constants';
 import { weierstrass } from '../../utils/ec';
 import { EDataAvailabilityMode } from '../api';

--- a/src/types/typedData.ts
+++ b/src/types/typedData.ts
@@ -6,4 +6,4 @@ export {
   type StarknetType,
   type StarknetDomain,
   type TypedData,
-} from 'starknet-types-07';
+} from '@starknet-io/starknet-types-07';

--- a/src/utils/outsideExecution.ts
+++ b/src/utils/outsideExecution.ts
@@ -1,4 +1,4 @@
-import { OutsideCallV1, OutsideCallV2 } from 'starknet-types-08';
+import { OutsideCallV1, OutsideCallV2 } from '@starknet-io/starknet-types-08';
 import { CallData } from './calldata';
 import { Call, type AllowArray, type BigNumberish, type Calldata } from '../types/lib';
 import {

--- a/src/utils/paymaster.ts
+++ b/src/utils/paymaster.ts
@@ -1,4 +1,4 @@
-import { OutsideCallV2, OutsideCallV1 } from 'starknet-types-08';
+import { OutsideCallV2, OutsideCallV1 } from '@starknet-io/starknet-types-08';
 import { NetworkName, PAYMASTER_RPC_NODES } from '../global/constants';
 import { logger } from '../global/logger';
 import { BigNumberish, PaymasterDetails, PreparedTransaction, Call } from '../types';

--- a/src/utils/stark/index.ts
+++ b/src/utils/stark/index.ts
@@ -1,7 +1,7 @@
 import { getPublicKey, getStarkKey, utils } from '@scure/starknet';
 import { gzip, ungzip } from 'pako';
 
-import { PRICE_UNIT } from 'starknet-types-08';
+import { PRICE_UNIT } from '@starknet-io/starknet-types-08';
 import { config } from '../../global/config';
 import { SupportedRpcVersion, ZERO } from '../../global/constants';
 import { FeeEstimate } from '../../provider/types/index.type';

--- a/src/wallet/account.ts
+++ b/src/wallet/account.ts
@@ -4,7 +4,7 @@ import type {
   NetworkChangeEventHandler,
   Signature,
   WatchAssetParameters,
-} from 'starknet-types-08';
+} from '@starknet-io/starknet-types-08';
 
 import { Account, AccountInterface } from '../account';
 import { StarknetChainId } from '../global/constants';

--- a/src/wallet/connect.ts
+++ b/src/wallet/connect.ts
@@ -15,7 +15,7 @@ import {
   AccountDeploymentData,
   Signature,
   SpecVersion,
-} from 'starknet-types-07';
+} from '@starknet-io/starknet-types-07';
 
 /**
  * Request Permission for wallet account, return addresses that are allowed by user

--- a/src/wallet/types.ts
+++ b/src/wallet/types.ts
@@ -1,4 +1,4 @@
-import { type RpcMessage, type StarknetWindowObject } from 'starknet-types-07';
+import { type RpcMessage, type StarknetWindowObject } from '@starknet-io/starknet-types-07';
 
 // ---- TT Request Handler
 export type RpcCall = Omit<RpcMessage, 'result'>;


### PR DESCRIPTION
## Motivation and Resolution
Prevent future attempts to create false packages by using organization-named aliases.

## Checklist:

- [ ] Performed a self-review of the code
- [ ] Rebased to the last commit of the target branch (or merged it into my branch)
- [ ] Linked the issues which this PR resolves
- [ ] Documented the changes in code (API docs will be generated automatically)
- [ ] Updated the tests
- [ ] All tests are passing
