### PR TITLE
docs: nethermind removed. rpc version 3 digits

### DIFF
--- a/www/docs/guides/connect_network.md
+++ b/www/docs/guides/connect_network.md
@@ -9,7 +9,7 @@ The first thing to do is to define with which network you want to interact (Main
 Then you need to select a node. A node is a safe way to connect with the Starknet blockchain. You can use:
 
 - a node supplied by a node provider - it can be free or not; it can have limitations or not; it can have WebSocket support or not.
-  > RPC node providers are for example Infura, Alchemy, Blast, Nethermind, Lava, Chainstack...
+  > RPC node providers are for example Infura, Alchemy, Blast, Lava, Chainstack...
 - your own node, located on your local computer or in your local network.
   > you can spin up your own node with Pathfinder, Juno, Papyrus, Deoxys, ...
 - a local development node, that simulates a Starknet network. Useful for devs to perform quick tests without spending precious fee token.
@@ -18,8 +18,8 @@ Then you need to select a node. A node is a safe way to connect with the Starkne
 Starknet.js communicates with nodes in accordance to a version of the RPC specification. Most nodes are able to use two RPC versions.  
 For example, this node is compatible with v0.7.1 and v0.8.0, using the following entry points:
 
-- "https://free-rpc.nethermind.io/sepolia-juno/v0_7"
-- "https://free-rpc.nethermind.io/sepolia-juno/v0_8"
+- "https://starknet-sepolia.public.blastapi.io/rpc/v0_7"
+- "https://starknet-sepolia.public.blastapi.io/rpc/v0_8"
 
 From RPC v0.5.0, you can make a request to retrieve the RPC version that a node uses:
 
@@ -61,7 +61,6 @@ import { RpcProvider } from 'starknet';
 |                  Alchemy |        No        |    v0_6, v0_7    |
 |                   Infura |        No        |       v0_7       |
 |                    Blast | v0_6, v0_7, v0_8 | v0_6, v0_7, v0_8 |
-|               Nethermind | v0_6, v0_7, v0_8 |        No        |
 |                     Lava | v0_6, v0_7, v0_8 |       v0_8       |
 | Local Pathfinder v0.16.2 | v0_6, v0_7, v0_8 |       N/A        |
 |       Local Juno v0.14.2 | v0_6, v0_7, v0_8 |       N/A        |
@@ -73,7 +72,6 @@ import { RpcProvider } from 'starknet';
 |                  Alchemy |        No        |  v0_6, v0_7  |
 |                   Infura |        No        |     v0_7     |
 |                    Blast | v0_6, v0_7, v0_8 |      No      |
-|               Nethermind | v0_6, v0_7, v0_8 |      No      |
 |                     Lava | v0_6, v0_7, v0_8 |      No      |
 | Local Pathfinder v0.16.2 | v0_6, v0_7, v0_8 |     N/A      |
 |       Local Juno v0.14.2 | v0_6, v0_7, v0_8 |     N/A      |
@@ -112,7 +110,7 @@ Some examples of `RpcProvider` instantiation to connect to RPC node providers:
 // Infura node RPC 0.7.0 for Mainnet:
 const providerInfuraMainnet = new RpcProvider({
   nodeUrl: 'https://starknet-mainnet.infura.io/v3/' + infuraKey,
-  specVersion: '0.7',
+  specVersion: '0.7.1',
 });
 // Blast node RPC 0.8.0 for Mainnet (0.6 & 0_7 also available):
 const providerBlastMainnet = new RpcProvider({
@@ -125,11 +123,7 @@ const providerMainnetLava = new RpcProvider({
 // Alchemy node RPC 0.7.0 for Mainnet  (0_6 also available):
 const providerAlchemyMainnet = new RpcProvider({
   nodeUrl: 'https://starknet-mainnet.g.alchemy.com/starknet/version/rpc/v0_7/' + alchemyKey,
-  specVersion: '0.7',
-});
-// Public Nethermind node RPC 0.8.0 for Mainnet (0_6 & 0_7 also available):
-const providerMainnetNethermindPublic = new RpcProvider({
-  nodeUrl: 'https://free-rpc.nethermind.io/mainnet-juno/v0_8',
+  specVersion: '0.7.1',
 });
 // Public Blast node RPC 0.8.0 for Mainnet (0.6 & 0_7 also available):
 const providerBlastMainnet = new RpcProvider({
@@ -149,7 +143,7 @@ If the RPC version of the node is 0.7, the `specVersion` parameter must be set:
 ```typescript
 const myProvider = new RpcProvider({
   nodeUrl: `${myNodeUrl}`,
-  specVersion: '0.7',
+  specVersion: '0.7.1',
 });
 ```
 
@@ -174,11 +168,7 @@ The Goerli Testnet is no longer in service.
 // Infura node RPC 0.7.0 for Sepolia Testnet :
 const providerInfuraSepoliaTestnet = new RpcProvider({
   nodeUrl: 'https://starknet-sepolia.infura.io/v3/' + infuraKey,
-  specVersion: '0.7',
-});
-// Public Nethermind node RPC 0.8.0 for Sepolia Testnet (0_6 & 0_7 also available) :
-const providerSepoliaTestnetNethermindPublic = new RpcProvider({
-  nodeUrl: 'https://free-rpc.nethermind.io/sepolia-juno/v0_8',
+  specVersion: '0.7.1',
 });
 // Public Blast node RPC 0.8.0 for Sepolia Testnet (0_6 & 0_7 also available) :
 const providerSepoliaTestnetBlastPublic = new RpcProvider({

--- a/www/docs/guides/create_account.md
+++ b/www/docs/guides/create_account.md
@@ -170,7 +170,7 @@ More complicated, a Braavos account needs a proxy and a specific signature. Star
 We will deploy hereunder a Braavos account in Devnet (use at least v0.3.0). So launch `starknet-devnet` with these parameters:
 
 ```bash
-starknet-devnet --seed 0 --fork-network 'https://free-rpc.nethermind.io/sepolia-juno/v0_8'
+starknet-devnet --seed 0 --fork-network 'https://starknet-sepolia.public.blastapi.io/rpc/v0_8'
 ```
 
 Initialization:

--- a/www/docs/guides/doc_scripts/deployBraavos.ts
+++ b/www/docs/guides/doc_scripts/deployBraavos.ts
@@ -58,7 +58,7 @@ export function getBraavosSignature(
 ): string[] {
   let txnHash: string = '';
   const det = details as V3DeployAccountSignerDetails;
-  const v3det = stark.v3Details(det, '0.8');
+  const v3det = stark.v3Details(det, '0.8.1');
   txnHash = hash.calculateDeployAccountTransactionHash({
     contractAddress: det.contractAddress,
     classHash: det.classHash,

--- a/www/docs/guides/interact.md
+++ b/www/docs/guides/interact.md
@@ -107,7 +107,7 @@ console.log('Final balance =', bal2);
 
 You need to be connected to a node using RPC 0.7:
 
-- Define `specVersion: '0.7'` when instantiating an RpcProvider
+- Define `specVersion: '0.7.1'` when instantiating an RpcProvider
 - Use `config.set('legacyMode', true)` to enable **V1** transactions (ETH fees)
 - Use `logger.setLogLevel('ERROR')` if you want to remove the warnings when processing **V1** transactions
 
@@ -115,8 +115,8 @@ You need to be connected to a node using RPC 0.7:
 import { RpcProvider, Account, config, logger, ETransactionVersion } from 'starknet';
 
 const myProvider = new RpcProvider({
-  nodeUrl: 'https://free-rpc.nethermind.io/sepolia-juno/v0_7',
-  specVersion: '0.7',
+  nodeUrl: 'https://starknet-sepolia.public.blastapi.io/rpc/v0_7',
+  specVersion: '0.7.1',
 });
 
 config.set('legacyMode', true);

--- a/www/docs/guides/migrate.md
+++ b/www/docs/guides/migrate.md
@@ -38,7 +38,7 @@ By default, Starknet.js v7 uses RPC **0.8** with **V3** transactions (STRK fees)
 
 You can configure your code to use RPC **0.7** with ETH and STRK fees available by using the following options:
 
-- Define `specVersion: '0.7'` when instantiating an RpcProvider
+- Define `specVersion: '0.7.1'` when instantiating an RpcProvider
 - Use `config.set('legacyMode', true)` to enable **V1** transactions
 - Use `logger.setLogLevel('ERROR')` if you want to remove the warnings when processing **V1** transactions
 
@@ -46,8 +46,8 @@ You can configure your code to use RPC **0.7** with ETH and STRK fees available 
 import { RpcProvider, Account, config, logger, ETransactionVersion } from 'starknet';
 
 const myProvider = new RpcProvider({
-  nodeUrl: 'https://free-rpc.nethermind.io/sepolia-juno/v0_7',
-  specVersion: '0.7',
+  nodeUrl: 'https://starknet-sepolia.public.blastapi.io/rpc/v0_8',
+  specVersion: '0.7.1',
 });
 
 config.set('legacyMode', true);

--- a/www/docs/guides/walletAccount.md
+++ b/www/docs/guides/walletAccount.md
@@ -36,7 +36,7 @@ Instantiating a new `WalletAccount`:
 ```typescript
 import { connect } from '@starknet-io/get-starknet'; // v4.0.3 min
 import { WalletAccount, wallet } from 'starknet'; // v7.0.1 min
-const myFrontendProviderUrl = 'https://free-rpc.nethermind.io/sepolia-juno/v0_8';
+const myFrontendProviderUrl = 'https://starknet-sepolia.public.blastapi.io/rpc/v0_8';
 // standard UI to select a wallet:
 const selectedWalletSWO = await connect({ modalMode: 'alwaysAsk', modalTheme: 'light' });
 const myWalletAccount = await WalletAccount.connect(


### PR DESCRIPTION
## Motivation and Resolution
These 2 modifications have not been reported in the guides:
- Nethermind public node removed.
- Rpc version is now on 3 digits



## Usage related changes
N/A

## Development related changes
N/A

## Checklist:

- [x] Rebased to the last commit of the target branch (or merged it into my branch)
