### PR TITLE
docs: replace ArgentX by Ready. Clean all notes format due to prettier

### DIFF
--- a/www/docs/guides/connect_network.md
+++ b/www/docs/guides/connect_network.md
@@ -41,7 +41,9 @@ The Starknet.js version must align with the RPC version supported by the chosen 
 |            v0.8.0             | Starknet.js v7.0.1            |
 
 :::note
+
 From version 6.x.x, Starknet.js is compatible with two RPC spec versions.
+
 :::
 
 With the `RpcProvider` class, you define the Starknet RPC node to use:
@@ -84,7 +86,9 @@ import { RpcProvider } from 'starknet';
 | starknet-devnet v0.3.0 |      v0_8       |     N/A      |
 
 :::note
+
 This status has been verified 02/apr/2025.
+
 :::
 
 ### Default RPC node
@@ -138,6 +142,7 @@ const providerLavaMainnet = new RpcProvider({
 > Take care to safely manage your API key. It's a confidential item!
 
 :::tip
+
 If the RPC version of the node is 0.7, the `specVersion` parameter must be set:
 
 ```typescript
@@ -154,12 +159,15 @@ const myProvider = await RpcProvider.create({ nodeUrl: `${myNodeUrl}` });
 ```
 
 Note that this approach is slower, it performs a request to the node.
+
 :::
 
 ### Goerli Testnet
 
 :::info
+
 The Goerli Testnet is no longer in service.
+
 :::
 
 ### Sepolia Testnet

--- a/www/docs/guides/create_account.md
+++ b/www/docs/guides/create_account.md
@@ -11,7 +11,7 @@ Unlike in Ethereum where a wallet is created with a public and private key pair,
 Account contracts on Starknet cannot be deployed without paying a fee.
 Creating an account is a bit tricky; you have several steps:
 
-1. Decide on your account type (OpenZeppelin, ArgentX, Braavos, ...).
+1. Decide on your account type (OpenZeppelin, Ready, Braavos, ...).
 2. Compute the address of your future account.
 3. Send funds to this pre-computed address. The funds will be used to pay for the account contract deployment and remains will fund the new account.
 4. Actual deployment of the Account
@@ -85,12 +85,14 @@ await provider.waitForTransaction(transaction_hash);
 console.log('✅ New OpenZeppelin account created.\n   address =', contract_address);
 ```
 
-## Create an Argent account
+## Create a Ready account
 
-Here, we will create a wallet with the Argent smart contract v0.4.0. The contract class is already implemented in the networks.
+Here, we will create a wallet with the Ready smart contract v0.4.0. The contract class is already implemented in the networks.
 
 :::caution
-Smart ArgentX accounts can't be used outside of the ArgentX wallet. With Starknet.js, use only standard ArgentX accounts.
+
+Smart Ready accounts can't be used outside of the Ready wallet. With Starknet.js, use only standard Ready accounts.
+
 :::
 
 ```typescript
@@ -114,30 +116,29 @@ import {
 // connect RPC 0.8 provider
 const provider = new RpcProvider({ nodeUrl: `${myNodeUrl}` });
 
-//new Argent X account v0.4.0
-const argentXaccountClassHash =
-  '0x036078334509b514626504edc9fb252328d1a240e4e948bef8d0c08dff45927f';
+//new Ready account v0.4.0
+const readyAccountClassHash = '0x036078334509b514626504edc9fb252328d1a240e4e948bef8d0c08dff45927f';
 
 // Generate public and private key pair.
-const privateKeyAX = stark.randomAddress();
-console.log('AX_ACCOUNT_PRIVATE_KEY=', privateKeyAX);
-const starkKeyPubAX = ec.starkCurve.getStarkKey(privateKeyAX);
-console.log('AX_ACCOUNT_PUBLIC_KEY=', starkKeyPubAX);
+const privateKeyRe = stark.randomAddress();
+console.log('RE_ACCOUNT_PRIVATE_KEY=', privateKeyRe);
+const starkKeyPubRe = ec.starkCurve.getStarkKey(privateKeyRe);
+console.log('RE_ACCOUNT_PUBLIC_KEY=', starkKeyPubRe);
 
-// Calculate future address of the ArgentX account
-const axSigner = new CairoCustomEnum({ Starknet: { pubkey: starkKeyPubAX } });
-const axGuardian = new CairoOption<unknown>(CairoOptionVariant.None);
-const AXConstructorCallData = CallData.compile({
+// Calculate future address of the Ready account
+const reSigner = new CairoCustomEnum({ Starknet: { pubkey: starkKeyPubRe } });
+const reGuardian = new CairoOption<unknown>(CairoOptionVariant.None);
+const reConstructorCallData = CallData.compile({
   owner: axSigner,
   guardian: axGuardian,
 });
-const AXcontractAddress = hash.calculateContractAddressFromHash(
-  starkKeyPubAX,
-  argentXaccountClassHash,
-  AXConstructorCallData,
+const reContractAddress = hash.calculateContractAddressFromHash(
+  starkKeyPubRe,
+  readyAccountClassHash,
+  reConstructorCallData,
   0
 );
-console.log('Precalculated account address=', AXcontractAddress);
+console.log('Precalculated account address=', reContractAddress);
 ```
 
 If you want a specific private key, replace `stark.randomAddress()` with a value of your choice.
@@ -149,18 +150,18 @@ Then you have to fund this address.
 If you have sent enough STRK to this new address, you can go forward to the final step:
 
 ```typescript
-const accountAX = new Account(provider, AXcontractAddress, privateKeyAX);
+const accountRe = new Account(provider, reContractAddress, privateKeyRe);
 
 const deployAccountPayload = {
-  classHash: argentXaccountClassHash,
-  constructorCalldata: AXConstructorCallData,
-  contractAddress: AXcontractAddress,
-  addressSalt: starkKeyPubAX,
+  classHash: readyAccountClassHash,
+  constructorCalldata: reConstructorCallData,
+  contractAddress: reContractAddress,
+  addressSalt: starkKeyPubRe,
 };
 
-const { transaction_hash: AXdAth, contract_address: AXcontractFinalAddress } =
-  await accountAX.deployAccount(deployAccountPayload);
-console.log('✅ ArgentX wallet deployed at:', AXcontractFinalAddress);
+const { transaction_hash: redAth, contract_address: reContractFinalAddress } =
+  await accountRe.deployAccount(deployAccountPayload);
+console.log('✅ Ready wallet deployed at:', reContractFinalAddress);
 ```
 
 ## Create a Braavos account
@@ -398,5 +399,5 @@ console.log('✅ New customized account created.\n   address =', contract_addres
 
 ## Account update
 
-For ArgentX and Braavos wallets, if you have created the private key inside the browser wallet, necessary upgrades will be automatically managed in the wallet.  
+For Ready and Braavos wallets, if you have created the private key inside the browser wallet, necessary upgrades will be automatically managed in the wallet.  
 However, if you have created the private key by yourself, it becomes your responsibility to update the account implementation class when it's necessary. It can be done with the `upgrade` function of the implementation class.

--- a/www/docs/guides/create_contract.md
+++ b/www/docs/guides/create_contract.md
@@ -202,5 +202,7 @@ console.log('✅ Test Completed.');
 ```
 
 :::tip
+
 If the class is already declared, `declare()` will fail. You can also use `declareIfNot()` to not fail in this case.
+
 :::

--- a/www/docs/guides/define_call_message.md
+++ b/www/docs/guides/define_call_message.md
@@ -201,6 +201,7 @@ const myTpl = { '0': '0x0a', '1': 200 };
 ### Named tuple
 
 :::warning Only for Cairo 0
+
 :::
 
 Starknet is waiting for a list of felts.  
@@ -222,7 +223,9 @@ await myContract.my_function(namedTup);
 ```
 
 :::tip
+
 It's not mandatory to create manually an object conform to the Cairo 0 named tuple ; you can just use the `cairo.tuple()` function.
+
 :::
 
 ### Ethereum public key
@@ -286,7 +289,9 @@ await myContract.my_function(myArray);
 ```
 
 :::danger important
+
 Do not add the `array_len` parameter before your array. Starknet.js will manage this element automatically.
+
 :::
 
 > It's also applicable for Cairo `Span` type.
@@ -303,6 +308,7 @@ await myContract.my_function(myArray);
 ```
 
 :::caution
+
 The fixed arrays are automatically handled only by the functions that uses the contract ABI. So, when using `CallData.compile()`, you have to use the `CairoFixedArray` class:
 
 ```typescript
@@ -380,7 +386,9 @@ await myContract[functionName](...myParams);
 ```
 
 :::warning important
+
 Objects properties have to be ordered in accordance with the ABI.
+
 :::
 
 ### Object (without ABI conformity check)
@@ -402,7 +410,9 @@ const deployResponse = await myAccount.deployContract({
 This type is available for: `CallData.compile(), hash.calculateContractAddressFromHash, account.deployContract, account.deployAccount, account.execute`
 
 :::warning important
+
 Objects properties have to be ordered in accordance with the ABI.
+
 :::
 
 ### Object (with ABI conformity check)

--- a/www/docs/guides/estimate_fees.md
+++ b/www/docs/guides/estimate_fees.md
@@ -25,7 +25,9 @@ const { suggestedMaxFee, unit } = await account0.estimateInvokeFee({
 The result is in `suggestedMaxFee`, of type BigInt. The corresponding unit for this number is in `unit`. It's WEI for "legacy" transactions, and FRI for V3 transactions.
 
 :::tip
+
 More details about the complex subject of Starknet fees in [Starknet docs](https://docs.starknet.io/architecture-and-concepts/network-architecture/fee-mechanism/)
+
 :::
 
 The complete answer for an RPC 0.7 "legacy" transaction:
@@ -154,7 +156,8 @@ config.set('feeMarginPercentage', {
 
 - Values are additional percentage: 75 means 75% additional fees.
 - To get back to normal values: set all values to 50.
-  :::
+
+:::
 
 Example for declaring, with 80% additional fees:
 

--- a/www/docs/guides/events.md
+++ b/www/docs/guides/events.md
@@ -83,7 +83,9 @@ const nameHash = num.toHex(hash.starknetKeccak('EventPanic'));
 ```
 
 :::info
+
 In some cases (when an event is coded in a Cairo component, without the `#[flat]` flag), this hash is handled in several numbers.
+
 :::
 
 The second parameter is the `errorType` variable content (stored in keys array because of the `#[key]` flag in the Cairo code).
@@ -138,14 +140,19 @@ const eventsList = await provider.getEvents({
 ```
 
 :::info
+
 `address, from_block, to_block, keys` are all optional parameters.
+
 :::
 
 :::tip
+
 If you don't want to filter by key, you can either remove the `keys` parameter, or affect it this way: `[[]]` .
+
 :::
 
 :::warning CAUTION
+
 An event can be nested in a Cairo component (See the Cairo code of the contract to verify). In this case, the array of keys will start with additional hashes, and you will have to adapt your code in consequence; in this example, we have to skip one hash :
 
 ```typescript

--- a/www/docs/guides/interact.md
+++ b/www/docs/guides/interact.md
@@ -63,7 +63,9 @@ You have to invoke Starknet, with the use of the meta-class method: `contract.fu
 > After the invoke, you have to wait the incorporation of the modification of Balance in the network, with `await provider.waitForTransaction(transaction_hash)`
 
 :::note
+
 By default, you are executing transactions that use the STRK token to pay the fees.
+
 :::
 
 Here is an example of how to increase and check the balance:

--- a/www/docs/guides/outsideExecution.md
+++ b/www/docs/guides/outsideExecution.md
@@ -22,8 +22,8 @@ At early-2025:
 
 |       account       | compatibility |
 | :-----------------: | :-----------: |
-|   ArgentX v0.3.0    |      v1       |
-|   ArgentX v0.4.0    |      v2       |
+|    Ready v0.3.0     |      v1       |
+|    Ready v0.4.0     |      v2       |
 |   Braavos v1.1.0    |      v2       |
 | OpenZeppelin v1.0.0 |    v2 (\*)    |
 
@@ -42,8 +42,10 @@ if (version === OutsideExecutionVersion.UNSUPPORTED) {
 ```
 
 :::info
+
 The account that will sign the transaction needs to be compatible with SNIP-9.  
 Nevertheless, the account that will execute the transaction do not needs to be SNIP-9 compatible ; it just needs to have enough fees to pay the transaction.
+
 :::
 
 ### Create an `OutsideTransaction` Object
@@ -75,7 +77,9 @@ const callOptions: OutsideExecutionOptions = {
 ```
 
 :::warning
+
 You can use the string `"ANY_CALLER"` as content of the `caller` property. To use with care, as anybody that get your `OutsideTransaction` object and execute it.
+
 :::
 
 To create the `OutsideTransaction` object, you just have to use:
@@ -88,6 +92,7 @@ const outsideTransaction1: OutsideTransaction = await signerAccount.getOutsideTr
 ```
 
 :::note
+
 In the same `OutsideTransaction` object, you can include several transactions. So, with only one signature of the signer Account, you can generate an `OutsideTransaction` object that performs many things:
 
 ```typescript
@@ -131,18 +136,21 @@ await provider.waitForTransaction(response.transaction_hash);
 ```
 
 :::info
+
 If you have created several `OutsideTransaction` objects using the same signer account, you can execute them in any order (no nonce problems).
+
 :::
 
 :::note
+
 In the same command, you can use several `OutsideTransaction` objects created by several signer accounts, even if they are not compatible with the same version of SNIP-9 (V1 or V2):
 
 ```typescript
-const outsideTransaction1: OutsideTransaction = await accountAX3.getOutsideTransaction(
+const outsideTransaction1: OutsideTransaction = await accountRe3.getOutsideTransaction(
   callOptions,
   call1
 ); // V1 compatible
-const outsideTransaction2: OutsideTransaction = await accountAX4.getOutsideTransaction(
+const outsideTransaction2: OutsideTransaction = await accountRe4.getOutsideTransaction(
   callOptions,
   call2
 ); // V2 compatible
@@ -267,7 +275,9 @@ The balances are finally :
 |                Account2 | 1006.0      |
 
 :::info
+
 The complete code of this example is available [here](https://github.com/PhilippeR26/starknet.js-workshop-typescript/blob/main/src/scripts/Starknet131/Starknet131-devnet/17.outsideExecuteLedger.ts).
+
 :::
 
 ## Estimate fees for an outside execution:

--- a/www/docs/guides/paymaster.md
+++ b/www/docs/guides/paymaster.md
@@ -162,7 +162,7 @@ const feesDetails: PaymasterDetails = {
 
 :::warning important
 
-If the account selected in the Wallet extension (Braavos, ArgentX, ...) is not deployed, you can't process a Paymaster transaction.
+If the account selected in the Wallet extension (Braavos, Ready, ...) is not deployed, you can't process a Paymaster transaction.
 
 :::
 

--- a/www/docs/guides/signature.md
+++ b/www/docs/guides/signature.md
@@ -150,7 +150,9 @@ const signature: Signature = (await account0.signMessage(myTypedData)) as Weiers
 ```
 
 :::note
+
 A message can be more complex, with nested types. See an example [here](https://github.com/PhilippeR26/starknet.js-workshop-typescript/blob/main/src/scripts/signature/4c.signSnip12vActive.ts).
+
 :::
 
 ### Verify TypedData outside Starknet
@@ -228,7 +230,9 @@ import type Transport from '@ledgerhq/hw-transport'; // type for the transporter
 In a Web DAPP, take care that some browsers are not compatible (FireFox, ...), and that the Bluetooth is not working in all cases and in all operating systems.
 
 :::note
+
 The last version of the Ledger Starknet APP (v2.3.1) supports explained V1 (ETH, Rpc 0.7) & V3 (STRK, Rpc 0.7 & 0.8) transactions & deploy accounts. For a class declaration or a message, you will have to blind sign a hash ; sign only hashes from a code that you trust. Do not forget to enable `Blind signing` in the APP settings.
+
 :::
 
 For example, for a Node script:
@@ -266,6 +270,7 @@ console.log('version=', appVersion);
 ```
 
 :::note
+
 You also have in Starknet.js a signer for the old v1.1.1 Ledger Starknet APP.
 
 ```typescript

--- a/www/docs/guides/walletAccount.md
+++ b/www/docs/guides/walletAccount.md
@@ -8,10 +8,12 @@ sidebar_position: 9
 
 The [`WalletAccount`](../API/classes/WalletAccount) class is similar to the regular [`Account`](../API/classes/Account) class, with the added ability to ask a browser wallet to sign and send transactions. Some other cool functionalities will be detailed hereunder.
 
-The private key of a `WalletAccount` is held in a browser wallet (such as ArgentX, Braavos, etc.), and any signature is managed by the wallet. With this approach DAPPs don't need to manage the security for any private key.
+The private key of a `WalletAccount` is held in a browser wallet (such as Ready, Braavos, etc.), and any signature is managed by the wallet. With this approach DAPPs don't need to manage the security for any private key.
 
 :::caution
+
 This class functions only within the scope of a DAPP. It can't be used in a Node.js script.
+
 :::
 
 ## Architecture
@@ -137,8 +139,10 @@ selectedWalletSWO.off('networkChanged', handleNetwork);
 ```
 
 :::info
+
 You can subscribe both with the SWO or with a `WalletAccount` instance.  
 The above examples are using the SWO, because it is the simpler way to process.
+
 :::
 
 ## Direct access to the wallet API entry points
@@ -199,5 +203,7 @@ useEffect(
 When you change the network or the account address a `WalletAccount` instance is automatically updated, however, this can lead to unexpected behavior if one is not careful (reads and writes targeting different networks, problems with Cairo versions of the accounts, ...).
 
 :::warning RECOMMENDATION
+
 It is strongly recommended to create a new `WalletAccount` instance each time the network or the account address is changed.
+
 :::


### PR DESCRIPTION
## Motivation and Resolution
- `ArgentX` wallet has been rebranded to `Ready`. Docs updated in accordance.
- Complete cleaning of notes (related to #1411)

## Usage related changes
N/A

## Development related changes
N/A

## Checklist:

- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Linked the issues which this PR resolves
- [x] All tests are passing
