### PR TITLE
fix: allow numeric revision value for typed data

### DIFF
--- a/__tests__/utils/typedData.test.ts
+++ b/__tests__/utils/typedData.test.ts
@@ -34,6 +34,8 @@ import {
 
 const exampleAddress = '0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826';
 
+const copyMock = <T>(o: T) => JSON.parse(JSON.stringify(o)) as T;
+
 describe('typedData', () => {
   test('should get right type encoding', () => {
     let encoded: string;
@@ -328,6 +330,13 @@ describe('typedData', () => {
       `"0xdb7829db8909c0c5496f5952bcfc4fc894341ce01842537fc4f448743480b6"`
     );
 
+    // support for numeric revision value
+    const previousMessageHash = messageHash;
+    const exampleBaseTypesCopy = copyMock(exampleBaseTypes);
+    exampleBaseTypesCopy.domain.revision = 1 as any;
+    messageHash = getMessageHash(exampleBaseTypesCopy, exampleAddress);
+    expect(messageHash).toMatch(previousMessageHash);
+
     messageHash = getMessageHash(examplePresetTypes, exampleAddress);
     expect(messageHash).toMatchInlineSnapshot(
       `"0x185b339d5c566a883561a88fb36da301051e2c0225deb325c91bb7aa2f3473a"`
@@ -351,7 +360,7 @@ describe('typedData', () => {
 
   describe('should fail validation', () => {
     const baseTypes = (type: string, value: any = PRIME) => {
-      const copy = JSON.parse(JSON.stringify(exampleBaseTypes)) as typeof exampleBaseTypes;
+      const copy = copyMock(exampleBaseTypes);
       const property = copy.types.Example.find((e) => e.type === type)!.name;
       (copy.message as any)[property] = value;
       return copy;

--- a/src/utils/typedData.ts
+++ b/src/utils/typedData.ts
@@ -70,7 +70,10 @@ function assertRange(data: unknown, type: string, { min, max }: { min: bigint; m
 }
 
 function identifyRevision({ types, domain }: TypedData) {
-  if (revisionConfiguration[Revision.ACTIVE].domain in types && domain.revision === Revision.ACTIVE)
+  if (
+    revisionConfiguration[Revision.ACTIVE].domain in types &&
+    domain.revision?.toString() === Revision.ACTIVE
+  )
     return Revision.ACTIVE;
 
   if (


### PR DESCRIPTION
## Motivation and Resolution

Allows a numeric revision value for typed data.

## Checklist:

- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [ ] Linked the issues which this PR resolves
- [ ] Documented the changes in code (API docs will be generated automatically)
- [x] Updated the tests
- [x] All tests are passing
