### PR TITLE
test: modify estimation of tip for Devnet

### DIFF
--- a/__tests__/WebSocketChannel.test.ts
+++ b/__tests__/WebSocketChannel.test.ts
@@ -2,7 +2,8 @@
 import { Provider, Subscription, WebSocketChannel } from '../src';
 import { logger } from '../src/global/logger';
 import { StarknetChainId } from '../src/global/constants';
-import { getTestAccount, getTestProvider, STRKtokenAddress, TEST_WS_URL } from './config/fixtures';
+import { getTestProvider, TEST_WS_URL } from './config/fixtures';
+import { getTestAccount, STRKtokenAddress } from './config/fixturesInit';
 
 const describeIfWs = TEST_WS_URL ? describe : describe.skip;
 const NODE_URL = TEST_WS_URL!;

--- a/__tests__/account.outsideExecution.test.ts
+++ b/__tests__/account.outsideExecution.test.ts
@@ -27,7 +27,13 @@ import {
 } from '../src';
 import { getSelectorFromName } from '../src/utils/hash';
 import { getDecimalString } from '../src/utils/num';
-import { contracts, createTestProvider, getTestAccount, STRKtokenAddress } from './config/fixtures';
+import { contracts } from './config/fixtures';
+import {
+  adaptAccountIfDevnet,
+  createTestProvider,
+  getTestAccount,
+  STRKtokenAddress,
+} from './config/fixturesInit';
 import { initializeMatcher } from './config/schema';
 
 describe('Account and OutsideExecution', () => {
@@ -92,11 +98,13 @@ describe('Account and OutsideExecution', () => {
       constructorCalldata: constructorAXCallData,
     });
     const targetAddress = response.deploy.contract_address;
-    signerAccount = new Account({
-      provider,
-      address: targetAddress,
-      signer: targetPK,
-    });
+    signerAccount = adaptAccountIfDevnet(
+      new Account({
+        provider,
+        address: targetAddress,
+        signer: targetPK,
+      })
+    );
 
     // Transfer dust of STRK token to the signer account
     const transferCall = {

--- a/__tests__/account.starknetId.test.ts
+++ b/__tests__/account.starknetId.test.ts
@@ -1,5 +1,6 @@
 import { Account, Provider, num, shortString } from '../src';
-import { contracts, createTestProvider, getTestAccount, STRKtokenAddress } from './config/fixtures';
+import { contracts } from './config/fixtures';
+import { createTestProvider, getTestAccount, STRKtokenAddress } from './config/fixturesInit';
 
 const { hexToDecimalString } = num;
 

--- a/__tests__/account.test.ts
+++ b/__tests__/account.test.ts
@@ -16,16 +16,14 @@ import {
   type Calldata,
   type InvokeTransactionReceiptResponse,
 } from '../src';
+import { C1v2ClassHash, contracts, describeIfDevnet, erc20ClassHash } from './config/fixtures';
 import {
-  C1v2ClassHash,
-  TEST_TX_VERSION,
-  contracts,
   createTestProvider,
-  describeIfDevnet,
-  devnetFeeTokenAddress,
-  erc20ClassHash,
   getTestAccount,
-} from './config/fixtures';
+  devnetFeeTokenAddress,
+  adaptAccountIfDevnet,
+  TEST_TX_VERSION,
+} from './config/fixturesInit';
 import { initializeMatcher } from './config/schema';
 
 const { cleanHex, hexToDecimalString, toBigInt } = num;
@@ -124,12 +122,14 @@ describe('deploy and test Account', () => {
       await account.waitForTransaction(transaction_hash);
 
       // deploy account
-      const accountOZ = new Account({
-        provider,
-        address: toBeAccountAddress,
-        signer: privKey,
-        transactionVersion: TEST_TX_VERSION,
-      });
+      const accountOZ = adaptAccountIfDevnet(
+        new Account({
+          provider,
+          address: toBeAccountAddress,
+          signer: privKey,
+          transactionVersion: TEST_TX_VERSION,
+        })
+      );
       const deployed = await accountOZ.deploySelf({
         classHash: accountClassHash,
         constructorCalldata: calldata,
@@ -299,11 +299,13 @@ describe('deploy and test Account', () => {
         { publicKey: starkKeyPub },
         0
       );
-      const newAccount = new Account({
-        provider,
-        address: precalculatedAddress,
-        signer: privateKey,
-      });
+      const newAccount = adaptAccountIfDevnet(
+        new Account({
+          provider,
+          address: precalculatedAddress,
+          signer: privateKey,
+        })
+      );
 
       const res = await newAccount.simulateTransaction([
         {
@@ -549,11 +551,13 @@ describe('deploy and test Account', () => {
         { publicKey: starkKeyPub },
         0
       );
-      newAccount = new Account({
-        provider,
-        address: precalculatedAddress,
-        signer: privateKey,
-      });
+      newAccount = adaptAccountIfDevnet(
+        new Account({
+          provider,
+          address: precalculatedAddress,
+          signer: privateKey,
+        })
+      );
     });
 
     test('estimateAccountDeployFee Cairo 1', async () => {

--- a/__tests__/cairo1v2.test.ts
+++ b/__tests__/cairo1v2.test.ts
@@ -24,8 +24,9 @@ import {
   selector,
   shortString,
 } from '../src';
-import { contracts, createTestProvider, getTestAccount } from './config/fixtures';
+import { contracts } from './config/fixtures';
 import { initializeMatcher } from './config/schema';
+import { createTestProvider, getTestAccount } from './config/fixturesInit';
 
 const { uint256, tuple, isCairo1Abi } = cairo;
 const { toHex } = num;

--- a/__tests__/cairo1v2_typed.test.ts
+++ b/__tests__/cairo1v2_typed.test.ts
@@ -30,13 +30,14 @@ import {
 import { hexToDecimalString } from '../src/utils/num';
 import { encodeShortString } from '../src/utils/shortString';
 import { isString } from '../src/utils/typed';
+import { contracts } from './config/fixtures';
 import {
-  contracts,
   createTestProvider,
   getTestAccount,
   STRKtokenAddress,
+  adaptAccountIfDevnet,
   TEST_TX_VERSION,
-} from './config/fixtures';
+} from './config/fixturesInit';
 import { initializeMatcher } from './config/schema';
 
 const { uint256, tuple, isCairo1Abi } = cairo;
@@ -743,12 +744,14 @@ describe('Cairo 1', () => {
       await account.waitForTransaction(transaction_hash);
 
       // deploy account
-      accountC1 = new Account({
-        provider,
-        address: toBeAccountAddress,
-        signer: priKey,
-        transactionVersion: TEST_TX_VERSION,
-      });
+      accountC1 = adaptAccountIfDevnet(
+        new Account({
+          provider,
+          address: toBeAccountAddress,
+          signer: priKey,
+          transactionVersion: TEST_TX_VERSION,
+        })
+      );
       const deployed = await accountC1.deploySelf({
         classHash: accountClassHash,
         constructorCalldata: calldata,

--- a/__tests__/cairov24onward.test.ts
+++ b/__tests__/cairov24onward.test.ts
@@ -19,7 +19,8 @@ import {
 } from '../src';
 import { hexToDecimalString } from '../src/utils/num';
 import { encodeShortString } from '../src/utils/shortString';
-import { contracts, createTestProvider, getTestAccount } from './config/fixtures';
+import { contracts } from './config/fixtures';
+import { createTestProvider, getTestAccount } from './config/fixturesInit';
 
 describe('Cairo v2.4 onwards', () => {
   let provider: ProviderInterface;

--- a/__tests__/config/fixtures.ts
+++ b/__tests__/config/fixtures.ts
@@ -1,18 +1,17 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
-import { Account, Provider, ProviderInterface, RpcProvider, config, hash, json } from '../../src';
+import { Provider, ProviderInterface, RpcProvider, config, hash, json } from '../../src';
 import {
   CompiledSierra,
   CompiledSierraCasm,
   LegacyCompiledContract,
   RpcProviderOptions,
 } from '../../src/types';
-import { toHex } from '../../src/utils/num';
 import { wait } from '../../src/utils/provider';
 import { isString } from '../../src/utils/typed';
 import './customMatchers'; // ensures TS traversal
-import { SupportedRpcVersion, SupportedTransactionVersion } from '../../src/global/constants';
+import { SupportedRpcVersion } from '../../src/global/constants';
 
 const readFile = (subpath: string) => fs.readFileSync(path.resolve(__dirname, subpath));
 
@@ -101,44 +100,7 @@ export function getTestProvider(
   return isProvider ? new Provider(providerOptions) : new RpcProvider(providerOptions);
 }
 
-export async function createTestProvider(
-  isProvider?: true,
-  setProviderOptions?: RpcProviderOptions
-): Promise<ProviderInterface>;
-export async function createTestProvider(
-  isProvider?: false,
-  setProviderOptions?: RpcProviderOptions
-): Promise<RpcProvider>;
-export async function createTestProvider(
-  isProvider: boolean = true,
-  setProviderOptions?: RpcProviderOptions
-): Promise<ProviderInterface | RpcProvider> {
-  const isDevnet = process.env.IS_DEVNET === 'true';
-
-  const providerOptions: RpcProviderOptions = {
-    ...setProviderOptions,
-    nodeUrl: process.env.TEST_RPC_URL,
-    specVersion: process.env.RPC_SPEC_VERSION as SupportedRpcVersion,
-    // accelerate the tests when running locally
-    ...(isDevnet && { transactionRetryIntervalFallback: 1000 }),
-  };
-  return isProvider ? Provider.create(providerOptions) : RpcProvider.create(providerOptions);
-}
-
-export const TEST_TX_VERSION = process.env.TX_VERSION as SupportedTransactionVersion;
 export const { TEST_WS_URL } = process.env;
-
-export const getTestAccount = (
-  provider: ProviderInterface,
-  txVersion?: SupportedTransactionVersion
-) => {
-  return new Account({
-    provider,
-    address: toHex(process.env.TEST_ACCOUNT_ADDRESS || ''),
-    signer: process.env.TEST_ACCOUNT_PRIVATE_KEY || '',
-    transactionVersion: txVersion ?? TEST_TX_VERSION,
-  });
-};
 
 export const createBlockForDevnet = async (): Promise<void> => {
   if (!(process.env.IS_DEVNET === 'true')) return;
@@ -180,7 +142,3 @@ export const describeIfRpc09 = describeIf(process.env.RPC_SPEC_VERSION === '0.9.
 export const erc20ClassHash: string = hash.computeContractClassHash(contracts.Erc20OZ.sierra); // Cairo 1
 export const C1v2ClassHash: string = hash.computeContractClassHash(contracts.C1v2.sierra); // Cairo 1
 export const wrongClassHash = '0x000000000000000000000000000000000000000000000000000000000000000';
-export const ETHtokenAddress = '0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7';
-export const STRKtokenAddress =
-  '0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d';
-export const devnetFeeTokenAddress = TEST_TX_VERSION === '0x3' ? STRKtokenAddress : ETHtokenAddress;

--- a/__tests__/config/fixturesInit.ts
+++ b/__tests__/config/fixturesInit.ts
@@ -1,0 +1,76 @@
+import {
+  Account,
+  Provider,
+  ProviderInterface,
+  RpcProvider,
+  config,
+  getTipStatsFromBlocks,
+  type TipAnalysisOptions,
+} from '../../src';
+import { RpcProviderOptions, type BlockIdentifier } from '../../src/types';
+import { toHex } from '../../src/utils/num';
+import './customMatchers'; // ensures TS traversal
+import { SupportedRpcVersion, SupportedTransactionVersion } from '../../src/global/constants';
+
+config.set('logLevel', 'ERROR');
+
+export async function createTestProvider(
+  isProvider?: true,
+  setProviderOptions?: RpcProviderOptions
+): Promise<ProviderInterface>;
+export async function createTestProvider(
+  isProvider?: false,
+  setProviderOptions?: RpcProviderOptions
+): Promise<RpcProvider>;
+export async function createTestProvider(
+  isProvider: boolean = true,
+  setProviderOptions?: RpcProviderOptions
+): Promise<ProviderInterface | RpcProvider> {
+  const isDevnet = process.env.IS_DEVNET === 'true';
+  const providerOptions: RpcProviderOptions = {
+    ...setProviderOptions,
+    nodeUrl: process.env.TEST_RPC_URL,
+    specVersion: process.env.RPC_SPEC_VERSION as SupportedRpcVersion,
+    // accelerate the tests when running locally
+    ...(isDevnet && { transactionRetryIntervalFallback: 1000 }),
+  };
+  return isProvider ? Provider.create(providerOptions) : RpcProvider.create(providerOptions);
+}
+
+export const TEST_TX_VERSION = process.env.TX_VERSION as SupportedTransactionVersion;
+export function adaptAccountIfDevnet(account: Account): Account {
+  const isDevnet = process.env.IS_DEVNET === 'true';
+  if (isDevnet) {
+    // eslint-disable-next-line no-param-reassign
+    account.getEstimateTip = function async(
+      blockIdentifier?: BlockIdentifier,
+      options: TipAnalysisOptions = {}
+    ) {
+      return getTipStatsFromBlocks(this, blockIdentifier, {
+        ...options,
+        minTxsNecessary: options.minTxsNecessary ?? 3,
+        maxBlocks: options.maxBlocks ?? 10,
+      });
+    };
+  }
+  return account;
+}
+
+export const getTestAccount = (
+  provider: ProviderInterface,
+  txVersion?: SupportedTransactionVersion
+) => {
+  return adaptAccountIfDevnet(
+    new Account({
+      provider,
+      address: toHex(process.env.TEST_ACCOUNT_ADDRESS || ''),
+      signer: process.env.TEST_ACCOUNT_PRIVATE_KEY || '',
+      transactionVersion: txVersion ?? TEST_TX_VERSION,
+    })
+  );
+};
+
+export const ETHtokenAddress = '0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7';
+export const STRKtokenAddress =
+  '0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d';
+export const devnetFeeTokenAddress = TEST_TX_VERSION === '0x3' ? STRKtokenAddress : ETHtokenAddress;

--- a/__tests__/config/helpers/initDevnetHistory.ts
+++ b/__tests__/config/helpers/initDevnetHistory.ts
@@ -1,0 +1,35 @@
+/* eslint-disable no-await-in-loop */
+import { cairo } from '../../../src';
+import { createTestProvider, devnetFeeTokenAddress, getTestAccount } from '../fixturesInit';
+
+/** Create in Devnet 3 transactions to initiate tip history */
+export async function InitDevnetHistory() {
+  // It has been checked previously that we are using Devnet
+  const provider = await createTestProvider();
+  const account = getTestAccount(provider);
+  const nbBlocks = await provider.getBlockNumber();
+  if (nbBlocks < 3) {
+    // eslint-disable-next-line no-console
+    console.log('Init Devnet...');
+    // eslint-disable-next-line no-plusplus
+    for (let i = 1n; i <= 3n; i++) {
+      try {
+        const { transaction_hash } = await account.execute(
+          {
+            contractAddress: devnetFeeTokenAddress,
+            entrypoint: 'transfer',
+            calldata: {
+              recipient: account.address,
+              amount: cairo.uint256(1n * 10n ** 3n),
+            },
+          },
+          { tip: i * 10n ** 6n }
+        );
+        await account.waitForTransaction(transaction_hash);
+      } catch (error: any) {
+        // eslint-disable-next-line no-console
+        console.error('Error in Devnet initialization.', error);
+      }
+    }
+  }
+}

--- a/__tests__/config/helpers/strategyResolver.ts
+++ b/__tests__/config/helpers/strategyResolver.ts
@@ -28,7 +28,7 @@ class StrategyResolver {
     return !!(TEST_ACCOUNT_PRIVATE_KEY && TEST_ACCOUNT_ADDRESS);
   }
 
-  private async isRsDevnet(): Promise<boolean> {
+  private async isStarknetDevnet(): Promise<boolean> {
     const response = await fetch(GS_DEFAULT_TEST_PROVIDER_URL, {
       method: 'POST',
       headers: { Accept: 'application/json', 'Content-Type': 'application/json' },
@@ -39,10 +39,10 @@ class StrategyResolver {
   }
 
   async detectDevnet(): Promise<void> {
-    // if on base url RPC endpoint work it is devnet-rs else it devnet-py
+    // if on base url RPC endpoint work it is Starknet-devnet else it devnet-py
     try {
-      this.isDevnet = await this.isRsDevnet();
-      if (this.isDevnet) console.log('Detected Devnet-RS');
+      this.isDevnet = await this.isStarknetDevnet();
+      if (this.isDevnet) console.log('Detected Starknet-devnet');
     } catch (error) {
       console.log('\x1b[36m%s\x1b[0m', LOCAL_DEVNET_NOT_RUNNING_MESSAGE);
       throw new Error(

--- a/__tests__/config/jestGlobalSetup.ts
+++ b/__tests__/config/jestGlobalSetup.ts
@@ -5,6 +5,7 @@
  * ref: order of execution jestGlobalSetup.ts -> jest.setup.ts -> fixtures.ts
  */
 
+import { InitDevnetHistory } from './helpers/initDevnetHistory';
 import strategyResolver from './helpers/strategyResolver';
 
 /**
@@ -13,4 +14,7 @@ import strategyResolver from './helpers/strategyResolver';
 
 export default async (_globalConfig: any, _projectConfig: any) => {
   await strategyResolver.execute();
+  if (process.env.IS_DEVNET === 'true') {
+    await InitDevnetHistory();
+  }
 };

--- a/__tests__/contract.test.ts
+++ b/__tests__/contract.test.ts
@@ -16,7 +16,8 @@ import {
   RpcError,
 } from '../src';
 
-import { contracts, createTestProvider, describeIfRpc081, getTestAccount } from './config/fixtures';
+import { contracts, describeIfRpc081 } from './config/fixtures';
+import { createTestProvider, getTestAccount } from './config/fixturesInit';
 import { initializeMatcher } from './config/schema';
 
 describe('contract module', () => {

--- a/__tests__/defaultProvider.test.ts
+++ b/__tests__/defaultProvider.test.ts
@@ -12,13 +12,8 @@ import {
   type Calldata,
   type RawArgs,
 } from '../src';
-import {
-  contracts,
-  createTestProvider,
-  erc20ClassHash,
-  getTestAccount,
-  wrongClassHash,
-} from './config/fixtures';
+import { contracts, erc20ClassHash, wrongClassHash } from './config/fixtures';
+import { createTestProvider, getTestAccount } from './config/fixturesInit';
 import { initializeMatcher } from './config/schema';
 
 describe('defaultProvider', () => {

--- a/__tests__/rpcChannel081.test.ts
+++ b/__tests__/rpcChannel081.test.ts
@@ -1,5 +1,6 @@
 import { LibraryError, RPC08, RpcError } from '../src';
-import { createBlockForDevnet, createTestProvider, describeIfRpc081 } from './config/fixtures';
+import { createBlockForDevnet, describeIfRpc081 } from './config/fixtures';
+import { createTestProvider } from './config/fixturesInit';
 import { initializeMatcher } from './config/schema';
 
 describeIfRpc081('RpcChannel', () => {

--- a/__tests__/rpcChannel09.test.ts
+++ b/__tests__/rpcChannel09.test.ts
@@ -1,5 +1,6 @@
 import { LibraryError, RPC09, RpcError } from '../src';
-import { createBlockForDevnet, createTestProvider } from './config/fixtures';
+import { createBlockForDevnet } from './config/fixtures';
+import { createTestProvider } from './config/fixturesInit';
 import { initializeMatcher } from './config/schema';
 
 // Force RPC 0.9.0 for testing purposes (bypasses auto-detection)

--- a/__tests__/rpcProvider.test.ts
+++ b/__tests__/rpcProvider.test.ts
@@ -3,14 +3,11 @@ import { hasMixin } from 'ts-mixer';
 import {
   contracts,
   createBlockForDevnet,
-  createTestProvider,
   describeIfDevnet,
   describeIfNotDevnet,
   describeIfRpc,
   describeIfRpc081,
   describeIfTestnet,
-  ETHtokenAddress,
-  getTestAccount,
   waitNextBlock,
 } from './config/fixtures';
 import { initializeMatcher } from './config/schema';
@@ -35,12 +32,14 @@ import {
   isVersion,
   toAnyPatchVersion,
   BlockTag,
+  logger,
 } from '../src';
 import { StarknetChainId } from '../src/global/constants';
 import { isBoolean } from '../src/utils/typed';
 import { RpcProvider as BaseRpcProvider } from '../src/provider/rpc';
 import { RpcProvider as ExtendedRpcProvider } from '../src/provider/extensions/default';
 import { StarknetId } from '../src/provider/extensions/starknetId';
+import { createTestProvider, ETHtokenAddress, getTestAccount } from './config/fixturesInit';
 
 /**
  * Helper function to create expected zero tip estimate for tests
@@ -591,10 +590,12 @@ describeIfRpc('RPCProvider', () => {
       });
 
       test('should return zero values with insufficient transaction data', async () => {
+        logger.setLogLevel('FATAL');
         const tipEstimate = await rpcProvider.getEstimateTip('latest', {
           minTxsNecessary: 1000, // Unreasonably high requirement
           maxBlocks: 1,
         });
+        logger.setLogLevel('ERROR');
 
         expect(tipEstimate).toEqual(expectZeroTipEstimate());
       });
@@ -657,10 +658,12 @@ describeIfRpc('RPCProvider', () => {
           }
 
           // Test with different block ranges
+          logger.setLogLevel('FATAL');
           const smallRange = await rpcProvider.getEstimateTip('latest', {
             minTxsNecessary: 1,
             maxBlocks: 1,
           });
+          logger.setLogLevel('ERROR');
 
           const largeRange = await rpcProvider.getEstimateTip('latest', {
             minTxsNecessary: 1,
@@ -829,7 +832,7 @@ describeIfTestnet('RPCProvider', () => {
   });
 });
 describeIfNotDevnet('If not devnet: waitForBlock', () => {
-  // As Devnet-rs isn't generating automatically blocks at a periodic time, it's excluded of this test.
+  // As Starknet-devnet isn't generating automatically blocks at a periodic time, it's excluded of this test.
   const providerStandard = new RpcProvider({ nodeUrl: process.env.TEST_RPC_URL });
   const providerFastTimeOut = new RpcProvider({ nodeUrl: process.env.TEST_RPC_URL, retries: 1 });
   let block: number;

--- a/__tests__/transactionReceipt.test.ts
+++ b/__tests__/transactionReceipt.test.ts
@@ -9,7 +9,8 @@ import {
   Account,
   EstimateFeeResponseOverhead,
 } from '../src';
-import { contracts, createTestProvider, getTestAccount } from './config/fixtures';
+import { contracts } from './config/fixtures';
+import { createTestProvider, getTestAccount } from './config/fixturesInit';
 
 // TODO: add RPC 0.7 V3, RPC 0.8 V3
 describe('Transaction receipt utility - RPC 0.8+ - V3', () => {

--- a/__tests__/utils/batch.test.ts
+++ b/__tests__/utils/batch.test.ts
@@ -1,13 +1,9 @@
 import fetch from '../../src/utils/connect/fetch';
 import { BatchClient } from '../../src/utils/batch';
-import {
-  createBlockForDevnet,
-  createTestProvider,
-  describeIfRpc081,
-  getTestProvider,
-} from '../config/fixtures';
+import { createBlockForDevnet, describeIfRpc081, getTestProvider } from '../config/fixtures';
 import { initializeMatcher } from '../config/schema';
 import { RPC } from '../../src/types';
+import { createTestProvider } from '../config/fixturesInit';
 
 describe('BatchClient', () => {
   initializeMatcher(expect);

--- a/__tests__/utils/ethSigner.test.ts
+++ b/__tests__/utils/ethSigner.test.ts
@@ -18,13 +18,13 @@ import {
   type DeclareContractPayload,
 } from '../../src';
 import { validateAndParseEthAddress } from '../../src/utils/eth';
+import { contracts, describeIfDevnet } from '../config/fixtures';
 import {
-  contracts,
   createTestProvider,
-  describeIfDevnet,
   getTestAccount,
+  adaptAccountIfDevnet,
   STRKtokenAddress,
-} from '../config/fixtures';
+} from '../config/fixturesInit';
 
 describe('Ethereum signer', () => {
   describe('signer', () => {
@@ -133,11 +133,13 @@ describe('Ethereum signer', () => {
         0
       );
 
-      ethAccount = new Account({
-        provider,
-        address: contractETHAccountAddress,
-        signer: ethSigner,
-      });
+      ethAccount = adaptAccountIfDevnet(
+        new Account({
+          provider,
+          address: contractETHAccountAddress,
+          signer: ethSigner,
+        })
+      );
       const feeEstimation = await ethAccount.estimateAccountDeployFee({
         classHash: decClassHash,
         addressSalt: salt,

--- a/__tests__/utils/tip.test.ts
+++ b/__tests__/utils/tip.test.ts
@@ -5,12 +5,14 @@ import {
   LibraryError,
   type RPC,
   type TipEstimate,
+  logger,
 } from '../../src';
 
 // Mock the RpcProvider
 jest.mock('../../src/provider/rpc');
 
 describe('Tip Analysis', () => {
+  logger.setLogLevel('FATAL');
   let mockProvider: jest.Mocked<RpcProvider>;
 
   beforeEach(() => {
@@ -395,5 +397,9 @@ describe('Tip Analysis', () => {
       // When tied, should choose the smaller value (20 < 30)
       expect(result.modeTip).toBe(20n);
     });
+  });
+
+  afterAll(() => {
+    logger.setLogLevel('ERROR');
   });
 });

--- a/__tests__/utils/utils.test.ts
+++ b/__tests__/utils/utils.test.ts
@@ -1,7 +1,7 @@
 import * as starkCurve from '@scure/starknet';
 
 import { constants, ec, hash, num, units } from '../../src';
-import { ETHtokenAddress } from '../config/fixtures';
+import { ETHtokenAddress } from '../config/fixturesInit';
 
 const { IS_BROWSER } = constants;
 

--- a/www/docs/guides/what_s_starknet.js.md
+++ b/www/docs/guides/what_s_starknet.js.md
@@ -13,13 +13,11 @@ Starknet.js is a library that helps connect your website or your Decentralized A
 Some important topics that have to be understood:
 
 - You can connect your DAPP to several networks:
-
   - [Starknet Mainnet](https://starkscan.co) (Layer 2 of [Ethereum network](https://etherscan.io/) ).
   - [Starknet Testnet](https://sepolia.starkscan.co/) (Layer 2 of [Sepolia network](https://sepolia.etherscan.io/) (testnet of Ethereum)).
   - [Starknet Devnet](https://github.com/0xSpaceShard/starknet-devnet) (your local Starknet network, for developers).
 
   and also to some more specific solutions:
-
   - private customized version of Starknet.
   - local Starknet node (connected to mainnet or testnet).
 

--- a/www/versioned_docs/version-6.11.0/guides/what_s_starknet.js.md
+++ b/www/versioned_docs/version-6.11.0/guides/what_s_starknet.js.md
@@ -13,13 +13,11 @@ Starknet.js is a library that helps to connect your website or your Decentralize
 Some important topics that have to be understood:
 
 - You can connect your DAPP to several networks:
-
   - [Starknet mainnet](https://starkscan.co) (Layer 2 of [Ethereum network](https://etherscan.io/) ).
   - [Starknet testnet](https://sepolia.starkscan.co/) (Layer 2 of [Sepolia network](https://sepolia.etherscan.io/) (testnet of Ethereum)).
   - [Starknet-devnet](https://github.com/0xSpaceShard/starknet-devnet-rs) (your local Starknet network, for developers).
 
   and also to some more specific solutions:
-
   - private customized version of Starknet.
   - local Starknet node (connected to mainnet or testnet).
 

--- a/www/versioned_docs/version-6.23.1/guides/what_s_starknet.js.md
+++ b/www/versioned_docs/version-6.23.1/guides/what_s_starknet.js.md
@@ -13,13 +13,11 @@ Starknet.js is a library that helps connect your website or your Decentralized A
 Some important topics that have to be understood:
 
 - You can connect your DAPP to several networks:
-
   - [Starknet mainnet](https://starkscan.co) (Layer 2 of [Ethereum network](https://etherscan.io/) ).
   - [Starknet testnet](https://sepolia.starkscan.co/) (Layer 2 of [Sepolia network](https://sepolia.etherscan.io/) (testnet of Ethereum)).
   - [Starknet-devnet](https://github.com/0xSpaceShard/starknet-devnet-rs) (your local Starknet network, for developers).
 
   and also to some more specific solutions:
-
   - private customized version of Starknet.
   - local Starknet node (connected to mainnet or testnet).
 

--- a/www/versioned_docs/version-6.24.1/guides/what_s_starknet.js.md
+++ b/www/versioned_docs/version-6.24.1/guides/what_s_starknet.js.md
@@ -13,13 +13,11 @@ Starknet.js is a library that helps connect your website or your Decentralized A
 Some important topics that have to be understood:
 
 - You can connect your DAPP to several networks:
-
   - [Starknet mainnet](https://starkscan.co) (Layer 2 of [Ethereum network](https://etherscan.io/) ).
   - [Starknet testnet](https://sepolia.starkscan.co/) (Layer 2 of [Sepolia network](https://sepolia.etherscan.io/) (testnet of Ethereum)).
   - [Starknet-devnet](https://github.com/0xSpaceShard/starknet-devnet-rs) (your local Starknet network, for developers).
 
   and also to some more specific solutions:
-
   - private customized version of Starknet.
   - local Starknet node (connected to mainnet or testnet).
 

--- a/www/versioned_docs/version-7.6.4/guides/what_s_starknet.js.md
+++ b/www/versioned_docs/version-7.6.4/guides/what_s_starknet.js.md
@@ -13,13 +13,11 @@ Starknet.js is a library that helps connect your website or your Decentralized A
 Some important topics that have to be understood:
 
 - You can connect your DAPP to several networks:
-
   - [Starknet Mainnet](https://starkscan.co) (Layer 2 of [Ethereum network](https://etherscan.io/) ).
   - [Starknet Testnet](https://sepolia.starkscan.co/) (Layer 2 of [Sepolia network](https://sepolia.etherscan.io/) (testnet of Ethereum)).
   - [Starknet Devnet](https://github.com/0xSpaceShard/starknet-devnet) (your local Starknet network, for developers).
 
   and also to some more specific solutions:
-
   - private customized version of Starknet.
   - local Starknet node (connected to mainnet or testnet).
 


### PR DESCRIPTION
## Motivation and Resolution
When executing the test suite in Devnet, we have a flood of tip error messages.
Devnet is starting from block 0 (no history of transactions) and creates a new block at each transaction. So, the default `maxBlocks` and `minTxsNecessary` are not adapted for Devnet.
This PR create a small initiial history of Devnet transactions, and is changing the default values (only for Devnet)

## Usage related changes
N/A

## Development related changes
- if Devnet is just launched (zero blocks), 3 random transactions are created, with random tips, to create an initial tip history.
- account.getEstimateTip() is overwritten when using Devnet, to use new default values:
```ts
minTxsNecessary: options.minTxsNecessary ?? 3,
maxBlocks: options.maxBlocks ?? 10,
```
- To create these 3 new transactions before launching the test suite, some parts of `tests/config/fixtures.ts` are necessary, but Jest do not accept at this stage code including the use of `subscribe`. So the file has been splitted in 2 files: `fixtures.ts` & `fixturesInit.ts`.
- When tip is estimated out of an account, the logger has been temporary set to `critcal`.

Tested with success in:
- New Devnet
- Devnet with history
- Testnet

> [!NOTE]
> - wording of `devnet-rs` replaced by `starknet-devnet`.
> - prettier has automatically modified some documentation files.

## Checklist:
- [ ] Performed a self-review of the code
- [ ] Rebased to the last commit of the target branch (or merged it into my branch)
- [ ] Linked the issues which this PR resolves
- [ ] Documented the changes in code (API docs will be generated automatically)
- [ ] Updated the tests
- [ ] All tests are passing
