### PR TITLE
fix(rpc): ensure method argument is string when calling errorHandler

### DIFF
--- a/src/channel/rpc_0_7_1.ts
+++ b/src/channel/rpc_0_7_1.ts
@@ -178,16 +178,16 @@ export class RpcChannel {
           params as any, // TODO: fix this temporary cast with some permanent solution
           (this.requestId += 1)
         );
-        this.errorHandler(method, params, error);
+        this.errorHandler(String(method), params, error);
         return result as RPC.Methods[T]['result'];
       }
 
       const rawResult = await this.fetch(method, params, (this.requestId += 1));
       const { error, result } = await rawResult.json();
-      this.errorHandler(method, params, error);
+      this.errorHandler(String(method), params, error);
       return result as RPC.Methods[T]['result'];
     } catch (error: any) {
-      this.errorHandler(method, params, error?.response?.data, error);
+      this.errorHandler(String(method), params, error?.response?.data, error);
       throw error;
     }
   }


### PR DESCRIPTION
Convert the method parameter to a string when passing it to errorHandler and similar functions that expect a string. This resolves TypeScript type errors related to passing a value of type string | number | symbol, ensuring compatibility and type safety. No logic is changed, only type correctness is improved.