### PR TITLE
docs: add Contract.providerOrAccount explanation in migration guide

### DIFF
--- a/www/docs/guides/migrate.md
+++ b/www/docs/guides/migrate.md
@@ -246,7 +246,7 @@ import { Contract } from 'starknet';
 const contract = await Contract.factory({
   contract: sierraContract, // Compiled Sierra contract
   casm: casmContract, // Compiled CASM contract
-  account: account,
+  account: account, // optional
   constructorCalldata: {
     name: 'Token',
     symbol: 'ERC20',
@@ -259,6 +259,9 @@ const contract = await Contract.factory({
   unique: true, // optional
   deployer: account.deployer, // optional
 });
+
+// if `account` property has not been defined above, it can be added later with:
+contract.providerOrAccount = myAccount;
 ```
 
 ### Removed Helper Functions


### PR DESCRIPTION
## Motivation and Resolution
Add in the migration guide an explanation to connect an account to a contract after contract instantiation.
v7:
```ts
myContract.connect(myAccount);
```

v8:
```ts
myContract.providerOrAccount = myAccount;
```

## Usage related changes
N/A

## Development related changes
N/A

## Checklist:

- [x] Rebased to the last commit of the target branch (or merged it into my branch)

