### PR TITLE
fix: migration docs update and fix overhead method to allow false ove…

### DIFF
--- a/src/account/default.ts
+++ b/src/account/default.ts
@@ -73,7 +73,7 @@ import { parseContract } from '../utils/provider';
 import { supportsInterface } from '../utils/src5';
 import {
   randomAddress,
-  resourceBoundsToEstimateFee,
+  resourceBoundsToEstimateFeeResponse,
   signatureToHexArray,
   toFeeVersion,
   toTransactionVersion,
@@ -237,7 +237,8 @@ export class Account extends Provider implements AccountInterface {
   ): Promise<EstimateFeeBulk> {
     if (!invocations.length) throw TypeError('Invocations should be non-empty array');
     // skip estimating bounds if user provide bounds
-    if (details.resourceBounds) return [resourceBoundsToEstimateFee(details.resourceBounds)];
+    if (details.resourceBounds)
+      return [resourceBoundsToEstimateFeeResponse(details.resourceBounds)];
 
     const { nonce, blockIdentifier, version, skipValidate } = details;
     const detailsWithTip = await this.resolveDetailsWithTip(details);

--- a/src/provider/types/configuration.type.ts
+++ b/src/provider/types/configuration.type.ts
@@ -15,6 +15,6 @@ export type RpcProviderOptions = {
   default?: boolean;
   waitMode?: boolean;
   baseFetch?: WindowOrWorkerGlobalScope['fetch'];
-  resourceBoundsOverhead?: ResourceBoundsOverhead;
+  resourceBoundsOverhead?: ResourceBoundsOverhead | false;
   batch?: false | number;
 };

--- a/src/provider/types/response.type.ts
+++ b/src/provider/types/response.type.ts
@@ -54,11 +54,6 @@ export type EstimateFeeResponseOverhead = {
   unit: PRICE_UNIT;
 };
 
-/**
- * same type as EstimateFeeResponseOverhead but without overhead
- */
-export type EstimateFeeResponse = EstimateFeeResponseOverhead;
-
 export type EstimateFeeResponseBulkOverhead = Array<EstimateFeeResponseOverhead>;
 
 export type InvokeFunctionResponse = InvokedTransaction;

--- a/src/provider/types/spec.type.ts
+++ b/src/provider/types/spec.type.ts
@@ -147,6 +147,8 @@ export function isRPC08Plus_ResourceBoundsBN(entry: ResourceBoundsBN): entry is 
 
 export type ResourceBounds = Merge<RPCSPEC08.ResourceBounds, RPCSPEC09.ResourceBounds>; // same sa rpc0.8
 
+export type EventFilter = RPCSPEC09.EventFilter;
+
 /**
  * Represents percentage overhead for each resource bound
  * numerical 50 means 50% overhead

--- a/src/signer/interface.ts
+++ b/src/signer/interface.ts
@@ -11,7 +11,7 @@ export abstract class SignerInterface {
   /**
    * Method to get the public key of the signer
    *
-   * @returns {string} hex-string
+   * @returns {Promise<string>} hex-string public key
    * @example
    * ```typescript
    * const mySigner = new Signer("0x123");
@@ -25,50 +25,68 @@ export abstract class SignerInterface {
    * Signs a JSON object for off-chain usage with the private key and returns the signature.
    * This adds a message prefix so it can't be interchanged with transactions
    *
-   * @param {TypedData} typedData JSON object to be signed
-   * @param {string} accountAddress Hex string of the account's address
+   * @param {TypedData} typedData - JSON object to be signed
+   * @param {string} accountAddress - Hex string of the account's address
    * @returns {Promise<Signature>} the signature of the message
    * @example
    * ```typescript
    * const mySigner = new Signer("0x123");
-   *     const myTypedData: TypedData = {
-   *         domain: {name: "Example DApp",
-   *           chainId: constants.StarknetChainId.SN_SEPOLIA,
-   *           version: "0.0.3"},
-   *         types: {StarkNetDomain: [
-   *             { name: "name", type: "string" },
-   *             { name: "chainId", type: "felt" },
-   *             { name: "version", type: "string" }],
-   *           Message: [{ name: "message", type: "felt" }]},
-   *         primaryType: "Message", message: {message: "1234"}};
-   *     const result = await mySigner.signMessage(myTypedData,"0x5d08a4e9188429da4e993c9bf25aafe5cd491ee2b501505d4d059f0c938f82d");
+   * const myTypedData: TypedData = {
+   *   domain: {
+   *     name: "Example DApp",
+   *     chainId: constants.StarknetChainId.SN_SEPOLIA,
+   *     version: "0.0.3"
+   *   },
+   *   types: {
+   *     StarkNetDomain: [
+   *       { name: "name", type: "string" },
+   *       { name: "chainId", type: "felt" },
+   *       { name: "version", type: "string" }
+   *     ],
+   *     Message: [{ name: "message", type: "felt" }]
+   *   },
+   *   primaryType: "Message",
+   *   message: { message: "1234" }
+   * };
+   * const result = await mySigner.signMessage(myTypedData, "0x5d08a4e9188429da4e993c9bf25aafe5cd491ee2b501505d4d059f0c938f82d");
    * // result = Signature {r: 684915484701699003335398790608214855489903651271362390249153620883122231253n,
    * // s: 1399150959912500412309102776989465580949387575375484933432871778355496929189n, recovery: 1}
    * ```
-
    */
   public abstract signMessage(typedData: TypedData, accountAddress: string): Promise<Signature>;
 
   /**
-   * Signs transactions with the private key and returns the signature
+   * Signs INVOKE transactions with the private key and returns the signature
    *
-   * @param {Call[]} transactions array of Call objects
-   * @param {InvocationsSignerDetails} transactionsDetail InvocationsSignerDetails object
+   * @param {Call[]} transactions - Array of Call objects representing the transactions
+   * @param {InvocationsSignerDetails} transactionsDetail - Transaction details including V3 fields
    * @returns {Promise<Signature>} the signature of the transaction
+   * @remarks Only supports V3 transactions. V0, V1, and V2 transactions will throw an error.
    * @example
    * ```typescript
    * const mySigner = new Signer("0x123");
    * const calls: Call[] = [{
-   *     contractAddress: "0x1234567890123456789012345678901234567890",
-   *     entrypoint: "functionName",
-   *     calldata: [1, 2, 3]
+   *   contractAddress: "0x1234567890123456789012345678901234567890",
+   *   entrypoint: "transfer",
+   *   calldata: ["0xRecipient", "1000", "0"]
    * }];
    * const transactionsDetail: InvocationsSignerDetails = {
-   *     walletAddress: '0x742d35Cc6634C0532925a3b844Bc454e4438f44e',
-   *     chainId: constants.StarknetChainId.SN_MAIN,
-   *     cairoVersion: "1",
-   *     maxFee: '0x1234567890abcdef',
-   *     version: "0x0", nonce: 1};
+   *   walletAddress: '0x742d35Cc6634C0532925a3b844Bc454e4438f44e',
+   *   chainId: constants.StarknetChainId.SN_MAIN,
+   *   cairoVersion: "1",
+   *   version: "0x3",
+   *   nonce: 1,
+   *   resourceBounds: {
+   *     l1_gas: { amount: "0x1000", price: "0x20" },
+   *     l2_gas: { amount: "0x200", price: "0x5" },
+   *     l1_data_gas: { amount: "0x500", price: "0x10" }
+   *   },
+   *   tip: 0,
+   *   paymasterData: [],
+   *   accountDeploymentData: [],
+   *   nonceDataAvailabilityMode: RPC.EDataAvailabilityMode.L1,
+   *   feeDataAvailabilityMode: RPC.EDataAvailabilityMode.L1
+   * };
    * const result = await mySigner.signTransaction(calls, transactionsDetail);
    * // result = Signature {r: 304910226421970384958146916800275294114105560641204815169249090836676768876n,
    * //   s: 1072798866000813654190523783606274062837012608648308896325315895472901074693n, recovery: 0}
@@ -82,21 +100,31 @@ export abstract class SignerInterface {
   /**
    * Signs a DEPLOY_ACCOUNT transaction with the private key and returns the signature
    *
-   * @param {DeployAccountSignerDetails} transaction to deploy an account contract
+   * @param {DeployAccountSignerDetails} transaction - Transaction details to deploy an account contract
    * @returns {Promise<Signature>} the signature of the transaction to deploy an account
+   * @remarks Only supports V3 transactions. V0, V1, and V2 transactions will throw an error.
    * @example
    * ```typescript
    * const mySigner = new Signer("0x123");
    * const myDeployAcc: DeployAccountSignerDetails = {
    *   contractAddress: "0x65a822fbee1ae79e898688b5a4282dc79e0042cbed12f6169937fddb4c26641",
-   *   version: "0x2", chainId: constants.StarknetChainId.SN_SEPOLIA,
+   *   version: "0x3",
+   *   chainId: constants.StarknetChainId.SN_SEPOLIA,
    *   classHash: "0x5f3614e8671257aff9ac38e929c74d65b02d460ae966cd826c9f04a7fa8e0d4",
-   *   constructorCalldata: [1, 2],addressSalt: 1234,
-   *   nonce: 45, maxFee: 10 ** 15, tip: 0, paymasterData: [],accountDeploymentData: [],
+   *   constructorCalldata: ["0x123", "0x456"],
+   *   addressSalt: "0x789",
+   *   nonce: 0,
+   *   resourceBounds: {
+   *     l1_gas: { amount: "0x1000", price: "0x20" },
+   *     l2_gas: { amount: "0x200", price: "0x5" },
+   *     l1_data_gas: { amount: "0x500", price: "0x10" }
+   *   },
+   *   tip: 0,
+   *   paymasterData: [],
+   *   accountDeploymentData: [],
    *   nonceDataAvailabilityMode: RPC.EDataAvailabilityMode.L1,
-   *   feeDataAvailabilityMode: RPC.EDataAvailabilityMode.L1,
-   *   resourceBounds: stark.estimateFeeToBounds(constants.ZERO),
-   * }
+   *   feeDataAvailabilityMode: RPC.EDataAvailabilityMode.L1
+   * };
    * const result = await mySigner.signDeployAccountTransaction(myDeployAcc);
    * // result = Signature {r: 2871311234341436528393212130310036951068553852419934781736214693308640202748n,
    * //  s: 1746271646048888422437132495446973163454853863041370993384284773665861377605n, recovery: 1}
@@ -109,20 +137,30 @@ export abstract class SignerInterface {
   /**
    * Signs a DECLARE transaction with the private key and returns the signature
    *
-   * @param {DeclareSignerDetails} transaction to declare a class
+   * @param {DeclareSignerDetails} transaction - Transaction details to declare a contract class
    * @returns {Promise<Signature>} the signature of the transaction to declare a class
+   * @remarks Only supports V3 transactions. V0, V1, and V2 transactions will throw an error.
    * @example
    * ```typescript
    * const mySigner = new Signer("0x123");
    * const myDeclare: DeclareSignerDetails = {
-   *   version: "0x2", chainId: constants.StarknetChainId.SN_SEPOLIA,
+   *   version: "0x3",
+   *   chainId: constants.StarknetChainId.SN_SEPOLIA,
    *   senderAddress: "0x65a822fbee1ae79e898688b5a4282dc79e0042cbed12f6169937fddb4c26641",
    *   classHash: "0x5f3614e8671257aff9ac38e929c74d65b02d460ae966cd826c9f04a7fa8e0d4",
-   *   nonce: 45, maxFee: 10 ** 15, tip: 0, paymasterData: [], accountDeploymentData: [],
+   *   compiledClassHash: "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+   *   nonce: 45,
+   *   resourceBounds: {
+   *     l1_gas: { amount: "0x1000", price: "0x20" },
+   *     l2_gas: { amount: "0x200", price: "0x5" },
+   *     l1_data_gas: { amount: "0x500", price: "0x10" }
+   *   },
+   *   tip: 0,
+   *   paymasterData: [],
+   *   accountDeploymentData: [],
    *   nonceDataAvailabilityMode: RPC.EDataAvailabilityMode.L1,
-   *   feeDataAvailabilityMode: RPC.EDataAvailabilityMode.L1,
-   *   resourceBounds: stark.estimateFeeToBounds(constants.ZERO),
-}
+   *   feeDataAvailabilityMode: RPC.EDataAvailabilityMode.L1
+   * };
    * const result = await mySigner.signDeclareTransaction(myDeclare);
    * // result = Signature {r: 2432056944313955951711774394836075930010416436707488863728289188289211995670n,
    * //  s: 3407649393310177489888603098175002856596469926897298636282244411990343146307n, recovery: 1}

--- a/src/utils/stark/index.ts
+++ b/src/utils/stark/index.ts
@@ -185,7 +185,7 @@ export function zeroResourceBounds(): ResourceBoundsBN {
 /**
  * Calculates the maximum resource bounds for fee estimation.
  *
- * @param {FeeEstimate} estimate The estimate for the fee. If a BigInt is provided, the returned bounds will be set to 0n.
+ * @param {FeeEstimate} estimate The estimate for the fee.
  * @param {ResourceBoundsOverhead | false} [overhead] - The percentage overhead added to the max units and max price per unit. Pass `false` to disable overhead.
  * @returns {ResourceBoundsBN} The resource bounds with overhead represented as BigInt.
  * @throws {Error} If the estimate object is undefined or does not have the required properties.
@@ -310,7 +310,7 @@ export function toOverheadOverallFee(
 }
 
 /**
- * Mock zero fee response
+ * Mock zero fee API response
  */
 export function ZeroFeeEstimate(): FeeEstimate {
   return {

--- a/www/docs/guides/migrate.md
+++ b/www/docs/guides/migrate.md
@@ -288,6 +288,112 @@ const txReceipt = await account.waitForTransaction(deployTx.transaction_hash);
 const deployedContract = defaultDeployer.parseDeployerEvent(txReceipt);
 ```
 
+### Response Parser Changes
+
+The response parser now automatically adds overhead calculations to fee estimations, providing `resourceBounds` and `overall_fee` with configurable overhead margins.
+
+**All estimate methods now use `parseFeeEstimateBulkResponse`** internally, which:
+
+- Adds overhead to resource bounds for safety margin
+- Formats responses to include both `resourceBounds` and `overall_fee`
+- Returns `EstimateFeeResponseBulkOverhead` type with standardized structure
+
+**v7 Response Structure:**
+
+```typescript
+// Raw fee estimate from RPC
+{
+  l1_gas_consumed: "0x1000",
+  l1_gas_price: "0x20",
+  l1_data_gas_consumed: "0x500",
+  l1_data_gas_price: "0x10",
+  l2_gas_consumed: "0x200",
+  l2_gas_price: "0x5",
+  unit: "FRI"
+}
+```
+
+**v8 Response Structure:**
+
+```typescript
+// Enhanced response with overhead and resource bounds
+{
+  resourceBounds: {
+    l1_gas: { amount: "0x1200", price: "0x20" },    // With overhead
+    l2_gas: { amount: "0x240", price: "0x5" },      // With overhead
+    l1_data_gas: { amount: "0x600", price: "0x10" } // With overhead
+  },
+  overall_fee: 12345n, // Total fee calculation with overhead
+  unit: "FRI"
+}
+```
+
+**Configuring Resource Bounds Overhead:**
+
+```typescript
+import { RpcProvider } from 'starknet';
+
+// Configure custom overhead percentages (default: 50% for all)
+const provider = new RpcProvider({
+  nodeUrl: 'https://your-node-url',
+  resourceBoundsOverhead: {
+    l1_gas: {
+      max_amount: 10, // 10% overhead for L1 gas amount
+      max_price_per_unit: 10, // 10% overhead for L1 gas price
+    },
+    l2_gas: {
+      max_amount: 5, // 5% overhead for L2 gas amount
+      max_price_per_unit: 5, // 5% overhead for L2 gas price
+    },
+    l1_data_gas: {
+      max_amount: 15, // 15% overhead for L1 data gas amount
+      max_price_per_unit: 15, // 15% overhead for L1 data gas price
+    },
+  },
+});
+
+// All estimate methods benefit from this overhead
+const invokeEstimate = await account.estimateInvokeFee(calls);
+const declareEstimate = await account.estimateDeclareFee(contract);
+const deployEstimate = await account.estimateDeployFee(payload);
+const bulkEstimate = await account.estimateFeeBulk(invocations);
+```
+
+This change ensures safer transaction execution by automatically adding a margin to prevent out-of-gas errors due to network fluctuations.
+
+### Removed Fee Utility Methods
+
+The following utility methods have been removed and replaced with new resource bounds methods:
+
+**Removed Methods:**
+
+- `RPCResponseParser.ZEROFee()` → replaced with `stark.ZeroFeeEstimate()`
+- `stark.estimatedFeeToMaxFee()` → replaced with `stark.toOverheadOverallFee()`
+- `stark.estimateFeeToBounds()` → replaced with `stark.toOverheadResourceBounds()`
+
+**Replaced Types:**
+
+- `EstimateFeeResponse` → replaced with `EstimateFeeResponseOverhead`
+- `EstimateFeeResponseBulk` → replaced with `EstimateFeeResponseBulkOverhead`
+
+The new overhead types provide enhanced structure with `resourceBounds` (ResourceBoundsBN) and `overall_fee` (bigint) instead of the previous flat structure with individual gas consumption fields.
+
+**New Resource Bounds Methods:**
+
+- `stark.zeroResourceBounds()` - Returns zero resource bounds
+- `stark.toOverheadResourceBounds()` - Converts fee estimates to resource bounds with overhead
+- `stark.resourceBoundsToEstimateFeeResponse()` - Converts resource bounds back to fee response format
+- `stark.toOverheadOverallFee()` - Calculates total fee with overhead
+- `stark.ZeroFeeEstimate()` - Returns zero fee estimate structure
+
+These new methods provide better handling of the enhanced resource bounds structure introduced in v8.
+
+:::tip Important: Default Overhead Configuration
+By default, all fee estimation methods now include a **50% overhead** on all resource bounds (l1_gas, l2_gas, l1_data_gas) for both `max_amount` and `max_price_per_unit`. This global configuration ensures safer transaction execution by preventing out-of-gas errors due to network fluctuations. You can customize this overhead using `resourceBoundsOverhead` in provider options, ;with custom parser or global config.
+`toOverheadOverallFee()` and `toOverheadResourceBounds()` use default global overhead
+if overhead not specify. This could be disabled by providing false to overhead argument.
+:::
+
 ## New Features
 
 ### Custom Deployer Support

--- a/www/docs/guides/migrate.md
+++ b/www/docs/guides/migrate.md
@@ -288,7 +288,7 @@ const txReceipt = await account.waitForTransaction(deployTx.transaction_hash);
 const deployedContract = defaultDeployer.parseDeployerEvent(txReceipt);
 ```
 
-### Response Parser Changes
+### Response Parser Fee Estimate Changes
 
 The response parser now automatically adds overhead calculations to fee estimations, providing `resourceBounds` and `overall_fee` with configurable overhead margins.
 
@@ -389,9 +389,13 @@ The new overhead types provide enhanced structure with `resourceBounds` (Resourc
 These new methods provide better handling of the enhanced resource bounds structure introduced in v8.
 
 :::tip Important: Default Overhead Configuration
-By default, all fee estimation methods now include a **50% overhead** on all resource bounds (l1_gas, l2_gas, l1_data_gas) for both `max_amount` and `max_price_per_unit`. This global configuration ensures safer transaction execution by preventing out-of-gas errors due to network fluctuations. You can customize this overhead using `resourceBoundsOverhead` in provider options, ;with custom parser or global config.
+By default, all fee estimation methods now include a **50% overhead** on all resource bounds (l1_gas, l2_gas, l1_data_gas) for both `max_amount` and `max_price_per_unit`. This global configuration ensures safer transaction execution by preventing out-of-gas errors due to network fluctuations. You can customize this overhead using `resourceBoundsOverhead` in provider options, with custom parser or global config.
 `toOverheadOverallFee()` and `toOverheadResourceBounds()` use default global overhead
-if overhead not specify. This could be disabled by providing false to overhead argument.
+if overhead not specified. This could be disabled by providing false to overhead argument.
+:::
+
+:::warning Fee Estimation Implementation Notice
+The current fee estimation calculation, particularly regarding tip handling, is still under discussion. The implementation may change based on the final solution determined by the Starknet protocol team. Future updates may modify how fees are calculated and structured.
 :::
 
 ## New Features


### PR DESCRIPTION
## Motivation and Resolution
@filenko45 (Serhii Filenko) reported missing info on migration guide
- Update migration guides with the Fee estimate format and stark fee helpers.
- Update on EstimateFee replacement
- Fixed a loophole in the overhead estimate utils that does not allow simple disabling of overhead.
- Return of the EventFilter as PCSPEC09.EventFilter as preferred event filter. Even do we support RPC 0.8 in the provider as the last -1 version support, it can produce unexpected empty results when used with a pending block.

### RPC version (if applicable)
EventFilter default PCSPEC09

## Usage-related changes
Simple disable of overhead in util methods
zeroResourceBounds() - return ResourceBoundsBN with zero bounds (without overhead).

## Checklist:

- [ ] Performed a self-review of the code
- [ ] Rebased to the last commit of the target branch (or merged it into my branch)
- [ ] Linked the issues which this PR resolves
- [ ] Documented the changes in code (API docs will be generated automatically)
- [ ] Updated the tests
- [ ] All tests are passing
