### PR TITLE
fix: ensure a Buffer type is available for all environments

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -13,3 +13,9 @@ export * from '../paymaster/types/index.type';
 export * from '../deployer/types/index.type';
 
 export * as RPC from './api';
+
+// ensures a Buffer type is available for development environments without Node.js types
+declare global {
+  interface Buffer<TArrayBuffer extends ArrayBufferLike = ArrayBufferLike>
+    extends Uint8Array<TArrayBuffer> {}
+}


### PR DESCRIPTION
## Motivation and Resolution

Ensures a Buffer type is available for development environments without Node.js types.