### PR TITLE
fix: enforce fixed size for cairo bytes

### DIFF
--- a/__tests__/utils/cairoDataTypes/CairoByteArray.test.ts
+++ b/__tests__/utils/cairoDataTypes/CairoByteArray.test.ts
@@ -707,13 +707,43 @@ describe('CairoByteArray Unit Tests', () => {
         '0x' +
         '000000019900000000000002222222374206275726e206d65737aaaa000001' +
         '000000029900000000000002222222374206275726e206d65737aaaa000002' +
-        '000000039900000000000002222222374206275726e206d65737aaaa000003';
+        '000000039900000000000002222222374206275726e206d65737aaaa000003' +
+        '00d0f0';
       const buffer = Buffer.from(content.slice(2), 'hex');
       const byteArray = new CairoByteArray(buffer);
       const apiRequest = byteArray.toApiRequest();
       const reconstructedByteArray = CairoByteArray.factoryFromApiResponse(apiRequest.values());
 
       expect(reconstructedByteArray.toHexString()).toEqual(content);
+    });
+  });
+
+  describe('toElements method', () => {
+    test('should convert empty string to empty array', () => {
+      const byteArray = new CairoByteArray('');
+      expect(byteArray.toElements()).toEqual([]);
+    });
+
+    test('should convert short string into single element array corresponding to the pending word', () => {
+      const byteArray = new CairoByteArray('Test');
+      expect(byteArray.toElements()).toEqual([new Uint8Array([84, 101, 115, 116])]);
+    });
+
+    test('should convert large string into full size elements', () => {
+      const apiResponse = [
+        '0x3',
+        '0x19900000000000002222222374206275726e206d65737aaaa000001',
+        '0x29900000000000002222222374206275726e206d65737aaaa000002',
+        '0x39900000000000002222222374206275726e206d65737aaaa000003',
+        '0xd0f0',
+        '0xa',
+      ];
+      const byteArray = CairoByteArray.factoryFromApiResponse(apiResponse.values());
+      const elements = byteArray.toElements();
+
+      expect(elements).toHaveLength(Number(apiResponse[0]) + 1);
+      elements.slice(0, -1).forEach((e) => expect(e).toHaveLength(31));
+      expect(elements.at(-1)).toHaveLength(Number(apiResponse.at(-1)));
     });
   });
 });

--- a/src/utils/cairoDataTypes/felt.ts
+++ b/src/utils/cairoDataTypes/felt.ts
@@ -71,7 +71,9 @@ export class CairoFelt252 {
 
   constructor(data: BigNumberish | boolean | unknown) {
     CairoFelt252.validate(data);
-    this.data = CairoFelt252.__processData(data as BigNumberish | boolean);
+    const processedData = CairoFelt252.__processData(data as BigNumberish | boolean);
+    // remove leading zeros, ensure data is an exact value/number
+    this.data = processedData.subarray(processedData.findIndex((x) => x > 0));
   }
 
   static __processData(data: BigNumberish | boolean): Uint8Array {


### PR DESCRIPTION
## Motivation and Resolution

Resolves the latest issue described in #1477.

Modifies the initialization of `CairoBytes31`, `CairoFelt252`, and consequently `CairoByteArray` to be more uniform, and adjusts their output methods to be better aligned with how RPC nodes communicate.

## Usage related changes

###  Initialization changes
The main change is that for the `CairoBytes31` class the `data` `Uint8Array` will always be initialized to the exact size of 31 regardless of input size. As an example, `new CairoBytes31('0x1')` and `new CairoBytes31('0x0001')` will both have the value of `data` set to `[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]`.

A similar change is made to `CairoFelt252`, the underlying `data` isn't prepended with zeros to match a fixed size like with `CairoBytes31`, and is instead truncated to exclude leading zeros. `new CairoFelt252('0x1')` and `new CairoFelt252('0x0001')` will both result in `data` having the value `[1]`.

###  Method changes

The existing behaviour of the `CairoBytes31` `toHexString()` method is modified to exclude leading zeros, to include them `toHexString('padded')` can be used.

The items in the `CairoByteArray` `toApiRequest()` output will not have leading zeros to match how RPC nodes format `ByteArray` data in their responses.

The `CairoByteArray` `toElements()` method is introduced to enable a simple overview of the unified underlying data, it outputs and array of `Uint8Array` entries that represent all the `bytes31` data chunks and the pending word.

## Checklist:

- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Linked the issues which this PR resolves
- [x] Documented the changes in code (API docs will be generated automatically)
- [x] Updated the tests
- [x] All tests are passing
