### PR TITLE
fix: fix waitfortransaction for rotating nodes services with lifeCycl…

### DIFF
--- a/src/channel/rpc_0_8_1.ts
+++ b/src/channel/rpc_0_8_1.ts
@@ -396,21 +396,22 @@ export class RpcChannel {
 
   public async waitForTransaction(txHash: BigNumberish, options?: waitForTransactionOptions) {
     const transactionHash = toHex(txHash);
-    let { retries } = this;
+    let retries = options?.retries ?? this.retries;
+    let lifeCycleRetries = options?.lifeCycleRetries ?? 3;
     let onchain = false;
     let isErrorState = false;
     const retryInterval = options?.retryInterval ?? this.transactionRetryIntervalDefault;
-    const errorStates: any = options?.errorStates ?? [
-      RPC.ETransactionStatus.REJECTED,
-      // TODO: commented out to preserve the long-standing behavior of "reverted" not being treated as an error by default
-      // should decide which behavior to keep in the future
-      // RPC.ETransactionExecutionStatus.REVERTED,
-    ];
+    const errorStates: any = options?.errorStates ?? [RPC.ETransactionStatus.REJECTED];
     const successStates: any = options?.successStates ?? [
       // RPC.ETransactionExecutionStatus.SUCCEEDED, Starknet 0.14.0 this one can have incomplete events
       RPC.ETransactionStatus.ACCEPTED_ON_L2,
       RPC.ETransactionStatus.ACCEPTED_ON_L1,
     ];
+    const LifeCycleErrorMessages: Record<string, string> = {
+      [RPCSPEC09.ETransactionStatus.RECEIVED]: SYSTEM_MESSAGES.txEvictedFromMempool,
+      [RPCSPEC09.ETransactionStatus.PRE_CONFIRMED]: SYSTEM_MESSAGES.consensusFailed,
+      [RPCSPEC09.ETransactionStatus.CANDIDATE]: SYSTEM_MESSAGES.txFailsBlockBuildingValidation,
+    };
 
     const txLife: string[] = [];
     let txStatus: RPC.TransactionStatus;
@@ -451,16 +452,11 @@ export class RpcChannel {
 
         if (error instanceof RpcError && error.isType('TXN_HASH_NOT_FOUND')) {
           logger.info('txLife: ', txLife);
-          const errorMessages: Record<string, string> = {
-            [RPCSPEC09.ETransactionStatus.RECEIVED]: SYSTEM_MESSAGES.txEvictedFromMempool,
-            [RPCSPEC09.ETransactionStatus.PRE_CONFIRMED]: SYSTEM_MESSAGES.consensusFailed,
-            [RPCSPEC09.ETransactionStatus.CANDIDATE]:
-              SYSTEM_MESSAGES.txFailsBlockBuildingValidation,
-          };
-          const errorMessage = errorMessages[txLife.at(-1) as string];
-          if (errorMessage) {
+          const errorMessage = LifeCycleErrorMessages[txLife.at(-1) as string];
+          if (errorMessage && lifeCycleRetries <= 0) {
             throw new Error(errorMessage);
           }
+          lifeCycleRetries -= 1;
         }
 
         if (retries <= 0) {

--- a/src/provider/types/configuration.type.ts
+++ b/src/provider/types/configuration.type.ts
@@ -1,13 +1,22 @@
 import { NetworkName, StarknetChainId, SupportedRpcVersion } from '../../global/constants';
-import { BlockIdentifier } from '../../types/lib';
+import { BlockIdentifier, waitForTransactionOptions } from '../../types/lib';
 import { ResourceBoundsOverhead } from './spec.type';
 
 export interface ProviderOptions extends RpcProviderOptions {}
 
 export type RpcProviderOptions = {
   nodeUrl?: string | NetworkName;
-  retries?: number;
+  /**
+   * Define the number of retries for waitForTransaction
+   */
+  retries?: waitForTransactionOptions['retries'];
+  /**
+   * Define the time interval between retries in milliseconds
+   */
   transactionRetryIntervalFallback?: number;
+  /**
+   * Define the headers
+   */
   headers?: object;
   blockIdentifier?: BlockIdentifier;
   chainId?: StarknetChainId;

--- a/src/types/lib/index.ts
+++ b/src/types/lib/index.ts
@@ -313,8 +313,26 @@ export type ParsedStruct = {
 };
 
 export type waitForTransactionOptions = {
+  /**
+   * Define the number of retries before throwing an error for the transaction life cycle when the transaction is not found after it had a valid status.
+   * This is useful for nodes that are not fully synced yet when connecting to service that rotate nodes.
+   */
+  lifeCycleRetries?: number;
+  /**
+   * Define the number of retries before throwing an error
+   */
+  retries?: number;
+  /**
+   * Define the time interval between retries in milliseconds
+   */
   retryInterval?: number;
+  /**
+   * Define which states are considered as successful
+   */
   successStates?: Array<TransactionFinalityStatus | TransactionExecutionStatus>;
+  /**
+   * Define which states are considered as errors
+   */
   errorStates?: Array<TransactionFinalityStatus | TransactionExecutionStatus>;
 };
 


### PR DESCRIPTION
## Motivation and Resolution
If a user connects to a node service or infra that rotates rpc nodes, the node can be unsynced, yet when conducting tx status, and returns TXN_HASH_NOT_FOUND after the tx has status. This indicates the tx lifecycle, but in this case, it could be an unsynced node.

The solution is to add lifecycle retries, default to 3, before concluding that it is evicted or another lifecycle event happened.
Also added retries directly to the method instead of just provider config.

## Usage related changes
waitForTransaction options
```ts
  /**
   * Define the number of retries before throwing an error for the transaction life cycle when the transaction is not found after it had a valid status.
   * This is useful for nodes that are not fully synced yet when connecting to service that rotate nodes.
   */
  lifeCycleRetries?: number;
  /**
   * Define the number of retries before throwing an error
   */
  retries?: number;
  /**
   * Define the time interval between retries in milliseconds
   */
```

## Checklist:

- [ ] Performed a self-review of the code
- [ ] Rebased to the last commit of the target branch (or merged it into my branch)
- [ ] Linked the issues which this PR resolves
- [ ] Documented the changes in code (API docs will be generated automatically)
- [ ] Updated the tests
- [ ] All tests are passing
