### PR TITLE
fix(starknetId): accept bigAlphabet characters in isStarkDomain

### DIFF
--- a/__tests__/utils/starknetId.test.ts
+++ b/__tests__/utils/starknetId.test.ts
@@ -65,10 +65,12 @@ describe('Should test StarknetId utils', () => {
   });
 
   test('Should validate StarknetId domain label boundaries', () => {
-    // exactly 48 chars — valid
-    expect(isStarkDomain(`${'a'.repeat(48)}.stark`)).toBe(true);
-    // subdomain label exactly 48 chars — valid
-    expect(isStarkDomain(`${'a'.repeat(48)}.example.stark`)).toBe(true);
+    // 47 chars — the longest ASCII label whose encoding still fits in a felt
+    expect(isStarkDomain(`${'a'.repeat(47)}.stark`)).toBe(true);
+    // subdomain label of 47 chars — valid
+    expect(isStarkDomain(`${'a'.repeat(47)}.example.stark`)).toBe(true);
+    // 48 chars — under the 48-char label limit, but the encoding overflows the felt
+    expect(isStarkDomain(`${'a'.repeat(48)}.stark`)).toBe(false);
     // subdomain label 49 chars — invalid (uniform 48-char limit on all labels)
     expect(isStarkDomain(`${'a'.repeat(49)}.example.stark`)).toBe(false);
     // empty label from double dot — invalid
@@ -90,8 +92,24 @@ describe('Should test StarknetId utils', () => {
     expect(useDecoded([useEncoded(name)])).toBe(`${name}.stark`);
     expect(isStarkDomain(`${name}.stark`)).toBe(true);
 
-    // both bigAlphabet chars are single UTF-16 units, so the 48-char label limit is unchanged
-    expect(isStarkDomain(`${'来'.repeat(48)}.stark`)).toBe(true);
-    expect(isStarkDomain(`${'来'.repeat(49)}.stark`)).toBe(false);
+    // a bigAlphabet character eats far more encoding capacity than an ASCII one, so what caps
+    // these labels is the felt bound, not the 48-char limit: 20 chars for '来', 40 for '这'
+    expect(isStarkDomain(`${'来'.repeat(20)}.stark`)).toBe(true);
+    expect(isStarkDomain(`${'来'.repeat(21)}.stark`)).toBe(false);
+    expect(isStarkDomain(`${'这'.repeat(40)}.stark`)).toBe(true);
+    expect(isStarkDomain(`${'这'.repeat(41)}.stark`)).toBe(false);
+  });
+
+  test('Should reject characters outside the Starknet.id alphabets', () => {
+    // An unknown character used to be skipped silently, so a mistyped name encoded as an
+    // existing one: 'Grug' and 'rug' both gave 9441n and resolved to the very same address.
+    expect(() => useEncoded('Grug')).toThrow('Invalid character "G"');
+    expect(() => useEncoded('cafè')).toThrow('Invalid character "è"');
+    // useEncoded takes a single label, so the separator is not part of its alphabets either
+    expect(() => useEncoded('starknet.js')).toThrow('Invalid character "."');
+
+    // the guard reports the same names as invalid, rather than resolving another account
+    expect(isStarkDomain('Grug.stark')).toBe(false);
+    expect(isStarkDomain('cafè.stark')).toBe(false);
   });
 });

--- a/__tests__/utils/starknetId.test.ts
+++ b/__tests__/utils/starknetId.test.ts
@@ -76,4 +76,22 @@ describe('Should test StarknetId utils', () => {
     // no name before .stark — invalid
     expect(isStarkDomain('.stark')).toBe(false);
   });
+
+  test('Should accept bigAlphabet characters that the encoder supports', () => {
+    // '这' and '来' are the two bigAlphabet characters used by useEncoded/useDecoded.
+    // The encoder round-trips names containing them, so the guard must accept them too,
+    // otherwise getAddressFromStarkName rejects names the same version encodes correctly.
+    expect(isStarkDomain('来baba这.stark')).toBe(true);
+    expect(isStarkDomain('starknet这.stark')).toBe(true);
+    expect(isStarkDomain('这.stark')).toBe(true);
+
+    // guard stays consistent with the encoder for the same name
+    const name = '来baba这';
+    expect(useDecoded([useEncoded(name)])).toBe(`${name}.stark`);
+    expect(isStarkDomain(`${name}.stark`)).toBe(true);
+
+    // both bigAlphabet chars are single UTF-16 units, so the 48-char label limit is unchanged
+    expect(isStarkDomain(`${'来'.repeat(48)}.stark`)).toBe(true);
+    expect(isStarkDomain(`${'来'.repeat(49)}.stark`)).toBe(false);
+  });
 });

--- a/src/utils/starknetId.ts
+++ b/src/utils/starknetId.ts
@@ -424,7 +424,12 @@ export function isStarkDomain(domain: string): boolean {
       label.length > 0 &&
       label.length <= 48 &&
       [...label].every((char) => {
-        return (char >= 'a' && char <= 'z') || (char >= '0' && char <= '9') || char === '-';
+        return (
+          (char >= 'a' && char <= 'z') ||
+          (char >= '0' && char <= '9') ||
+          char === '-' ||
+          bigAlphabet.includes(char)
+        );
       })
     );
   });

--- a/src/utils/starknetId.ts
+++ b/src/utils/starknetId.ts
@@ -1,4 +1,4 @@
-import { StarknetChainId, ZERO } from '../global/constants';
+import { PRIME, StarknetChainId, ZERO } from '../global/constants';
 import { BigNumberish } from '../types';
 import { tuple } from './calldata/cairo';
 import { CairoCustomEnum } from './calldata/enum/CairoCustomEnum';
@@ -72,14 +72,22 @@ export function useDecoded(encoded: bigint[]): string {
 }
 
 /**
- * Encodes a string into a bigint value.
+ * Encodes a single Starknet.id label into a bigint value.
  *
- * @param {string} decoded The string to be encoded.
+ * Only the characters of the Starknet.id alphabets are accepted: `a-z`, `0-9`, `-` and the two
+ * `bigAlphabet` characters. Any other character throws, so a mistyped name can never be silently
+ * encoded as a different, existing one.
+ *
+ * @param {string} decoded The label to be encoded, without any `.` separator nor `.stark` suffix.
  * @returns {bigint} The encoded bigint value.
+ * @throws {Error} If the label holds a character outside the Starknet.id alphabets.
  * @example
  * ```typescript
- * const result = starknetId.useEncoded("starknet.js");
+ * const result = starknetId.useEncoded("starknetjs");
  * // result = 3015206943634620n
+ *
+ * starknetId.useEncoded("Starknetjs");
+ * // throws an Error: the uppercase "S" is not a Starknet.id character
  * ```
  */
 export function useEncoded(decoded: string): bigint {
@@ -118,6 +126,10 @@ export function useEncoded(decoded: string): bigint {
       const newid = (i === decoded.length - 1 ? 1 : 0) + bigAlphabet.indexOf(char);
       encoded += multiplier * BigInt(newid);
       multiplier *= bigAlphabetSize;
+    } else {
+      throw new Error(
+        `Invalid character "${char}" in a Starknet.id name: allowed characters are "${basicAlphabet}" and "${bigAlphabet}"`
+      );
     }
   }
 
@@ -420,17 +432,17 @@ export function isStarkDomain(domain: string): boolean {
   }
 
   return name.split('.').every((label) => {
-    return (
-      label.length > 0 &&
-      label.length <= 48 &&
-      [...label].every((char) => {
-        return (
-          (char >= 'a' && char <= 'z') ||
-          (char >= '0' && char <= '9') ||
-          char === '-' ||
-          bigAlphabet.includes(char)
-        );
-      })
-    );
+    if (label.length === 0 || label.length > 48) {
+      return false;
+    }
+
+    // The encoder owns the alphabets, so deriving from it keeps the guard and the encoding from
+    // ever disagreeing again. The felt bound is checked here because a 48 character label can
+    // still overflow the field.
+    try {
+      return useEncoded(label) < PRIME;
+    } catch {
+      return false;
+    }
   });
 }


### PR DESCRIPTION
## Problem

`getAddressFromStarkName` refuses to resolve names that the same library version encodes correctly. A registered Starknet.id name containing a `bigAlphabet` character (e.g. `来baba这.stark`, live on mainnet) is rejected by the `isStarkDomain` guard before the call ever reaches the naming contract, so it throws `Invalid domain, must be a valid .stark domain`. This is a self-inconsistency: `useEncoded`/`useDecoded` round-trip the same name, and the felt they produce matches what the naming contract expects.

## Root cause

The guard added in #1301 (and kept unchanged by the per-character rewrite in #1612) only accepts `[a-z0-9-]`, but the encoder in `src/utils/starknetId.ts` accepts `basicAlphabet` plus `bigAlphabet` (`'这来'`). `getAddressFromStarkName` calls `isStarkDomain` first (`src/plugins/starknet-id/index.ts`), so any name using a `bigAlphabet` character fails validation before it is ever encoded.

## Fix

Extend the per-character test in `isStarkDomain` with a `bigAlphabet.includes(char)` branch, so the guard accepts exactly the characters the encoder accepts. Both `bigAlphabet` characters are single UTF-16 code units, so the existing 48-character label limit is unchanged. The same character set also lives in starknetid.js (`packages/core/src/utils.ts`) and can be aligned separately there.

## Test

Added a regression test in `__tests__/utils/starknetId.test.ts` asserting that `isStarkDomain` accepts `bigAlphabet` names (including the mainnet example `来baba这.stark`), stays consistent with the encoder for the same name, and still enforces the 48-character label limit. Runs with the infra-free unit config:

```
npx jest -c jest.unit.config.ts -i __tests__/utils/starknetId.test.ts -t "bigAlphabet"
```

Fixes #1668