### PR TITLE
fix(calldata): long string chunks stay text, at any ABI depth

### DIFF
--- a/__tests__/factories/abi.ts
+++ b/__tests__/factories/abi.ts
@@ -36,6 +36,30 @@ export const getAbiStructs = (): AbiStructs => ({
     name: 'cairo__struct',
     type: 'struct',
   },
+  struct_with_felt_array: {
+    members: [
+      {
+        name: 'felt_array',
+        type: 'core::array::Array::<core::felt252>',
+        offset: 0,
+      },
+    ],
+    size: 1,
+    name: 'cairo__struct_with_felt_array',
+    type: 'struct',
+  },
+  struct_with_u8_array: {
+    members: [
+      {
+        name: 'u8_array',
+        type: 'core::array::Array::<core::integer::u8>',
+        offset: 0,
+      },
+    ],
+    size: 1,
+    name: 'cairo__struct_with_u8_array',
+    type: 'struct',
+  },
 });
 
 export const getAbiEnums = (): AbiEnums => ({
@@ -49,6 +73,23 @@ export const getAbiEnums = (): AbiEnums => ({
     ],
     size: 2,
     name: 'test_cairo',
+    type: 'enum',
+  },
+  'core::option::Option::<core::array::Array::<core::felt252>>': {
+    variants: [
+      {
+        name: 'Some',
+        type: 'core::array::Array::<core::felt252>',
+        offset: 0,
+      },
+      {
+        name: 'None',
+        type: '()',
+        offset: 1,
+      },
+    ],
+    size: 2,
+    name: 'core::option::Option::<core::array::Array::<core::felt252>>',
     type: 'enum',
   },
 });

--- a/__tests__/utils/calldata/requestParser.test.ts
+++ b/__tests__/utils/calldata/requestParser.test.ts
@@ -50,6 +50,99 @@ describe('requestParser', () => {
       expect(parsedField).toEqual(['1', '599374153440608178282648329058547045']);
     });
 
+    describe('long string in place of an Array<felt252>', () => {
+      // 33 characters : the split isolates a chunk that looks like a decimal number
+      const longText = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567';
+      // 37 characters : the split isolates a chunk that looks like a hex string
+      const longTextHex = `${'A'.repeat(31)}0x1234`;
+      const firstChunk =
+        '115302387975643577911206786302384344998065844015382184106956994275072750645';
+      const firstChunkHex =
+        '115295431991813000957906158479851623934781694290236468482915792900036051265';
+
+      const parse = (type: string, value: unknown) =>
+        parseCalldataField({
+          argsIterator: [value][Symbol.iterator](),
+          input: getAbiEntry(type),
+          structs: getAbiStructs(),
+          enums: getAbiEnums(),
+          parser: new AbiParser1([getAbiEntry(type)]),
+        });
+
+      test('should encode a chunk that looks like a number as text', () => {
+        expect(parse('core::array::Array::<core::felt252>', longText)).toEqual([
+          '2',
+          firstChunk,
+          '13879', // '67' encoded as text, not as the number 67
+        ]);
+      });
+
+      test('should encode a chunk that looks like a hex string as text', () => {
+        expect(parse('core::array::Array::<core::felt252>', longTextHex)).toEqual([
+          '2',
+          firstChunkHex,
+          '53292779582260', // '0x1234' encoded as text, not as the number 4660
+        ]);
+      });
+
+      test('should not convert the items of an array provided by the caller', () => {
+        expect(parse('core::array::Array::<core::felt252>', ['67'])).toEqual(['1', '67']);
+      });
+
+      test('should convert a long string in a struct member', () => {
+        expect(parse('struct_with_felt_array', { felt_array: longText })).toEqual([
+          '2',
+          firstChunk,
+          '13879',
+        ]);
+      });
+
+      test('should convert a long string in a tuple member', () => {
+        expect(
+          parse('(core::array::Array::<core::felt252>, core::felt252)', { 0: longText, 1: 5 })
+        ).toEqual(['2', firstChunk, '13879', '5']);
+      });
+
+      test('should convert a long string in an array of arrays', () => {
+        expect(
+          parse('core::array::Array::<core::array::Array::<core::felt252>>', [longText])
+        ).toEqual(['1', '2', firstChunk, '13879']);
+      });
+
+      test('should convert a long string in an enum variant', () => {
+        expect(
+          parse(
+            'core::option::Option::<core::array::Array::<core::felt252>>',
+            new CairoOption<string>(0, longText)
+          )
+        ).toEqual(['0', '2', firstChunk, '13879']);
+      });
+
+      test('should throw when the array is not an array of felt252', () => {
+        expect(() => parse('core::array::Array::<core::integer::u8>', longText)).toThrow(
+          new Error(`ABI expected parameter test to be array, got ${longText}`)
+        );
+      });
+
+      test('should throw when a nested array is not an array of felt252', () => {
+        expect(() =>
+          parse('core::array::Array::<core::array::Array::<core::integer::u8>>', [longText])
+        ).toThrow(
+          new Error(
+            `ABI expected type core::array::Array::<core::integer::u8> to be array, got ${longText}`
+          )
+        );
+      });
+
+      test('should throw when a struct member is not an array of felt252', () => {
+        expect(() => parse('struct_with_u8_array', { u8_array: longText })).toThrow(
+          new Error(
+            `ABI expected type core::array::Array::<core::integer::u8> to be array, got ${longText}`
+          )
+        );
+      });
+    });
+
     test('should return parsed calldata field for NonZero type', () => {
       const args = [true];
       const argsIterator = args[Symbol.iterator]();

--- a/src/utils/calldata/requestParser.ts
+++ b/src/utils/calldata/requestParser.ts
@@ -25,16 +25,17 @@ import { CairoInt16 } from '../cairoDataTypes/int16';
 import { CairoInt32 } from '../cairoDataTypes/int32';
 import { CairoInt64 } from '../cairoDataTypes/int64';
 import { CairoInt128 } from '../cairoDataTypes/int128';
-import { addHexPrefix, removeHexPrefix } from '../encode';
+import { addHexPrefix, buf2hex, removeHexPrefix, utf8ToUint8Array } from '../encode';
 import { toHex } from '../num';
 import { isText, splitLongString } from '../shortString';
-import { isUndefined, isString } from '../typed';
+import { isUndefined } from '../typed';
 import {
   felt,
   getArrayType,
   isTypeArray,
   isTypeEnum,
   isTypeEthAddress,
+  isTypeFelt,
   isTypeNonZero,
   isTypeOption,
   isTypeResult,
@@ -54,6 +55,59 @@ import { AbiParserInterface } from './parser';
 import extractTupleMemberTypes from './tuple';
 
 // TODO: cleanup implementations to work with unknown, instead of blind casting with 'as'
+
+/**
+ * Test if a long string can be provided in place of an array of values.
+ * Only an array of felt252 can be filled this way, as a felt252 holds up to 31 characters of text.
+ * @param {string} type type from abi
+ * @returns {boolean} Returns true if a long string is a valid input for this type
+ * @example
+ * ```typescript
+ * const result = acceptsLongString('core::array::Array::<core::felt252>');
+ * // result = true
+ * const result2 = acceptsLongString('core::array::Array::<core::integer::u8>');
+ * // result2 = false
+ * ```
+ */
+function acceptsLongString(type: string): boolean {
+  return isTypeArray(type) && isTypeFelt(getArrayType(type));
+}
+
+/**
+ * Convert a long string to the array of felt252 that Cairo is expecting.
+ * Each chunk is encoded to its explicit hex value : the value has already been identified as text,
+ * so a chunk that looks like a number ('67') or like a hex string ('0x12') has to stay text.
+ * @param {string} longStr text to convert
+ * @returns {string[]} an array of hex strings, one per chunk of 31 characters
+ * @example
+ * ```typescript
+ * const result = longStringToFeltArray('ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567');
+ * // result = [
+ * //   '0x4142434445464748494a4b4c4d4e4f505152535455565758595a3132333435',
+ * //   '0x3637'
+ * // ]
+ * ```
+ */
+function longStringToFeltArray(longStr: string): string[] {
+  return splitLongString(longStr).map((chunk) => addHexPrefix(buf2hex(utf8ToUint8Array(chunk))));
+}
+
+/**
+ * Build the message of the error thrown when an array type receives an unusable value
+ * @param {string} subject faulty input, as described in the error message
+ * @param {string} type type from abi
+ * @param {unknown} value value provided
+ * @returns {string} the error message
+ * @example
+ * ```typescript
+ * const result = arrayInputErrorMessage('parameter tokens', 'core::array::Array::<core::integer::u8>', 'abc');
+ * // result = "ABI expected parameter tokens to be array, got abc"
+ * ```
+ */
+function arrayInputErrorMessage(subject: string, type: string, value: unknown): string {
+  const expected = acceptsLongString(type) ? 'array or long string' : 'array';
+  return `ABI expected ${subject} to be ${expected}, got ${value}`;
+}
 
 /**
  * parse base types
@@ -187,6 +241,20 @@ function parseCalldataValue({
         parseCalldataValue({ element: it, type: arrayType, structs, enums, parser })
       );
     }, [] as string[]);
+  }
+
+  // value is a long string provided in place of an Array<felt252>, at any depth
+  if (isTypeArray(type) && !Array.isArray(element)) {
+    if (!acceptsLongString(type) || !isText(element)) {
+      throw Error(arrayInputErrorMessage(`type ${type}`, type, element));
+    }
+    return parseCalldataValue({
+      element: longStringToFeltArray(element),
+      type,
+      structs,
+      enums,
+      parser,
+    });
   }
 
   // value is Array
@@ -428,7 +496,7 @@ export function parseCalldataField({
   parser: AbiParserInterface;
 }): string | string[] {
   const { name, type } = input;
-  let { value } = argsIterator.next();
+  const { value } = argsIterator.next();
 
   switch (true) {
     // Fixed array
@@ -439,12 +507,8 @@ export function parseCalldataField({
       return parseCalldataValue({ element: value, type: input.type, structs, enums, parser });
     // Normal Array
     case isTypeArray(type):
-      if (!Array.isArray(value) && !isText(value)) {
-        throw Error(`ABI expected parameter ${name} to be array or long string, got ${value}`);
-      }
-      if (isString(value)) {
-        // long string match cairo felt*
-        value = splitLongString(value);
+      if (!Array.isArray(value) && !(acceptsLongString(type) && isText(value))) {
+        throw Error(arrayInputErrorMessage(`parameter ${name}`, type, value));
       }
       return parseCalldataValue({ element: value, type: input.type, structs, enums, parser });
     case isTypeNonZero(type):


### PR DESCRIPTION
## Motivation and Resolution

When an ABI expects an `Array<felt252>` (or the Cairo 0 `felt*`), starknet.js accepts a JS string
and splits it into chunks of 31 characters. Each chunk was then re-parsed as an independent
`felt252` argument, which re-applies the number-vs-text heuristic — so a chunk that looks like a
decimal number or like a hex string was encoded as a number instead of text.

`'ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567'` splits into `['ABCDEFGHIJKLMNOPQRSTUVWXYZ12345', '67']`, and
the second chunk was encoded as the number `67` instead of `0x3637`. A contract decoding it back as
short strings reads the single character `'C'` (0x43 = 67) instead of `'67'`. The corruption is
silent: no error, just wrong text on chain. The same happens whenever a chunk boundary isolates
digits or something starting with `0x` — the end of a numbered URL, an identifier, a digit run.

The root cause is that the information "this chunk comes from a value already identified as text"
was thrown away at the split site. Each chunk is now encoded to its explicit UTF-8 hex value, so it
can no longer be re-interpreted as a number.

The same change fixes two related gaps:

- the shortcut only worked for a top-level argument. A string provided for a struct member, a tuple
  member, an enum variant or a nested array typed `Array<felt252>` was parsed as one single felt,
  which failed with an "out of felt252 range" error. It now works at any depth.
- the shortcut was applied to every array type. A string passed for an `Array<u8>` silently produced
  values far outside the `u8` range. It is now restricted to arrays of `felt252`.

### RPC version (if applicable)

Not applicable.

## Usage related changes

- A long string passed for an `Array<felt252>` is no longer corrupted when one of its 31-character
  chunks looks like a number (`'67'`) or like a hex string (`'0x12'`).
- The long string shortcut now works at any depth: struct member, tuple member, enum variant,
  nested array — not only as a top-level argument.
- Passing a string for an array whose items are not `felt252` now throws
  `ABI expected ... to be array, got ...` instead of silently producing out-of-range values.
- Unchanged on purpose: when the caller provides the array, each item is still parsed
  independently, so `['67']` still means the number 67.

## Development related changes

- `parseCalldataField` no longer splits the string itself. The conversion lives in
  `parseCalldataValue`, so a single rule applies at every depth instead of two divergent ones.
- Three module-private helpers in `requestParser.ts`: `acceptsLongString` (the "only an array of
  felt252" rule), `longStringToFeltArray` (the conversion) and `arrayInputErrorMessage` (so both
  error sites word it the same way, with or without the "or long string" mention).
- `__tests__/factories/abi.ts` gains three new entries: a struct with an `Array<felt252>` member, a
  struct with an `Array<u8>` member, and an `Option<Array<felt252>>` enum. Existing entries are
  untouched, as they are shared by many tests.
- 10 new unit tests in `requestParser.test.ts`, covering the two trap chunks, the four nesting
  positions, the three refusal cases, and one test pinning the behaviour that must not change.

## Checklist:

- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Documented the changes in code (API docs will be generated automatically)
- [x] Updated the tests
- [x] All tests are passing
