### PR TITLE
fix(calldata): text reaches a ByteArray, whatever it spells

### DIFF
--- a/__tests__/utils/buffer.test.ts
+++ b/__tests__/utils/buffer.test.ts
@@ -233,7 +233,7 @@ describe('Buffer Environment Tests', () => {
       // Test invalid inputs
       expect(() => new CairoByteArray(null as any)).toThrow(/Invalid input: null/);
       expect(() => new CairoByteArray({} as any)).toThrow(
-        /Invalid input.*objects are not supported/
+        /Invalid input for CairoByteArray: the only objects supported/
       );
     });
   });

--- a/__tests__/utils/cairoDataTypes/CairoByteArray.test.ts
+++ b/__tests__/utils/cairoDataTypes/CairoByteArray.test.ts
@@ -1,4 +1,5 @@
 import { CairoByteArray, CairoBytes31, CairoFelt252, CairoUint32 } from '../../../src';
+import { byteArrayFromString } from '../../../src/utils/calldata/byteArray';
 
 describe('CairoByteArray Unit Tests', () => {
   describe('String constructor', () => {
@@ -782,6 +783,152 @@ describe('CairoByteArray Unit Tests', () => {
       expect(elements).toHaveLength(Number(apiResponse[0]) + 1);
       elements.slice(0, -1).forEach((e) => expect(e).toHaveLength(31));
       expect(elements.at(-1)).toHaveLength(Number(apiResponse.at(-1)));
+    });
+  });
+
+  describe('fromText static method', () => {
+    // every expected value below comes from Buffer.from(text, 'utf8').toString('hex'),
+    // then BigInt() of that hex - computed outside the library
+    test('should encode a text that spells a decimal number as text', () => {
+      const byteArray = CairoByteArray.fromText('12345');
+
+      expect(byteArray.data).toEqual([]);
+      expect(byteArray.pending_word.toHexString()).toBe('0x3132333435');
+      expect(byteArray.pending_word_len.toBigInt()).toBe(5n);
+      expect(byteArray.toApiRequest()).toEqual(['0', '211295614005', '5']);
+    });
+
+    test('should encode a text that spells a hex string as text', () => {
+      const byteArray = CairoByteArray.fromText('0x4142');
+
+      expect(byteArray.toHexString()).toBe('0x307834313432');
+      expect(byteArray.pending_word_len.toBigInt()).toBe(6n);
+      expect(byteArray.toApiRequest()).toEqual(['0', '53292829848626', '6']);
+    });
+
+    test('should read the same strings differently from the constructor', () => {
+      // the constructor reads '12345' as the decimal number 12345, whose bytes are 0x30 0x39,
+      // and '0x4142' as the two bytes 0x41 0x42 - both legitimate, neither one the text
+      expect(new CairoByteArray('12345').toHexString()).toBe('0x3039');
+      expect(new CairoByteArray('0x4142').toHexString()).toBe('0x4142');
+      expect(CairoByteArray.fromText('12345').toHexString()).toBe('0x3132333435');
+      expect(CairoByteArray.fromText('0x4142').toHexString()).toBe('0x307834313432');
+    });
+
+    test('should leave a text that looks like neither untouched', () => {
+      // 'Take care.' already reached its UTF-8 bytes through the constructor
+      expect(CairoByteArray.fromText('Take care.').toApiRequest()).toEqual(
+        new CairoByteArray('Take care.').toApiRequest()
+      );
+      expect(CairoByteArray.fromText('héllo').toApiRequest()).toEqual(
+        new CairoByteArray('héllo').toApiRequest()
+      );
+    });
+
+    test('should cut a long text into 31-byte words rather than read it as one number', () => {
+      const digits = '1'.repeat(40); // 40 UTF-8 bytes : one full word, then 9 pending bytes
+      const byteArray = CairoByteArray.fromText(digits);
+
+      expect(byteArray.data).toHaveLength(1);
+      expect(byteArray.data[0].toBigInt()).toBe(BigInt(`0x${'31'.repeat(31)}`));
+      expect(byteArray.pending_word.toHexString()).toBe(`0x${'31'.repeat(9)}`);
+      expect(byteArray.pending_word_len.toBigInt()).toBe(9n);
+      expect(byteArray.decodeUtf8()).toBe(digits);
+      // read as one number, the same 40 characters hold in 17 bytes and spell something else
+      expect(new CairoByteArray(digits).pending_word_len.toBigInt()).toBe(17n);
+    });
+
+    test('should round trip through decodeUtf8', () => {
+      expect(CairoByteArray.fromText('12345').decodeUtf8()).toBe('12345');
+      expect(CairoByteArray.fromText('héllo').decodeUtf8()).toBe('héllo');
+    });
+
+    test('should handle an empty text', () => {
+      const byteArray = CairoByteArray.fromText('');
+
+      expect(byteArray.data).toEqual([]);
+      expect(byteArray.pending_word_len.toBigInt()).toBe(0n);
+      expect(byteArray.toApiRequest()).toEqual(['0', '0', '0']);
+    });
+  });
+
+  describe('ByteArray components constructor', () => {
+    // 'A'.repeat(31) then 'BC' : one full data word, then a two-byte pending word.
+    // 0x41 is 'A', 0x4243 is 'BC', and the felt is BigInt of the 62 hex characters.
+    const fullWordHex = `0x${'41'.repeat(31)}`;
+    const fullWordFelt = BigInt(fullWordHex).toString();
+    const text = `${'A'.repeat(31)}BC`;
+
+    test('should adopt a plain ByteArray object', () => {
+      const byteArray = new CairoByteArray({
+        data: [],
+        pending_word: '0x3132333435',
+        pending_word_len: 5,
+      });
+
+      expect(byteArray.toApiRequest()).toEqual(['0', '211295614005', '5']);
+      expect(byteArray.decodeUtf8()).toBe('12345');
+    });
+
+    test('should adopt the object returned by byteArrayFromString', () => {
+      expect(new CairoByteArray(byteArrayFromString('héllo')).decodeUtf8()).toBe('héllo');
+      expect(new CairoByteArray(byteArrayFromString(text)).decodeUtf8()).toBe(text);
+    });
+
+    test('should adopt data words given as a hex string', () => {
+      const byteArray = new CairoByteArray({
+        data: [fullWordHex],
+        pending_word: '0x4243',
+        pending_word_len: 2,
+      });
+
+      expect(byteArray.toApiRequest()).toEqual(['1', fullWordFelt, '16963', '2']);
+      expect(byteArray.decodeUtf8()).toBe(text);
+    });
+
+    test('should adopt data words given as a bigint', () => {
+      const byteArray = new CairoByteArray({
+        data: [BigInt(fullWordHex)],
+        pending_word: 16963n,
+        pending_word_len: 2,
+      });
+
+      expect(byteArray.toApiRequest()).toEqual(['1', fullWordFelt, '16963', '2']);
+      expect(byteArray.decodeUtf8()).toBe(text);
+    });
+
+    test('should adopt an existing CairoByteArray', () => {
+      const source = CairoByteArray.fromText('12345');
+      const copy = new CairoByteArray(source);
+
+      expect(copy.toApiRequest()).toEqual(['0', '211295614005', '5']);
+      expect(copy.decodeUtf8()).toBe('12345');
+    });
+
+    test('should adopt the components as they are, without cutting them again', () => {
+      // a pending word longer than what its content needs stays as declared
+      const byteArray = new CairoByteArray({
+        data: [],
+        pending_word: '0x4142',
+        pending_word_len: 4,
+      });
+
+      expect(byteArray.pending_word_len.toBigInt()).toBe(4n);
+      expect(byteArray.toElements()).toEqual([new Uint8Array([0, 0, 0x41, 0x42])]);
+    });
+
+    test('should recognise the shape in is()', () => {
+      expect(CairoByteArray.is({ data: [], pending_word: 0, pending_word_len: 0 })).toBe(true);
+      expect(CairoByteArray.is(CairoByteArray.fromText('12345'))).toBe(true);
+      expect(CairoByteArray.is({ data: 'ABC' } as any)).toBe(false);
+      expect(CairoByteArray.is({ pending_word: 0, pending_word_len: 0 } as any)).toBe(false);
+      expect(CairoByteArray.is({ data: [], pending_word: 0 } as any)).toBe(false);
+    });
+
+    test('should still reject an object that is not a ByteArray', () => {
+      expect(() => new CairoByteArray({} as any)).toThrow(
+        'Invalid input for CairoByteArray: the only objects supported are Uint8Array, Buffer, and { data, pending_word, pending_word_len }'
+      );
     });
   });
 });

--- a/__tests__/utils/cairoDataTypes/CairoBytes31.test.ts
+++ b/__tests__/utils/cairoDataTypes/CairoBytes31.test.ts
@@ -63,13 +63,13 @@ describe('CairoBytes31 class Unit Tests', () => {
 
     test('should reject invalid input types', () => {
       expect(() => new CairoBytes31(123 as any)).toThrow(
-        'Invalid input type for CairoBytes31. Expected string, Buffer, or Uint8Array'
+        'Invalid input type for CairoBytes31. Expected string, Buffer, Uint8Array, or CairoBytes31'
       );
       expect(() => new CairoBytes31({} as any)).toThrow(
-        'Invalid input type for CairoBytes31. Expected string, Buffer, or Uint8Array'
+        'Invalid input type for CairoBytes31. Expected string, Buffer, Uint8Array, or CairoBytes31'
       );
       expect(() => new CairoBytes31(null as any)).toThrow(
-        'Invalid input type for CairoBytes31. Expected string, Buffer, or Uint8Array'
+        'Invalid input type for CairoBytes31. Expected string, Buffer, Uint8Array, or CairoBytes31'
       );
     });
 
@@ -280,16 +280,16 @@ describe('CairoBytes31 class Unit Tests', () => {
 
     test('should reject invalid input types', () => {
       expect(() => CairoBytes31.validate(123 as any)).toThrow(
-        'Invalid input type for CairoBytes31. Expected string, Buffer, or Uint8Array'
+        'Invalid input type for CairoBytes31. Expected string, Buffer, Uint8Array, or CairoBytes31'
       );
       expect(() => CairoBytes31.validate({} as any)).toThrow(
-        'Invalid input type for CairoBytes31. Expected string, Buffer, or Uint8Array'
+        'Invalid input type for CairoBytes31. Expected string, Buffer, Uint8Array, or CairoBytes31'
       );
       expect(() => CairoBytes31.validate(null as any)).toThrow(
-        'Invalid input type for CairoBytes31. Expected string, Buffer, or Uint8Array'
+        'Invalid input type for CairoBytes31. Expected string, Buffer, Uint8Array, or CairoBytes31'
       );
       expect(() => CairoBytes31.validate(undefined as any)).toThrow(
-        'Invalid input type for CairoBytes31. Expected string, Buffer, or Uint8Array'
+        'Invalid input type for CairoBytes31. Expected string, Buffer, Uint8Array, or CairoBytes31'
       );
     });
 
@@ -441,6 +441,41 @@ describe('CairoBytes31 class Unit Tests', () => {
     test('should reject text longer than 31 bytes', () => {
       expect(() => CairoBytes31.fromText('x'.repeat(32))).toThrow(
         'Data is too long: 32 bytes (max 31 bytes)'
+      );
+    });
+  });
+
+  describe('constructor from an existing CairoBytes31', () => {
+    test('should adopt the bytes of another instance', () => {
+      const source = new CairoBytes31('0x4142');
+      const copy = new CairoBytes31(source);
+
+      expect(copy.toHexString()).toBe('0x4142');
+      expect(copy.data).toEqual(source.data);
+    });
+
+    test('should copy the bytes rather than share them', () => {
+      const source = new CairoBytes31('0x4142');
+      const copy = new CairoBytes31(source);
+      source.data[30] = 0;
+
+      expect(copy.toHexString()).toBe('0x4142');
+    });
+
+    test('should carry a fromText value through without reading it again', () => {
+      // '12345' as text is 0x3132333435, where the string constructor reads the number 0x3039
+      expect(new CairoBytes31(CairoBytes31.fromText('12345')).toHexString()).toBe('0x3132333435');
+      expect(new CairoBytes31('12345').toHexString()).toBe('0x3039');
+    });
+
+    test('should accept an instance in validate and is', () => {
+      expect(() => CairoBytes31.validate(CairoBytes31.fromText('12345'))).not.toThrow();
+      expect(CairoBytes31.is(CairoBytes31.fromText('12345'))).toBe(true);
+    });
+
+    test('should still reject an object that is not a bytes31', () => {
+      expect(() => new CairoBytes31({ data: '0x41' } as any)).toThrow(
+        'Invalid input type for CairoBytes31. Expected string, Buffer, Uint8Array, or CairoBytes31'
       );
     });
   });

--- a/__tests__/utils/calldata/requestParser.test.ts
+++ b/__tests__/utils/calldata/requestParser.test.ts
@@ -1,13 +1,20 @@
 import { parseCalldataField } from '../../../src/utils/calldata/requestParser';
 import { getAbiEnums, getAbiStructs, getAbiEntry } from '../../factories/abi';
 import {
+  Abi,
   AbiParser1,
+  CairoByteArray,
+  CairoBytes31,
   CairoCustomEnum,
   CairoOption,
   CairoResult,
+  CallData,
   ETH_ADDRESS,
   NON_ZERO_PREFIX,
+  ValidateType,
 } from '../../../src';
+import { byteArrayFromString } from '../../../src/utils/calldata/byteArray';
+import { ABI as StringABI } from '../../../__mocks__/cairo/cairo240/string';
 
 describe('requestParser', () => {
   describe('parseCalldataField', () => {
@@ -385,6 +392,114 @@ describe('requestParser', () => {
           parser: new AbiParser1([getAbiEntry('core::array::Array::<felt>')]),
         })
       ).toThrow(new Error('ABI expected parameter test to be array or long string, got 256'));
+    });
+  });
+
+  describe('a text that spells a number, through the abi', () => {
+    // proceed_string(mess: core::byte_array::ByteArray) and proceed_bytes31(str: bytes31),
+    // taken from the compiled test contract rather than from a hand-written abi
+    const stringCallData = new CallData(StringABI as Abi);
+
+    // Buffer.from('12345', 'utf8').toString('hex') is '3132333435', whose BigInt is this
+    const textFelt = '211295614005';
+
+    test('should keep reading a bare string the way calldata does', () => {
+      // '12345' is the decimal number 12345, whose two bytes 0x30 0x39 spell the text '09'
+      expect(stringCallData.compile('proceed_string', ['12345'])).toEqual(['0', '12345', '2']);
+      expect(stringCallData.compile('proceed_bytes31', ['12345'])).toEqual(['12345']);
+    });
+
+    test('should send the text itself when it is built with fromText', () => {
+      expect(stringCallData.compile('proceed_string', [CairoByteArray.fromText('12345')])).toEqual([
+        '0',
+        textFelt,
+        '5',
+      ]);
+      expect(stringCallData.compile('proceed_bytes31', [CairoBytes31.fromText('12345')])).toEqual([
+        textFelt,
+      ]);
+    });
+
+    test('should accept the object returned by byteArrayFromString', () => {
+      expect(stringCallData.compile('proceed_string', [byteArrayFromString('12345')])).toEqual([
+        '0',
+        textFelt,
+        '5',
+      ]);
+    });
+
+    test('should pass the validation a contract call runs before compiling', () => {
+      expect(() =>
+        stringCallData.validate(ValidateType.CALL, 'proceed_string', [
+          CairoByteArray.fromText('12345'),
+        ])
+      ).not.toThrow();
+      expect(() =>
+        stringCallData.validate(ValidateType.CALL, 'proceed_bytes31', [
+          CairoBytes31.fromText('12345'),
+        ])
+      ).not.toThrow();
+    });
+
+    test('should validate and compile named arguments in a single call', () => {
+      // named arguments are the only form that validates from inside compile
+      expect(
+        stringCallData.compile('proceed_string', { mess: CairoByteArray.fromText('12345') })
+      ).toEqual(['0', textFelt, '5']);
+      expect(
+        stringCallData.compile('proceed_bytes31', { str: CairoBytes31.fromText('12345') })
+      ).toEqual([textFelt]);
+    });
+
+    describe('at any abi depth', () => {
+      // no compiled contract of the repository exposes a nested ByteArray, so the two nesting
+      // cases are declared on top of the real abi - the ByteArray struct itself still comes
+      // from the contract, it is not written again here
+      const nestedCallData = new CallData([
+        ...StringABI,
+        {
+          type: 'struct',
+          name: 'string::string::Labelled',
+          members: [
+            { name: 'label', type: 'core::byte_array::ByteArray' },
+            { name: 'n', type: 'core::integer::u8' },
+          ],
+        },
+        {
+          type: 'function',
+          name: 'proceed_labelled',
+          inputs: [{ name: 'item', type: 'string::string::Labelled' }],
+          outputs: [],
+          state_mutability: 'view',
+        },
+        {
+          type: 'function',
+          name: 'proceed_many',
+          inputs: [{ name: 'items', type: 'core::array::Array::<core::byte_array::ByteArray>' }],
+          outputs: [],
+          state_mutability: 'view',
+        },
+      ] as Abi);
+
+      test('should reach a ByteArray held by a struct member', () => {
+        expect(
+          nestedCallData.compile('proceed_labelled', [
+            { label: CairoByteArray.fromText('12345'), n: 1 },
+          ])
+        ).toEqual(['0', textFelt, '5', '1']);
+      });
+
+      test('should reach a ByteArray held by an array', () => {
+        expect(
+          nestedCallData.compile('proceed_many', [[CairoByteArray.fromText('12345')]])
+        ).toEqual(['1', '0', textFelt, '5']);
+      });
+
+      test('should reach a byteArrayFromString object held by an array', () => {
+        expect(
+          nestedCallData.compile('proceed_many', { items: [byteArrayFromString('12345')] })
+        ).toEqual(['1', '0', textFelt, '5']);
+      });
     });
   });
 });

--- a/src/utils/cairoDataTypes/byteArray.ts
+++ b/src/utils/cairoDataTypes/byteArray.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-underscore-dangle */
-import { BigNumberish } from '../../types';
+import { BigNumberish, ByteArray } from '../../types';
 import assert from '../assert';
 import {
   addHexPrefix,
@@ -7,39 +7,153 @@ import {
   buf2hex,
   concatenateArrayBuffer,
   stringToUint8Array,
+  utf8ToUint8Array,
 } from '../encode';
 import { computeHashOnElements } from '../hash/pedersenCore';
-import { getNext } from '../num';
-import { isBigInt, isBuffer, isInteger, isNumber, isString } from '../typed';
+import { getNext, toHex } from '../num';
+import { isBigInt, isBuffer, isInteger, isNumber, isObject, isString } from '../typed';
 import { addCompiledFlag } from '../helpers';
 import Buffer from '../connect/buffer';
 import { CairoBytes31 } from './bytes31';
 import { CairoFelt252 } from './felt';
 import { CairoUint32 } from './uint32';
 
+/**
+ * The three components of a Cairo `ByteArray`, whatever the type of each one.
+ *
+ * A {@link CairoByteArray} holds them already typed, while the plain object of
+ * `byteArrayFromString` holds them as `BigNumberish`. This type is what the two have in common.
+ */
+type ByteArrayComponents = {
+  data: (BigNumberish | CairoBytes31)[];
+  pending_word: BigNumberish | CairoFelt252;
+  pending_word_len: BigNumberish | CairoUint32;
+};
+
+/**
+ * Does this value spell out the three components of a Cairo `ByteArray`?
+ *
+ * `data` has to be an array, which is what separates a ByteArray from an unrelated object that
+ * happens to own a `data` key. The members themselves are not inspected: whether they are typed
+ * or `BigNumberish` is decided when they are adopted, not here.
+ * @param {unknown} value the value to test
+ * @returns {boolean} true when the value owns `data` (an array), `pending_word` and `pending_word_len`
+ * @example
+ * ```typescript
+ * const result = isByteArrayShape({ data: [], pending_word: '0x3132', pending_word_len: 2 });
+ * // result = true
+ * const result2 = isByteArrayShape({ data: 'ABC' });
+ * // result2 = false
+ * ```
+ */
+function isByteArrayShape(value: unknown): value is ByteArrayComponents {
+  return (
+    isObject(value) &&
+    'data' in value &&
+    Array.isArray((value as ByteArrayComponents).data) &&
+    'pending_word' in value &&
+    'pending_word_len' in value
+  );
+}
+
+/**
+ * A Cairo `core::byte_array::ByteArray` : an arbitrary sequence of bytes, cut into words of 31.
+ *
+ * A ByteArray is **not** Cairo's string type. It carries bytes, and text is only one of the things
+ * those bytes can mean — which is why the constructor reads a string the way calldata does, and why
+ * text has a door of its own, {@link CairoByteArray.fromText}.
+ * @example
+ * ```typescript
+ * // the same four characters, read four ways
+ * new CairoByteArray('Hello').toHexString(); //      "0x48656c6c6f"  text, nothing else fits
+ * new CairoByteArray('12345').toHexString(); //      "0x3039"        the number 12345
+ * new CairoByteArray('0x4142').toHexString(); //     "0x4142"        the bytes 0x41 0x42
+ * CairoByteArray.fromText('12345').toHexString(); // "0x3132333435"  the text '12345'
+ * ```
+ */
 export class CairoByteArray {
   /**
-   * entire dataset
+   * The complete words, 31 bytes each.
+   *
+   * Bytes that do not fill a whole word are not here, but in {@link CairoByteArray.pending_word}.
+   * @example
+   * ```typescript
+   * const result = CairoByteArray.fromText('ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567').data.length;
+   * // result = 1     (33 bytes : one full word of 31, and 2 bytes left pending)
+   * ```
    */
   data: CairoBytes31[] = [];
 
   /**
-   * cairo specific implementation helper
+   * The bytes left over after the last complete word, held as a felt252.
+   *
+   * Its value alone does not say how many bytes it holds — a leading zero byte is invisible in a
+   * number — which is what {@link CairoByteArray.pending_word_len} is for.
+   * @example
+   * ```typescript
+   * const text = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567';
+   * const result = CairoByteArray.fromText(text).pending_word.toHexString();
+   * // result = "0x3637"     (the two characters '67' left after the first word)
+   * ```
    */
   pending_word!: CairoFelt252; // felt
 
   /**
-   * cairo specific implementation helper
+   * How many bytes {@link CairoByteArray.pending_word} holds, from 0 to 30.
+   *
+   * The contract reads this length, so the same pending word under two lengths is two different
+   * values : `0x41` on one byte is `A`, on two bytes it is a NUL followed by `A`.
+   * @example
+   * ```typescript
+   * const result = new CairoByteArray('0x0041').pending_word_len.toBigInt();
+   * // result = 2n    (where new CairoByteArray('0x41') gives 1n, for the same pending word)
+   * ```
    */
   pending_word_len!: CairoUint32; // u32
 
+  /**
+   * The abi type this class serializes.
+   * @example
+   * ```typescript
+   * const result = CairoByteArray.abiSelector;
+   * // result = "core::byte_array::ByteArray"
+   * ```
+   */
   static abiSelector = 'core::byte_array::ByteArray' as const;
 
   /**
-   * byteArray from typed components
+   * Build from components that are already typed, the form an api response arrives in.
+   * @param {CairoBytes31[]} data the complete 31-byte words
+   * @param {CairoFelt252} pendingWord the bytes left after the last complete word
+   * @param {CairoUint32} pendingWordLen how many bytes `pendingWord` holds
+   * @example
+   * ```typescript
+   * const pending = new CairoFelt252('0x48656c6c6f');
+   * const result = new CairoByteArray([], pending, new CairoUint32(5)).decodeUtf8();
+   * // result = "Hello"
+   * ```
    */
   public constructor(data: CairoBytes31[], pendingWord: CairoFelt252, pendingWordLen: CairoUint32);
-  public constructor(data: BigNumberish | Buffer | Uint8Array | unknown);
+  /**
+   * Build from a single value, cut into words of 31 bytes.
+   *
+   * A string is read the way calldata reads it : `'0x41'` as the byte 0x41, `'12345'` as the number
+   * 12345, anything else as UTF-8 text. A string that spells a number therefore becomes that
+   * number, with no error raised — use {@link CairoByteArray.fromText} when the argument is text.
+   *
+   * A value that is already a ByteArray — an instance, or the object returned by
+   * `byteArrayFromString` — is adopted as it stands, its words never cut again.
+   * @param {BigNumberish | Buffer | Uint8Array | ByteArray} data the value to carry
+   * @example
+   * ```typescript
+   * const result = new CairoByteArray('Hello').toApiRequest();
+   * // result = ["0", "310939249775", "5"]
+   * const components = { data: [], pending_word: '0x41', pending_word_len: 1 };
+   * const result2 = new CairoByteArray(components).decodeUtf8();
+   * // result2 = "A"
+   * ```
+   */
+  public constructor(data: BigNumberish | Buffer | Uint8Array | ByteArray | unknown);
   public constructor(...arr: any[]) {
     // Handle constructor from typed components
     if (arr.length === 3) {
@@ -68,7 +182,40 @@ export class CairoByteArray {
     this.pending_word_len = pending_word_len;
   }
 
-  static __processData(inData: BigNumberish | Buffer | Uint8Array | unknown) {
+  /**
+   * Turn any accepted input into the three components of a ByteArray.
+   *
+   * Shared by both constructor paths. An input that is already a ByteArray is adopted rather than
+   * cut again, so a pending word declared longer than its content keeps that declared length.
+   * @param {BigNumberish | Buffer | Uint8Array | ByteArray} inData the value to convert
+   * @returns {object} the `data`, `pending_word` and `pending_word_len` components
+   * @example
+   * ```typescript
+   * const result = CairoByteArray.__processData('Hello').pending_word_len.toBigInt();
+   * // result = 5n
+   * ```
+   */
+  static __processData(inData: BigNumberish | Buffer | Uint8Array | ByteArray | unknown) {
+    // An already cut ByteArray : its components are adopted as they are, never concatenated and
+    // cut again. Covers a CairoByteArray instance and the plain object of `byteArrayFromString`.
+    if (isByteArrayShape(inData)) {
+      return {
+        // a data word has no length field, so a BigNumberish one is normalized through its hex
+        // form, the only representation CairoBytes31 reads without guessing
+        data: inData.data.map((word) =>
+          word instanceof CairoBytes31 ? word : new CairoBytes31(toHex(word))
+        ),
+        pending_word:
+          inData.pending_word instanceof CairoFelt252
+            ? inData.pending_word
+            : new CairoFelt252(inData.pending_word),
+        pending_word_len:
+          inData.pending_word_len instanceof CairoUint32
+            ? inData.pending_word_len
+            : new CairoUint32(inData.pending_word_len),
+      };
+    }
+
     let fullData: Uint8Array;
     // Handle different input types
     if (inData instanceof Uint8Array) {
@@ -87,7 +234,9 @@ export class CairoByteArray {
       // byteArrayFromNumber
       fullData = bigIntToUint8Array(BigInt(inData));
     } else {
-      throw new Error('Invalid input type. Expected Uint8Array, Buffer, string, number, or bigint');
+      throw new Error(
+        'Invalid input type. Expected Uint8Array, Buffer, ByteArray, string, number, or bigint'
+      );
     }
 
     const CHUNK_SIZE = CairoBytes31.MAX_BYTE_SIZE;
@@ -125,6 +274,37 @@ export class CairoByteArray {
     return { data, pending_word, pending_word_len };
   }
 
+  /**
+   * Build from text, with no interpretation of what the text looks like.
+   *
+   * The constructor reads a string the way calldata does — `'0x1a'` as two hexadecimal bytes,
+   * `'12345'` as a decimal number — because a ByteArray is a byte sequence, not Cairo's string
+   * type, and spelling those bytes in hexadecimal is a legitimate way to fill one. Here there is
+   * no such ambiguity: the argument is text, and its UTF-8 bytes are the value.
+   * @param {string} text the text to encode
+   * @returns {CairoByteArray} the UTF-8 bytes of the text, cut into 31-byte words
+   * @example
+   * ```typescript
+   * const result = CairoByteArray.fromText('12345').toHexString();
+   * // result = "0x3132333435"     (the text, where the constructor would read the number 0x3039)
+   * const result2 = CairoByteArray.fromText('0x4142').toHexString();
+   * // result2 = "0x307834313432"  (six characters, where the constructor would read the bytes "AB")
+   * ```
+   */
+  static fromText(text: string): CairoByteArray {
+    return new CairoByteArray(utf8ToUint8Array(text));
+  }
+
+  /**
+   * Serialize to the felt sequence a contract call carries : the number of complete words, each of
+   * them, then the pending word and its length.
+   * @returns {string[]} the decimal-string felts, flagged as compiled
+   * @example
+   * ```typescript
+   * const result = CairoByteArray.fromText('Hello').toApiRequest();
+   * // result = ["0", "310939249775", "5"]
+   * ```
+   */
   toApiRequest() {
     this.assertInitialized();
 
@@ -136,6 +316,21 @@ export class CairoByteArray {
     ]);
   }
 
+  /**
+   * Read the bytes back as UTF-8 text.
+   *
+   * The words are concatenated before decoding, so a multi-byte character split across two of them
+   * survives. Bytes that are not valid UTF-8 come back as replacement characters rather than as an
+   * error, so succeeding here does not prove the ByteArray was carrying text.
+   * @returns {string} the bytes decoded as UTF-8
+   * @example
+   * ```typescript
+   * const result = CairoByteArray.fromText('héllo').decodeUtf8();
+   * // result = "héllo"    (5 characters, 6 bytes)
+   * const result2 = new CairoByteArray('12345').decodeUtf8();
+   * // result2 = "09"      (the number 12345 is the two bytes 0x30 0x39)
+   * ```
+   */
   decodeUtf8() {
     // Convert all bytes to Uint8Array and decode as UTF-8 string
     // This ensures multi-byte UTF-8 characters are not split across chunk boundaries
@@ -143,6 +338,20 @@ export class CairoByteArray {
     return new TextDecoder().decode(allBytes);
   }
 
+  /**
+   * The whole byte sequence read as one big-endian number.
+   *
+   * A number has no room for a leading zero byte, so that byte is lost here. Use
+   * {@link CairoByteArray.toHexString} when the byte count matters.
+   * @returns {bigint} the bytes as a number, 0n when there are none
+   * @example
+   * ```typescript
+   * const result = CairoByteArray.fromText('Hello').toBigInt();
+   * // result = 310939249775n
+   * const result2 = new CairoByteArray('0x0041').toBigInt();
+   * // result2 = 65n     (two bytes in, one byte out - toHexString keeps both)
+   * ```
+   */
   toBigInt() {
     // Reconstruct the full byte sequence
     const allBytes = concatenateArrayBuffer(this.toElements());
@@ -160,6 +369,19 @@ export class CairoByteArray {
     return result;
   }
 
+  /**
+   * The whole byte sequence in hexadecimal, leading zero bytes included.
+   *
+   * This is the faithful view : two hex digits per byte, whatever their value. An empty ByteArray
+   * and one holding a single zero byte both read as a zero here, which is the one case this form
+   * does not separate.
+   * @returns {string} the bytes as a 0x-prefixed hex string, "0x0" when there are none
+   * @example
+   * ```typescript
+   * const result = new CairoByteArray('0x0041').toHexString();
+   * // result = "0x0041"    (where toBigInt() gives 65n, having dropped the first byte)
+   * ```
+   */
   toHexString() {
     // TODO: revisit empty data handling, how to differentiate empty and zero input
     const allBytes = concatenateArrayBuffer(this.toElements());
@@ -167,6 +389,15 @@ export class CairoByteArray {
     return addHexPrefix(hexValue);
   }
 
+  /**
+   * The whole byte sequence as a Buffer, leading zero bytes included.
+   * @returns {Buffer} a copy of the bytes, empty when there are none
+   * @example
+   * ```typescript
+   * const result = CairoByteArray.fromText('Hello').toBuffer().toString('hex');
+   * // result = "48656c6c6f"
+   * ```
+   */
   toBuffer() {
     const allBytes = concatenateArrayBuffer(this.toElements());
     return Buffer.from(allBytes);
@@ -199,8 +430,18 @@ export class CairoByteArray {
   }
 
   /**
-   * returns an array of all the data chunks and the pending word
-   * when concatenated, represents the original bytes sequence
+   * The words as raw byte buffers : every complete word, then the pending one.
+   *
+   * Concatenating them gives the original byte sequence back. A complete word is always 31 bytes,
+   * while the last buffer holds exactly `pending_word_len` bytes — zero-padded on the left when the
+   * pending word is shorter than its declared length. A pending length of 0 yields no last buffer.
+   * @returns {Uint8Array[]} one buffer per word, in order
+   * @example
+   * ```typescript
+   * const text = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567';
+   * const result = CairoByteArray.fromText(text).toElements().map((word) => word.length);
+   * // result = [31, 2]
+   * ```
    */
   toElements(): Uint8Array[] {
     this.assertInitialized();
@@ -221,7 +462,19 @@ export class CairoByteArray {
   }
 
   /**
-   * Private helper to check if the CairoByteArray is properly initialized
+   * Throw unless the three components are present.
+   *
+   * They are declared with a definite assignment assertion, so TypeScript does not catch an
+   * instance whose components were never filled, or one overwritten after construction. Every
+   * method that reads them calls this first.
+   * @throws {Error} when any of the three components is missing
+   * @example
+   * ```typescript
+   * const byteArray = new CairoByteArray('test');
+   * (byteArray as any).data = undefined;
+   * byteArray.toApiRequest();
+   * // throws Error("CairoByteArray is not properly initialized")
+   * ```
    */
   private assertInitialized(): void {
     assert(
@@ -230,15 +483,35 @@ export class CairoByteArray {
     );
   }
 
-  static validate(data: Uint8Array | Buffer | BigNumberish | unknown) {
+  /**
+   * Throw unless the value is of a kind this class can carry.
+   *
+   * Called by the constructor, and called directly by the calldata validator before a contract
+   * call — so a value refused here never reaches serialization. It weighs the kind of the value,
+   * not its contents : a ByteArray object holding unusable components passes here and fails later,
+   * when those components are adopted.
+   * @param {Uint8Array | Buffer | BigNumberish | ByteArray} data the value to check
+   * @throws {Error} when the value is of a kind this class does not carry
+   * @example
+   * ```typescript
+   * CairoByteArray.validate('12345'); //           passes, and will be read as the number 12345
+   * CairoByteArray.validate(new Uint8Array(2)); // passes
+   * CairoByteArray.validate(-1);
+   * // throws Error("Invalid input for CairoByteArray: negative numbers are not supported")
+   * ```
+   */
+  static validate(data: Uint8Array | Buffer | BigNumberish | ByteArray | unknown) {
     assert(data !== null && data !== undefined, 'Invalid input: null or undefined');
     assert(
       !Array.isArray(data) || data instanceof Uint8Array,
       'Invalid input: arrays are not supported, use Uint8Array'
     );
     assert(
-      typeof data !== 'object' || isBuffer(data) || data instanceof Uint8Array,
-      'Invalid input for CairoByteArray: objects are not supported'
+      typeof data !== 'object' ||
+        isBuffer(data) ||
+        data instanceof Uint8Array ||
+        isByteArrayShape(data),
+      'Invalid input for CairoByteArray: the only objects supported are Uint8Array, Buffer, and { data, pending_word, pending_word_len }'
     );
     assert(
       !isNumber(data) || Number.isInteger(data),
@@ -259,16 +532,26 @@ export class CairoByteArray {
         isBuffer(data) ||
         isString(data) ||
         isNumber(data) ||
-        isBigInt(data),
-      'Invalid input type. Expected Uint8Array, Buffer, string, number, or bigint'
+        isBigInt(data) ||
+        isByteArrayShape(data),
+      'Invalid input type. Expected Uint8Array, Buffer, ByteArray, string, number, or bigint'
     );
   }
 
   /**
-   * Check if the provided data is a valid CairoByteArray
+   * Can this value be carried by a CairoByteArray?
    *
-   * @param data - The data to check
-   * @returns True if the data is a valid CairoByteArray, false otherwise
+   * The non-throwing form of {@link CairoByteArray.validate}, with the same reach : it answers on
+   * the kind of the value, not on the usability of its contents.
+   * @param {any} data the value to test
+   * @returns {boolean} true when the value is of a kind this class can carry
+   * @example
+   * ```typescript
+   * const result = CairoByteArray.is('12345');
+   * // result = true
+   * const result2 = CairoByteArray.is({ data: 'ABC' });
+   * // result2 = false    (an object, and not the three components of a ByteArray)
+   * ```
    */
   static is(data: any): boolean {
     try {
@@ -280,12 +563,34 @@ export class CairoByteArray {
   }
 
   /**
-   * Check if provided abi type is this data type
+   * Is this abi type the one this class serializes?
+   * @param {string} abiType the abi type to test
+   * @returns {boolean} true for `core::byte_array::ByteArray`
+   * @example
+   * ```typescript
+   * const result = CairoByteArray.isAbiType('core::byte_array::ByteArray');
+   * // result = true
+   * ```
    */
   static isAbiType(abiType: string): boolean {
     return abiType === CairoByteArray.abiSelector;
   }
 
+  /**
+   * Read one ByteArray off a contract response, advancing the iterator past it.
+   *
+   * The felts are consumed in the order a contract emits them : how many complete words follow,
+   * those words, then the pending word and its length. The iterator is left on the next value, so
+   * successive calls read successive return values.
+   * @param {Iterator<string>} responseIterator the response felts, positioned on this ByteArray
+   * @returns {CairoByteArray} the ByteArray that was read
+   * @example
+   * ```typescript
+   * const response = ['0', '310939249775', '5'];
+   * const result = CairoByteArray.factoryFromApiResponse(response.values()).decodeUtf8();
+   * // result = "Hello"
+   * ```
+   */
   static factoryFromApiResponse(responseIterator: Iterator<string>): CairoByteArray {
     const data = Array.from({ length: Number(getNext(responseIterator)) }, () =>
       CairoBytes31.factoryFromApiResponse(responseIterator)

--- a/src/utils/cairoDataTypes/bytes31.ts
+++ b/src/utils/cairoDataTypes/bytes31.ts
@@ -9,15 +9,94 @@ import {
 import { getNext } from '../num';
 import assert from '../assert';
 import { addCompiledFlag } from '../helpers';
-import { isBuffer, isString } from '../typed';
+import { isBuffer, isObject, isString } from '../typed';
 
+/**
+ * Does this value spell out the single component of a Cairo `bytes31`?
+ *
+ * An already built {@link CairoBytes31} answers yes: it is a lone `data` field holding the 31
+ * bytes, and that shape is what identifies it. A `CairoByteArray` does not — its own `data` is an
+ * array of words, not a byte buffer.
+ * @param {unknown} value the value to test
+ * @returns {boolean} true when the value owns a `data` field holding a Uint8Array
+ * @example
+ * ```typescript
+ * const result = isBytes31Shape(new CairoBytes31('0x31'));
+ * // result = true
+ * const result2 = isBytes31Shape({ data: '0x31' });
+ * // result2 = false
+ * ```
+ */
+function isBytes31Shape(value: unknown): value is { data: Uint8Array } {
+  return (
+    isObject(value) && 'data' in value && (value as { data: unknown }).data instanceof Uint8Array
+  );
+}
+
+/**
+ * A Cairo `core::bytes_31::bytes31` : up to 31 bytes, carried in a single felt252.
+ *
+ * The bytes are held right-aligned in a fixed 31-byte buffer, so the length of the input is not
+ * recoverable from the value — `'0x41'` and `'0x0041'` give the same bytes31. Reach for
+ * `CairoByteArray` when the byte count has to survive.
+ * @example
+ * ```typescript
+ * // the same five characters, read two ways
+ * new CairoBytes31('12345').toHexString(); //      "0x3039"        the number 12345
+ * CairoBytes31.fromText('12345').toHexString(); // "0x3132333435"  the text '12345'
+ * ```
+ */
 export class CairoBytes31 {
+  /**
+   * How many bytes a bytes31 holds, which is also the width of a `ByteArray` word.
+   * @example
+   * ```typescript
+   * const result = CairoBytes31.MAX_BYTE_SIZE;
+   * // result = 31
+   * ```
+   */
   static MAX_BYTE_SIZE = 31 as const;
 
+  /**
+   * The bytes, always exactly 31 of them.
+   *
+   * A shorter input is right-aligned and the leading bytes left at zero, so this buffer does not
+   * record how long that input was.
+   * @example
+   * ```typescript
+   * const result = new CairoBytes31('0x41').data.length;
+   * // result = 31    (the byte 0x41 sits last, at index 30)
+   * ```
+   */
   data: Uint8Array;
 
+  /**
+   * The abi type this class serializes.
+   * @example
+   * ```typescript
+   * const result = CairoBytes31.abiSelector;
+   * // result = "core::bytes_31::bytes31"
+   * ```
+   */
   static abiSelector = 'core::bytes_31::bytes31' as const;
 
+  /**
+   * Build from a single value, right-aligned in 31 bytes.
+   *
+   * A string is read the way calldata reads it : `'0x41'` as the byte 0x41, `'12345'` as the number
+   * 12345, anything else as UTF-8 text. A string that spells a number therefore becomes that
+   * number, with no error raised — use {@link CairoBytes31.fromText} when the argument is text.
+   *
+   * A value that is already a CairoBytes31 is adopted as it stands, its bytes copied rather than
+   * read a second time.
+   * @param {string | Uint8Array | Buffer | CairoBytes31} data the value to carry, 31 bytes at most
+   * @throws {Error} when the value needs more than 31 bytes
+   * @example
+   * ```typescript
+   * const result = new CairoBytes31('Hello').toApiRequest();
+   * // result = ["310939249775"]
+   * ```
+   */
   constructor(data: string | Uint8Array | Buffer | unknown) {
     CairoBytes31.validate(data);
     const processedData = CairoBytes31.__processData(data);
@@ -25,6 +104,20 @@ export class CairoBytes31 {
     this.data.set(processedData, CairoBytes31.MAX_BYTE_SIZE - processedData.length);
   }
 
+  /**
+   * Turn any accepted input into its bytes, before they are right-aligned by the constructor.
+   *
+   * The returned length is the length of the input, not 31 : `validate` reads it to decide whether
+   * the value fits. An input that is already a CairoBytes31 comes back as a copy of its 31 bytes.
+   * @param {Uint8Array | string | Buffer | CairoBytes31} data the value to convert
+   * @returns {Uint8Array} the bytes, of whatever length the input implied
+   * @throws {Error} when the input is of a type this class does not read
+   * @example
+   * ```typescript
+   * const result = CairoBytes31.__processData('0x4142').length;
+   * // result = 2     (where CairoBytes31.__processData('Hello').length is 5)
+   * ```
+   */
   static __processData(data: Uint8Array | string | Buffer | unknown): Uint8Array {
     if (isString(data)) {
       return stringToUint8Array(data);
@@ -35,7 +128,14 @@ export class CairoBytes31 {
     if (data instanceof Uint8Array) {
       return new Uint8Array(data);
     }
-    throw new Error('Invalid input type for CairoBytes31. Expected string, Buffer, or Uint8Array');
+    // an already built bytes31, adopted as it is : its bytes have already been decided, so they
+    // are copied rather than read again through the string heuristic
+    if (isBytes31Shape(data)) {
+      return new Uint8Array(data.data);
+    }
+    throw new Error(
+      'Invalid input type for CairoBytes31. Expected string, Buffer, Uint8Array, or CairoBytes31'
+    );
   }
 
   /**
@@ -56,14 +156,50 @@ export class CairoBytes31 {
     return new CairoBytes31(utf8ToUint8Array(text));
   }
 
+  /**
+   * Serialize to the single felt a contract call carries.
+   * @returns {string[]} one decimal-string felt, flagged as compiled
+   * @example
+   * ```typescript
+   * const result = CairoBytes31.fromText('Hello').toApiRequest();
+   * // result = ["310939249775"]
+   * ```
+   */
   toApiRequest(): string[] {
     return addCompiledFlag([BigInt(this.toHexString()).toString()]);
   }
 
+  /**
+   * The 31 bytes read as one big-endian number.
+   *
+   * The padding zeros weigh nothing, so this is the same number whether the input was `'0x41'` or
+   * `'0x0041'`.
+   * @returns {bigint} the bytes as a number, 0n when they are all zero
+   * @example
+   * ```typescript
+   * const result = CairoBytes31.fromText('Hello').toBigInt();
+   * // result = 310939249775n
+   * ```
+   */
   toBigInt() {
     return uint8ArrayToBigInt(this.data);
   }
 
+  /**
+   * Read the bytes back as UTF-8 text, leading zero bytes dropped.
+   *
+   * Those zeros are the padding that fills the buffer, and nothing tells them apart from a zero
+   * byte the caller meant to carry — so a text opening on a NUL does not survive the round trip.
+   * Reach for `CairoByteArray` when it has to.
+   * @returns {string} the bytes decoded as UTF-8, without their leading zeros
+   * @example
+   * ```typescript
+   * const result = CairoBytes31.fromText('12345').decodeUtf8();
+   * // result = "12345"
+   * const result2 = new CairoBytes31('12345').decodeUtf8();
+   * // result2 = "09"    (the number 12345 is the two bytes 0x30 0x39)
+   * ```
+   */
   decodeUtf8() {
     // strip leading zeros for decode to avoid leading null characters
     const cutoff = this.data.findIndex((x) => x > 0);
@@ -72,13 +208,39 @@ export class CairoBytes31 {
   }
 
   /**
-   * @param padded flag for including leading zeros
+   * The bytes in hexadecimal.
+   *
+   * Bare, the leading zeros are dropped, which is the form a node returns for a felt. Padded, all
+   * 31 bytes are written out, which is the form a `ByteArray` data word takes.
+   * @param {'padded'} [padded] write the 31 bytes in full, leading zeros included
+   * @returns {string} the bytes as a 0x-prefixed hex string
+   * @example
+   * ```typescript
+   * const result = new CairoBytes31('Hello').toHexString();
+   * // result = "0x48656c6c6f"
+   * const result2 = new CairoBytes31('Hello').toHexString('padded');
+   * // result2 = "0x000000000000000000000000000000000000000000000000000048656c6c6f"
+   * ```
    */
   toHexString(padded?: 'padded') {
     const hex = padded === 'padded' ? buf2hex(this.data) : this.toBigInt().toString(16);
     return addHexPrefix(hex);
   }
 
+  /**
+   * Throw unless the value fits in 31 bytes.
+   *
+   * Length is all it weighs. Deciding it means converting the value first, so an input of a type
+   * this class does not read raises from `__processData` instead, with that method's message.
+   * @param {Uint8Array | string | Buffer | CairoBytes31} data the value to check
+   * @throws {Error} when the value needs more than 31 bytes, or is of an unread type
+   * @example
+   * ```typescript
+   * CairoBytes31.validate('Hello'); // passes
+   * CairoBytes31.validate('x'.repeat(32));
+   * // throws Error("Data is too long: 32 bytes (max 31 bytes)")
+   * ```
+   */
   static validate(data: Uint8Array | string | Buffer | unknown): void {
     const byteLength = CairoBytes31.__processData(data).length;
     assert(
@@ -87,7 +249,22 @@ export class CairoBytes31 {
     );
   }
 
-  static is(data: Uint8Array | string | Buffer): boolean {
+  /**
+   * Can this value be carried by a CairoBytes31?
+   *
+   * The non-throwing form of {@link CairoBytes31.validate}, so a value of an unread type answers
+   * false here just as an over-long one does.
+   * @param {Uint8Array | string | Buffer | CairoBytes31} data the value to test
+   * @returns {boolean} true when the value fits in a bytes31
+   * @example
+   * ```typescript
+   * const result = CairoBytes31.is('Hello');
+   * // result = true
+   * const result2 = CairoBytes31.is('x'.repeat(32));
+   * // result2 = false
+   * ```
+   */
+  static is(data: Uint8Array | string | Buffer | unknown): boolean {
     try {
       CairoBytes31.validate(data);
       return true;
@@ -97,12 +274,32 @@ export class CairoBytes31 {
   }
 
   /**
-   * Check if provided abi type is this data type
+   * Is this abi type the one this class serializes?
+   * @param {string} abiType the abi type to test
+   * @returns {boolean} true for `core::bytes_31::bytes31`
+   * @example
+   * ```typescript
+   * const result = CairoBytes31.isAbiType('core::bytes_31::bytes31');
+   * // result = true
+   * ```
    */
   static isAbiType(abiType: string): boolean {
     return abiType === CairoBytes31.abiSelector;
   }
 
+  /**
+   * Read one bytes31 off a contract response, advancing the iterator past it.
+   *
+   * One felt is consumed, so successive calls read successive return values.
+   * @param {Iterator<string>} responseIterator the response felts, positioned on this bytes31
+   * @returns {CairoBytes31} the bytes31 that was read
+   * @example
+   * ```typescript
+   * const response = ['310939249775'];
+   * const result = CairoBytes31.factoryFromApiResponse(response.values()).decodeUtf8();
+   * // result = "Hello"
+   * ```
+   */
   static factoryFromApiResponse(responseIterator: Iterator<string>): CairoBytes31 {
     return new CairoBytes31(getNext(responseIterator));
   }

--- a/www/docs/guides/contracts/define_call_message.md
+++ b/www/docs/guides/contracts/define_call_message.md
@@ -164,6 +164,16 @@ You can send to Starknet.js methods: string.
 await myContract.my_function('http://addressOfMyERC721pictures/image1.jpg');
 ```
 
+If your text may spell a number, encode it explicitly:
+
+```typescript
+await myContract.my_function(CairoByteArray.fromText('12345'));
+```
+
+`fromText` is what tells the library the argument is text: the `CairoByteArray` constructor reads
+`'12345'` as a decimal number and `'0x4142'` as the two bytes `0x41 0x42`, so a string that spells
+a number would not be encoded as text.
+
 To force to send a shortString as a ByteArray with `CallData.compile()`:
 
 ```typescript

--- a/www/docs/guides/migrate.md
+++ b/www/docs/guides/migrate.md
@@ -120,6 +120,14 @@ CairoBytes31.fromText('12345').toHexString(); // 0x3132333435 — the text
 new CairoBytes31('12345').toHexString(); //     0x3039       — the number 12345
 ```
 
+**Passing the result to a contract.** For a `bytes31` parameter, hand over the object itself: v11
+accepts it. For a `felt252` parameter, convert it first, because a felt252 reads a number.
+
+```typescript
+await contract.set_word(CairoBytes31.fromText('12345')); //             a bytes31 parameter
+await contract.set_id(CairoBytes31.fromText('12345').toHexString()); // a felt252 parameter
+```
+
 **What you gain.** The removed encoder was ASCII-only, and for any byte below `0x10` it emitted a
 single hex digit instead of two, which misaligned every following byte:
 
@@ -418,6 +426,25 @@ See [When a subscription closes](./websocket_channel.md#when-a-subscription-clos
 `src/channel/` is reorganized into per-version directories, and the `RPC09`, `RPC0102` and `RPC0103`
 namespaces now export a `SubscriptionChannel` alongside their `RpcChannel`. Pairing the two of the
 same version is what makes a version mismatch between requests and subscriptions impossible.
+
+### Text for a `ByteArray` parameter
+
+A `ByteArray` is a sequence of bytes, so its constructor reads a string the way calldata does:
+`'12345'` is the number 12345, `'0x4142'` is the two bytes `0x41 0x42`, which spell `AB`. A text
+that spells a number had no way through. `CairoByteArray.fromText()` is that way, and mirrors
+`CairoBytes31.fromText()`.
+
+```typescript
+CairoByteArray.fromText('12345').toHexString(); // 0x3132333435 — the text
+new CairoByteArray('12345').toHexString(); //     0x3039       — the number 12345
+```
+
+Hand the result to the contract as it is — v11 accepts an already built `CairoByteArray`, and also
+the object returned by `byteArray.byteArrayFromString()`, which a contract call used to refuse.
+
+```typescript
+await contract.set_label(CairoByteArray.fromText('12345'));
+```
 
 ## Need Help?
 


### PR DESCRIPTION
## Motivation and Resolution

A JS string passed for a `core::byte_array::ByteArray` parameter was reinterpreted whenever it
looked like a number. Measured on `beta`, against a contract whose parameter is a ByteArray:

| Call | Calldata sent | What the contract reads |
| --- | --- | --- |
| `contract.fn('12345')` | `['0', '12345', '2']` | `"09"` |
| `contract.fn('0x4142')` | `['0', '16706', '2']` | `"AB"` |
| `contract.fn('Take care.')` | correct | correct |
| `contract.fn('héllo')` | correct | correct (UTF-8) |

Nothing was raised: the ByteArray produced is structurally valid, only its content is wrong.

The text case had no way through at all. Pre-encoding to a `Uint8Array` worked, but was documented
nowhere, and the two natural attempts — `new CairoByteArray('12345')`, and the plain
`{ data, pending_word, pending_word_len }` object — both failed on *"objects are not supported"*, a
message that suggests no way out.

`CairoByteArray.fromText()` is that way through, mirroring the `CairoBytes31.fromText()` added in
11.0.0-beta.2. On its own it would not have been enough: no Cairo type instance survived the ABI
path, `CairoBytes31.fromText()` included, and the rejection happened twice, since `validate` runs
before compilation on a contract call. Both classes now accept a value that is already built, so
what `fromText()` returns goes straight into `contract.fn(...)`, at any ABI depth.

For ByteArray the recognition is **by shape**, following the `CairoUint256`/`Uint256` precedent
rather than an `instanceof` convention that exists nowhere in the codebase. That also settles the
status of `byteArrayFromString()`: its object is now accepted with an ABI, as it already was
without one.

**The heuristic is untouched.** `encode.stringToUint8Array()` is unchanged, and a hex string still
denotes those bytes — a legitimate way to fill a byte sequence, including one that opens on a zero
byte. Only the error messages change, to name what is accepted.

### RPC version (if applicable)

Not applicable.

## Usage related changes

- `CairoByteArray.fromText(text)` encodes text as text, whatever it looks like, mirroring
  `CairoBytes31.fromText()`.
- `CairoByteArray` accepts a value that is already a ByteArray: an instance, or a plain
  `{ data, pending_word, pending_word_len }` object. So `byteArray.byteArrayFromString()` output is
  now valid input for a contract call, which it was not.
- `CairoBytes31` accepts an already built `CairoBytes31`, so `CairoBytes31.fromText(text)` can be
  passed to a `bytes31` parameter directly, without `.toHexString()`. A `felt252` parameter still
  needs the conversion.
- Both work at any ABI depth: array item, struct member, enum variant.
- `CairoBytes31.is()` accepts `unknown`, aligning it with `CairoBytes31.validate()`. Widening only.
- Error messages now name what is accepted. Three of them changed wording; no behaviour did.
- No breaking change: every input accepted before is accepted, and encodes identically.

## Development related changes

- Full JSDoc for `CairoByteArray` and `CairoBytes31`, every member, 52 examples — each one executed
  and checked against an independent oracle. The traps are documented: a string that spells a
  number, `'0x0041'` being two bytes where `'0x41'` is one, `toBigInt()` losing a leading zero byte
  where `toHexString()` keeps it, `CairoBytes31.decodeUtf8()` stripping leading zeros, and the
  31-**byte** cut that can split a multi-byte character.
- 28 tests added. Expected values are computed from `Buffer.from(s, 'utf8').toString('hex')`, never
  copied from current output. The ABI-path tests use the compiled `cairo240/string` contract for
  the root cases; only the nesting cases, which no compiled contract of the repository exposes, are
  declared on top of that real ABI. `__tests__/factories/abi.ts` is untouched.
- Guides: the missing `CairoBytes31` half of the v11 migration guide, a new ByteArray section in
  its part 3, and the `fromText` warning in the `define_call_message` ByteArray section, which only
  advised sending a string.

## Checklist:

- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Documented the changes in code (API docs will be generated automatically)
- [x] Updated the tests
- [x] All tests are passing
