### PR TITLE
Fix/callData.compile strings

### DIFF
--- a/__tests__/utils/cairoDataTypes/CairoUint32.test.ts
+++ b/__tests__/utils/cairoDataTypes/CairoUint32.test.ts
@@ -281,7 +281,8 @@ describe('CairoUint32 class Unit Tests', () => {
 
   describe('isAbiType static method', () => {
     test('should identify correct ABI type', () => {
-      expect(CairoUint32.isAbiType('core::u32::u32')).toBe(true);
+      expect(CairoUint32.isAbiType('core::integer::u32')).toBe(true);
+      expect(CairoUint32.isAbiType('core::u32::u32')).toBe(false); // no abi spells it this way
       expect(CairoUint32.isAbiType('u32')).toBe(false);
       expect(CairoUint32.isAbiType('core::u64::u64')).toBe(false);
       expect(CairoUint32.isAbiType('core::felt252')).toBe(false);
@@ -474,10 +475,11 @@ describe('CairoUint32 class Unit Tests', () => {
 
     describe('isAbiType method', () => {
       test('should return true for correct ABI selector', () => {
-        expect(CairoUint32.isAbiType('core::u32::u32')).toBe(true);
+        expect(CairoUint32.isAbiType('core::integer::u32')).toBe(true);
       });
 
       test('should return false for incorrect ABI selector', () => {
+        expect(CairoUint32.isAbiType('core::u32::u32')).toBe(false);
         expect(CairoUint32.isAbiType('core::u64::u64')).toBe(false);
         expect(CairoUint32.isAbiType('core::felt252')).toBe(false);
         expect(CairoUint32.isAbiType('')).toBe(false);

--- a/__tests__/utils/calldata/compile.test.ts
+++ b/__tests__/utils/calldata/compile.test.ts
@@ -1,0 +1,201 @@
+import {
+  CairoByteArray,
+  CairoBytes31,
+  CairoCustomEnum,
+  CairoFelt252,
+  CairoFixedArray,
+  CairoInt128,
+  CairoOption,
+  CairoOptionVariant,
+  CairoResult,
+  CairoResultVariant,
+  CairoUint64,
+  CairoUint256,
+  CairoUint512,
+  CallData,
+} from '../../../src';
+import { PRIME } from '../../../src/global/constants';
+import { byteArrayFromString } from '../../../src/utils/calldata/byteArray';
+
+/**
+ * `CallData.compile` without an abi, which walks its argument rather than reading a declared type.
+ *
+ * The classes of `src/utils/cairoDataTypes` are taken as working here — what each one serializes to
+ * is pinned by its own tests. What is asserted below is that this path *reaches* them, and that the
+ * structure it builds around them — variant indexes, array lengths, order — is right.
+ */
+describe('CallData.compile (no abi)', () => {
+  describe('a Cairo type instance is serialized by its own class, not enumerated', () => {
+    test('CairoByteArray keeps its pending word whole', () => {
+      // used to spell the pending word out one felt per byte:
+      // ["0","49","50","51","52","53","5"] where ["0","211295614005","5"] is expected
+      const byteArray = CairoByteArray.fromText('12345');
+      expect(CallData.compile({ v: byteArray })).toEqual(byteArray.toApiRequest());
+    });
+
+    test('CairoByteArray longer than one word', () => {
+      // 33 bytes: one complete word, then 2 bytes pending
+      const byteArray = CairoByteArray.fromText('ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567');
+      expect(CallData.compile({ v: byteArray })).toEqual(byteArray.toApiRequest());
+      expect(CallData.compile({ v: byteArray })).toHaveLength(4);
+    });
+
+    test('CairoBytes31 is one felt, not its 31-byte buffer', () => {
+      // used to enumerate the buffer, padding zeros included: 31 felts for ["211295614005"]
+      const bytes31 = CairoBytes31.fromText('12345');
+      expect(CallData.compile({ v: bytes31 })).toEqual(bytes31.toApiRequest());
+      expect(CallData.compile({ v: bytes31 })).toHaveLength(1);
+    });
+
+    test('CairoFelt252 is one felt, not its byte buffer', () => {
+      const felt = new CairoFelt252('Hello');
+      expect(CallData.compile({ v: felt })).toEqual(felt.toApiRequest());
+      expect(CallData.compile({ v: felt })).toHaveLength(1);
+    });
+
+    test('a negative signed integer becomes its field element', () => {
+      // used to throw: the raw -5n reached felt252, which has no negative values
+      expect(CallData.compile({ v: new CairoInt128(-5) })).toEqual([(PRIME - 5n).toString()]);
+    });
+
+    test('a fixed array carries no length, and not its type string either', () => {
+      // used to emit 5 felts: a length in front, and "[core::integer::u32; 3]" as a felt at the end
+      const fixedArray = new CairoFixedArray([10, 20, 30], '[core::integer::u32; 3]');
+      expect(CallData.compile({ v: fixedArray })).toEqual(['10', '20', '30']);
+      // the instance says what the object of its own compile() says
+      expect(CallData.compile({ v: fixedArray })).toEqual(
+        CallData.compile({ v: fixedArray.compile() })
+      );
+    });
+  });
+
+  describe('nesting, in both directions', () => {
+    test('a fixed array of ByteArrays', () => {
+      const first = CairoByteArray.fromText('12345');
+      const second = CairoByteArray.fromText('ab');
+      expect(
+        CallData.compile({
+          v: new CairoFixedArray([first, second], '[core::byte_array::ByteArray; 2]'),
+        })
+      ).toEqual([...first.toApiRequest(), ...second.toApiRequest()]);
+    });
+
+    test('a fixed array of Options, whose two variants differ in length', () => {
+      expect(
+        CallData.compile({
+          v: new CairoFixedArray(
+            [
+              new CairoOption(CairoOptionVariant.Some, 12),
+              new CairoOption(CairoOptionVariant.None),
+            ],
+            '[core::option::Option::<core::integer::u32>; 2]'
+          ),
+        })
+      ).toEqual(['0', '12', '1']);
+    });
+
+    test('an Option holding a fixed array', () => {
+      expect(
+        CallData.compile({
+          v: new CairoOption(
+            CairoOptionVariant.Some,
+            new CairoFixedArray([10, 20, 30], '[core::integer::u32; 3]')
+          ),
+        })
+      ).toEqual(['0', '10', '20', '30']);
+    });
+
+    test('a Result holding a ByteArray', () => {
+      const byteArray = CairoByteArray.fromText('ab');
+      expect(CallData.compile({ v: new CairoResult(CairoResultVariant.Ok, byteArray) })).toEqual([
+        '0',
+        ...byteArray.toApiRequest(),
+      ]);
+    });
+
+    test('a custom enum whose active variant holds a ByteArray', () => {
+      const byteArray = CairoByteArray.fromText('ab');
+      expect(CallData.compile({ v: new CairoCustomEnum({ A: undefined, B: byteArray }) })).toEqual([
+        '1',
+        ...byteArray.toApiRequest(),
+      ]);
+    });
+
+    test('a dynamic array of ByteArrays keeps its own length in front', () => {
+      const first = CairoByteArray.fromText('12345');
+      const second = CairoByteArray.fromText('ab');
+      expect(CallData.compile({ v: [first, second] })).toEqual([
+        '2',
+        ...first.toApiRequest(),
+        ...second.toApiRequest(),
+      ]);
+    });
+
+    test('a struct member, next to a plain one', () => {
+      const byteArray = CairoByteArray.fromText('ab');
+      expect(CallData.compile({ s: { text: byteArray, n: 7 } })).toEqual([
+        ...byteArray.toApiRequest(),
+        '7',
+      ]);
+    });
+
+    test('instances passed positionally', () => {
+      const byteArray = CairoByteArray.fromText('ab');
+      const bytes31 = CairoBytes31.fromText('12345');
+      expect(CallData.compile([byteArray, bytes31])).toEqual([
+        ...byteArray.toApiRequest(),
+        ...bytes31.toApiRequest(),
+      ]);
+    });
+  });
+
+  describe('what already worked keeps working', () => {
+    test('the plain object of byteArrayFromString', () => {
+      // a different implementation of the same thing, and the one several suites rely on
+      expect(CallData.compile({ mess: byteArrayFromString('Take care.') })).toEqual(
+        new CairoByteArray('Take care.').toApiRequest()
+      );
+    });
+
+    test('CairoUint256 gives its two felts, low first', () => {
+      const value = 2n ** 130n;
+      const uint256 = new CairoUint256(value);
+      expect(CallData.compile({ v: uint256 })).toEqual(uint256.toApiRequest());
+      // the instance says what the plain { low, high } object says, which is how this path used to
+      // reach the right answer, by duck-typing rather than by class
+      expect(CallData.compile({ v: uint256 })).toEqual(
+        CallData.compile({ v: { low: value % 2n ** 128n, high: value / 2n ** 128n } })
+      );
+    });
+
+    test('CairoUint512 gives its four limbs, lowest first', () => {
+      const uint512 = new CairoUint512(2n ** 300n);
+      expect(CallData.compile({ v: uint512 })).toEqual(uint512.toApiRequest());
+      expect(CallData.compile({ v: uint512 })).toHaveLength(4);
+    });
+
+    test('an unsigned integer instance is one felt', () => {
+      const uint64 = new CairoUint64(44);
+      expect(CallData.compile({ v: uint64 })).toEqual(uint64.toApiRequest());
+    });
+
+    test('a long text is still cut into a ByteArray', () => {
+      const text = 'Take care of this rather long string, please.';
+      expect(CallData.compile({ v: text })).toEqual(
+        CallData.compile({ v: byteArrayFromString(text) })
+      );
+    });
+  });
+
+  describe('an already compiled array stays a Cairo array', () => {
+    test('it gains a length, so the instance is what should be passed', () => {
+      // a documented limit rather than a bug to route around: a string[] value is read as a Cairo
+      // array here, whatever its __compiled__ flag says
+      const byteArray = CairoByteArray.fromText('12345');
+      expect(CallData.compile({ v: byteArray.toApiRequest() })).toEqual([
+        '3',
+        ...byteArray.toApiRequest(),
+      ]);
+    });
+  });
+});

--- a/__tests__/utils/calldata/parser/parsingStrategy.test.ts
+++ b/__tests__/utils/calldata/parser/parsingStrategy.test.ts
@@ -1,0 +1,112 @@
+import { Abi, CallData } from '../../../../src';
+import { PRIME } from '../../../../src/global/constants';
+import { fastParsingStrategy } from '../../../../src/utils/calldata/parser/parsingStrategy';
+
+const fn = (type: string) => ({
+  type: 'function',
+  name: 'fn',
+  inputs: [{ name: 'v', type }],
+  outputs: [{ type }],
+  state_mutability: 'view',
+});
+
+/** A real abi declares EthAddress as a struct, and the named form takes another branch without it. */
+const ETH_ADDRESS_STRUCT = {
+  type: 'struct',
+  name: 'core::starknet::eth_address::EthAddress',
+  members: [{ name: 'address', type: 'core::felt252' }],
+};
+
+/** A Cairo 1 abi, parsed by AbiParser1. */
+const abiV1 = (type: string): Abi => [ETH_ADDRESS_STRUCT, fn(type)] as Abi;
+
+/** The same, behind an interface, which is what sends it to AbiParser2. */
+const abiV2 = (type: string): Abi =>
+  [ETH_ADDRESS_STRUCT, { type: 'interface', name: 'test::ITest', items: [fn(type)] }] as Abi;
+
+/** Both parser versions carry the same default, so both are worth asserting. */
+const abiVersions: [string, (type: string) => Abi][] = [
+  ['AbiParser1', abiV1],
+  ['AbiParser2', abiV2],
+];
+
+describe('the default parsing strategy', () => {
+  describe.each(abiVersions)('%s', (_name, abiFor) => {
+    test('reads a negative signed integer back as a negative number', () => {
+      // on the wire a negative is a field element; only the declared type turns it back
+      const onTheWire = `0x${(PRIME - 5n).toString(16)}`;
+      expect(new CallData(abiFor('core::integer::i128')).parse('fn', [onTheWire])).toBe(-5n);
+      expect(new CallData(abiFor('core::integer::i8')).parse('fn', [onTheWire])).toBe(-5n);
+    });
+
+    test('refuses an out-of-range unsigned value instead of serializing it', () => {
+      // the argument array form runs no field validation, so the declared type is the only
+      // thing standing between an out-of-range value and the calldata
+      expect(() => new CallData(abiFor('core::integer::u8')).compile('fn', [256])).toThrow();
+      expect(() => new CallData(abiFor('core::integer::u64')).compile('fn', [2n ** 64n])).toThrow();
+    });
+
+    test('decodes an out-of-range response rather than refusing it', () => {
+      // deliberate, and the counterpart of the test above: the same value that is refused on the
+      // way out is returned on the way in. A node's answer is not the caller's mistake to catch,
+      // and decodeParameters is the tool for reading felts back as a chosen type
+      expect(new CallData(abiFor('core::integer::u8')).parse('fn', ['0x123456'])).toBe(1193046n);
+      expect(
+        new CallData(abiFor('core::integer::u64')).parse('fn', [`0x${(2n ** 64n).toString(16)}`])
+      ).toBe(2n ** 64n);
+    });
+
+    test('leaves ordinary values alone', () => {
+      expect(new CallData(abiFor('core::integer::u64')).compile('fn', [44])).toEqual(['44']);
+      expect(new CallData(abiFor('core::felt252')).parse('fn', ['0x2a'])).toBe(42n);
+      expect(new CallData(abiFor('core::integer::u128')).parse('fn', ['0x2a'])).toBe(42n);
+    });
+  });
+
+  describe('every unsigned type bounds a request, whatever the call form', () => {
+    /** each type with the smallest value that does not fit in it */
+    const bounds: [string, bigint][] = [
+      ['core::integer::u8', 2n ** 8n],
+      ['core::integer::u16', 2n ** 16n],
+      ['core::integer::u32', 2n ** 32n],
+      ['core::integer::u64', 2n ** 64n],
+      ['core::integer::u96', 2n ** 96n],
+      ['core::integer::u128', 2n ** 128n],
+      ['core::starknet::eth_address::EthAddress', 2n ** 160n],
+    ];
+
+    // u32 and EthAddress had no branch of their own and fell to felt252, which only bounds the
+    // field; u96 had one but no case in the named form's validator
+    test.each(bounds)('%s refuses the first value that does not fit', (type, tooBig) => {
+      const callData = new CallData(abiV2(type));
+      expect(() => callData.compile('fn', [tooBig])).toThrow();
+      expect(() => callData.compile('fn', { v: tooBig })).toThrow();
+    });
+
+    // the other half: a bound that refuses everything would pass the test above
+    test.each(bounds)('%s accepts the largest value that fits', (type, tooBig) => {
+      const callData = new CallData(abiV2(type));
+      const largest = [(tooBig - 1n).toString()];
+      expect(callData.compile('fn', [tooBig - 1n])).toEqual(largest);
+      expect(callData.compile('fn', { v: tooBig - 1n })).toEqual(largest);
+    });
+  });
+
+  describe('what opting into the fast strategy gives up', () => {
+    const fast = (type: string) => new CallData(abiV2(type), fastParsingStrategy);
+
+    test('a negative signed integer comes back as its raw field element', () => {
+      const onTheWire = `0x${(PRIME - 5n).toString(16)}`;
+      expect(fast('core::integer::i128').parse('fn', [onTheWire])).toBe(PRIME - 5n);
+    });
+
+    test('an out-of-range unsigned value reaches the calldata', () => {
+      expect(fast('core::integer::u8').compile('fn', [256])).toEqual(['256']);
+    });
+
+    test('but ordinary values say exactly what the default says', () => {
+      expect(fast('core::integer::u64').compile('fn', [44])).toEqual(['44']);
+      expect(fast('core::felt252').parse('fn', ['0x2a'])).toBe(42n);
+    });
+  });
+});

--- a/__tests__/utils/calldata/typedArguments.test.ts
+++ b/__tests__/utils/calldata/typedArguments.test.ts
@@ -1,0 +1,200 @@
+import {
+  Abi,
+  CairoByteArray,
+  CairoBytes31,
+  CairoFelt252,
+  CairoFixedArray,
+  CairoInt8,
+  CairoInt16,
+  CairoInt32,
+  CairoInt64,
+  CairoInt128,
+  CairoUint8,
+  CairoUint16,
+  CairoUint32,
+  CairoUint64,
+  CairoUint96,
+  CairoUint128,
+  CairoUint256,
+  CallData,
+} from '../../../src';
+
+const BYTE_ARRAY_STRUCT = {
+  type: 'struct',
+  name: 'core::byte_array::ByteArray',
+  members: [
+    { name: 'data', type: 'core::array::Array::<core::bytes_31::bytes31>' },
+    { name: 'pending_word', type: 'core::felt252' },
+    { name: 'pending_word_len', type: 'core::integer::u32' },
+  ],
+};
+
+const PAIR_STRUCT = {
+  type: 'struct',
+  name: 'test::Pair',
+  members: [
+    { name: 'a', type: 'core::integer::u64' },
+    { name: 'b', type: 'core::felt252' },
+  ],
+};
+
+/** An abi whose only function takes one parameter `v` of the given type. */
+const abiFor = (type: string): Abi =>
+  [
+    BYTE_ARRAY_STRUCT,
+    PAIR_STRUCT,
+    {
+      type: 'function',
+      name: 'fn',
+      inputs: [{ name: 'v', type }],
+      outputs: [],
+      state_mutability: 'external',
+    },
+  ] as Abi;
+
+/**
+ * Compile one argument both ways.
+ *
+ * The two forms are two pipelines, not one: an argument object goes through property ordering and
+ * field validation first, where an argument array goes straight to serialization. A fix that holds
+ * for one says nothing about the other.
+ */
+const bothForms = (type: string, value: any) => {
+  const callData = new CallData(abiFor(type));
+  return {
+    positional: () => callData.compile('fn', [value]),
+    named: () => callData.compile('fn', { v: value }),
+  };
+};
+
+const expectBothForms = (type: string, value: any, expected: string[]) => {
+  const { positional, named } = bothForms(type, value);
+  expect(positional()).toEqual(expected);
+  expect(named()).toEqual(expected);
+};
+
+const expectRefusedBothForms = (type: string, value: any) => {
+  const { positional, named } = bothForms(type, value);
+  expect(positional).toThrow();
+  expect(named).toThrow();
+};
+
+describe('an argument already typed by the caller', () => {
+  describe('an instance fills the slot its own type declares', () => {
+    test.each([
+      ['core::felt252', new CairoFelt252('Hello')],
+      ['core::integer::u8', new CairoUint8(5)],
+      ['core::integer::u16', new CairoUint16(500)],
+      ['core::integer::u32', new CairoUint32(70000)],
+      ['core::integer::u64', new CairoUint64(44)],
+      ['core::integer::u96', new CairoUint96(5)],
+      ['core::integer::u128', new CairoUint128(5)],
+      ['core::integer::i8', new CairoInt8(-5)],
+      ['core::integer::i16', new CairoInt16(-5)],
+      ['core::integer::i32', new CairoInt32(-5)],
+      ['core::integer::i64', new CairoInt64(-5)],
+      ['core::integer::i128', new CairoInt128(-5)],
+    ])('%s', (type, instance) => {
+      expectBothForms(type, instance, instance.toApiRequest());
+    });
+
+    test('bytes31, which is read as an instance rather than as a number', () => {
+      const bytes31 = new CairoBytes31('ab');
+      expectBothForms(CairoBytes31.abiSelector, bytes31, bytes31.toApiRequest());
+    });
+
+    test('a plain value is still accepted, and says the same thing', () => {
+      expectBothForms('core::integer::u64', 44, new CairoUint64(44).toApiRequest());
+    });
+  });
+
+  describe('only its own type: a one-felt instance is not a number to be re-typed', () => {
+    test('a wider type is refused, even holding a value that would fit', () => {
+      expectRefusedBothForms('core::integer::u64', new CairoUint128(44));
+    });
+
+    test('a narrower type is refused too', () => {
+      expectRefusedBothForms('core::integer::u128', new CairoUint8(5));
+    });
+
+    test('a bytes31 is refused where a felt252 is declared', () => {
+      expectRefusedBothForms('core::felt252', new CairoBytes31('ab'));
+    });
+  });
+
+  describe('at any depth', () => {
+    test('a struct member', () => {
+      expectBothForms('test::Pair', { a: new CairoUint64(44), b: 7 }, ['44', '7']);
+    });
+
+    test('an item of a dynamic array', () => {
+      expectBothForms(
+        'core::array::Array::<core::integer::u64>',
+        [new CairoUint64(44)],
+        ['1', '44']
+      );
+      expectBothForms(
+        'core::array::Array::<core::felt252>',
+        [new CairoFelt252('ab')],
+        ['1', ...new CairoFelt252('ab').toApiRequest()]
+      );
+    });
+
+    test('an item of an array of bytes31, typed or not', () => {
+      // the named form used to refuse the whole array, for any value: validateArray had no
+      // bytes31 branch and fell through to its "Validate Unhandled" default
+      const bytes31 = new CairoBytes31('ab');
+      expectBothForms(
+        'core::array::Array::<core::bytes_31::bytes31>',
+        [bytes31],
+        ['1', ...bytes31.toApiRequest()]
+      );
+      expectBothForms(
+        'core::array::Array::<core::bytes_31::bytes31>',
+        ['ab'],
+        ['1', ...bytes31.toApiRequest()]
+      );
+    });
+
+    test('the items of a fixed array', () => {
+      expectBothForms(
+        '[core::integer::u8; 3]',
+        [new CairoUint8(10), new CairoUint8(20), new CairoUint8(30)],
+        ['10', '20', '30']
+      );
+    });
+
+    test('a fixed array passed as its own instance', () => {
+      // its two fields used to be counted as the items, giving "2 items provided"
+      const fixedArray = new CairoFixedArray([10, 20, 30], '[core::integer::u32; 3]');
+      expectBothForms('[core::integer::u32; 3]', fixedArray, ['10', '20', '30']);
+    });
+
+    test('a fixed array instance whose size disagrees with the abi is refused', () => {
+      const fixedArray = new CairoFixedArray([10, 20], '[core::integer::u32; 2]');
+      expectRefusedBothForms('[core::integer::u32; 3]', fixedArray);
+    });
+  });
+
+  describe('the multi-felt types keep working as they did', () => {
+    test('u256 and its two felts', () => {
+      const uint256 = new CairoUint256(5);
+      expectBothForms(CairoUint256.abiSelector, uint256, uint256.toApiRequest());
+      expectBothForms(
+        'core::array::Array::<core::integer::u256>',
+        [uint256],
+        ['1', ...uint256.toApiRequest()]
+      );
+    });
+
+    test('ByteArray, flat and in an array', () => {
+      const byteArray = CairoByteArray.fromText('ab');
+      expectBothForms(CairoByteArray.abiSelector, byteArray, byteArray.toApiRequest());
+      expectBothForms(
+        'core::array::Array::<core::byte_array::ByteArray>',
+        [byteArray],
+        ['1', ...byteArray.toApiRequest()]
+      );
+    });
+  });
+});

--- a/src/global/constants.ts
+++ b/src/global/constants.ts
@@ -42,6 +42,10 @@ export const RANGE_I32 = range(-(2n ** 31n), 2n ** 31n - 1n);
 export const RANGE_I64 = range(-(2n ** 63n), 2n ** 63n - 1n);
 export const RANGE_I128 = range(-(2n ** 127n), 2n ** 127n - 1n);
 
+// An Ethereum address, carried in a felt but only 160 bits wide
+// https://github.com/starkware-libs/starknet-specs/blob/29bab650be6b1847c92d4461d4c33008b5e50b1a/api/starknet_api_openrpc.json#L1259
+export const RANGE_ETH_ADDRESS = range(ZERO, 2n ** 160n - 1n);
+
 export const LegacyUDC = {
   ADDRESS: '0x041a78e741e5af2fec34b695679bc6891742439f7afb8484ecd7766661ad02bf',
   ENTRYPOINT: 'deployContract',

--- a/src/utils/cairoDataTypes/scalar.ts
+++ b/src/utils/cairoDataTypes/scalar.ts
@@ -1,0 +1,72 @@
+import { CairoFelt252 } from './felt';
+import { CairoInt8 } from './int8';
+import { CairoInt16 } from './int16';
+import { CairoInt32 } from './int32';
+import { CairoInt64 } from './int64';
+import { CairoInt128 } from './int128';
+import { CairoUint8 } from './uint8';
+import { CairoUint16 } from './uint16';
+import { CairoUint32 } from './uint32';
+import { CairoUint64 } from './uint64';
+import { CairoUint96 } from './uint96';
+import { CairoUint128 } from './uint128';
+
+/** What this module needs of a Cairo type class: the abi type it answers to, and its value. */
+type SingleFeltCairoType = {
+  isAbiType(abiType: string): boolean;
+  new (...args: any[]): { toBigInt(): bigint };
+};
+
+/**
+ * The Cairo types that occupy one felt and are built from a number.
+ *
+ * Listed rather than recognized by shape: `toBigInt` alone would also catch `CairoUint256` and
+ * `CairoByteArray`, which carry a number too but do not fit in one felt — reducing those to it
+ * would silently drop felts from the calldata.
+ *
+ * `CairoBytes31` is one felt as well but is absent on purpose: it reads bytes, not numbers, so its
+ * own constructor is what adopts an instance — reducing one here would hand it a bigint it refuses.
+ */
+const SINGLE_FELT_TYPES: readonly SingleFeltCairoType[] = [
+  CairoFelt252,
+  CairoUint8,
+  CairoUint16,
+  CairoUint32,
+  CairoUint64,
+  CairoUint96,
+  CairoUint128,
+  CairoInt8,
+  CairoInt16,
+  CairoInt32,
+  CairoInt64,
+  CairoInt128,
+];
+
+/**
+ * The number a one-felt Cairo type carries, when it is the very type the abi declares.
+ *
+ * An abi slot normally receives a `BigNumberish`; this lets an already typed value stand there too,
+ * by reducing the instance to its number so that the declared type reads and range-checks it as it
+ * would any other input. The match is on the declared type alone: a `CairoUint128` facing a `u64`
+ * slot comes back untouched and is refused further down, whatever number it holds — a value that
+ * happens to fit is not a reason to let a wider type through.
+ *
+ * Every other value — a plain number, a string, a `CairoUint256`, a `CairoByteArray` — comes back
+ * unchanged, so this is a no-op wherever it does not apply.
+ * @param {unknown} value the value an abi slot received
+ * @param {string} abiType the type that slot declares
+ * @returns {unknown} the number the instance carries, or the value unchanged
+ * @example
+ * ```typescript
+ * const result = unwrapCairoScalar(new CairoUint64(44), 'core::integer::u64');
+ * // result = 44n
+ * const result2 = unwrapCairoScalar(new CairoInt128(-5), 'core::integer::i128');
+ * // result2 = -5n     (the field element is computed later, by the declared type)
+ * const result3 = unwrapCairoScalar(new CairoUint128(44), 'core::integer::u64');
+ * // result3 = CairoUint128 { data: 44n }     (not the declared type, so left for it to refuse)
+ * ```
+ */
+export function unwrapCairoScalar(value: unknown, abiType: string): unknown {
+  const declared = SINGLE_FELT_TYPES.find((cairoType) => cairoType.isAbiType(abiType));
+  return declared && value instanceof declared ? value.toBigInt() : value;
+}

--- a/src/utils/cairoDataTypes/uint32.ts
+++ b/src/utils/cairoDataTypes/uint32.ts
@@ -10,7 +10,7 @@ import { addCompiledFlag } from '../helpers';
 export class CairoUint32 {
   data: bigint;
 
-  static abiSelector = 'core::u32::u32';
+  static abiSelector = 'core::integer::u32';
 
   constructor(data: BigNumberish) {
     CairoUint32.validate(data);

--- a/src/utils/cairoDataTypes/uint32.ts
+++ b/src/utils/cairoDataTypes/uint32.ts
@@ -6,25 +6,26 @@ import { isText } from '../shortString';
 import { isString, isObject, isNumber } from '../typed';
 import assert from '../assert';
 import { addCompiledFlag } from '../helpers';
+import { RANGE_U32 } from '../../global/constants';
 
 export class CairoUint32 {
   data: bigint;
 
   static abiSelector = 'core::integer::u32';
 
-  constructor(data: BigNumberish) {
+  constructor(data: BigNumberish | boolean | unknown) {
     CairoUint32.validate(data);
     this.data = CairoUint32.__processData(data);
   }
 
-  static __processData(data: BigNumberish): bigint {
+  static __processData(data: BigNumberish | boolean | unknown): bigint {
     if (isString(data) && isText(data)) {
       // Only allow text strings that represent valid UTF-8 byte sequences for specific use cases
       // For general numeric input validation, reject pure text strings
       // This maintains compatibility while being more restrictive for validation
       return utf8ToBigInt(data);
     }
-    return BigInt(data);
+    return BigInt(data as BigNumberish);
   }
 
   toApiRequest(): string[] {
@@ -43,7 +44,7 @@ export class CairoUint32 {
     return addHexPrefix(this.toBigInt().toString(16));
   }
 
-  static validate(data: BigNumberish): void {
+  static validate(data: BigNumberish | boolean | unknown): void {
     assert(data !== null && data !== undefined, 'Invalid input: null or undefined');
     assert(!isObject(data) && !Array.isArray(data), 'Invalid input: objects are not supported');
     assert(
@@ -52,10 +53,10 @@ export class CairoUint32 {
     );
 
     const value = CairoUint32.__processData(data);
-    assert(value >= 0n && value <= 2n ** 32n - 1n, 'Value is out of u32 range [0, 2^32)');
+    assert(value >= RANGE_U32.min && value <= RANGE_U32.max, 'Value is out of u32 range [0, 2^32)');
   }
 
-  static is(data: BigNumberish): boolean {
+  static is(data: BigNumberish | boolean | unknown): boolean {
     try {
       CairoUint32.validate(data);
       return true;

--- a/src/utils/calldata/index.ts
+++ b/src/utils/calldata/index.ts
@@ -16,6 +16,7 @@ import {
 } from '../../types';
 import assert from '../assert';
 import { CairoFelt252 } from '../cairoDataTypes/felt';
+import { CairoFixedArray } from '../cairoDataTypes/fixedArray';
 import { toHex } from '../num';
 import { isBigInt } from '../typed';
 import { getSelectorFromName } from '../hash/selector';
@@ -169,8 +170,23 @@ export class CallData {
 
   /**
    * Compile contract callData without abi
+   *
+   * An instance of a Cairo type class — `CairoByteArray`, `CairoBytes31`, `CairoUint256`, … — is
+   * serialized by that class, so it yields the same felts here as it would through an abi. Any
+   * other object is walked field by field, which is what makes a plain `{ low, high }` and the
+   * object of `byteArrayFromString` work just as well.
+   *
+   * A `string[]` value is always read as a Cairo array and gains a length in front of it, an
+   * already compiled one included : pass the instance itself rather than its `toApiRequest()`.
    * @param rawArgs RawArgs representing cairo method arguments or string array of compiled data
    * @returns Calldata
+   * @example
+   * ```typescript
+   * const result = CallData.compile({ text: CairoByteArray.fromText('12345') });
+   * // result = ["0", "211295614005", "5"]
+   * const result2 = CallData.compile({ text: CairoByteArray.fromText('12345').toApiRequest() });
+   * // result2 = ["3", "0", "211295614005", "5"]   the three felts, behind an array length
+   * ```
    */
   static compile(rawArgs: RawArgs): Calldata {
     const createTree = (obj: object) => {
@@ -183,6 +199,25 @@ export class CallData {
           const kk = Array.isArray(oe) && k === '0' ? '$$len' : k;
           if (isBigInt(value)) return [[`${prefix}${kk}`, felt(value)]];
           if (Object(value) === value) {
+            // a Cairo type instance already knows its own wire format, and it is the one the abi
+            // path uses. Enumerating it instead would spell out its internals — the byte buffer of
+            // a felt252 or a bytes31 byte by byte, the three fields of a ByteArray.
+            // Tested on the value rather than on `keys` below, which only reaches one level of
+            // prototype: a subclass would otherwise fall back to being enumerated.
+            if (typeof (value as { toApiRequest?: unknown }).toApiRequest === 'function') {
+              // unpacked felt by felt: the array itself must never become a value in the tree,
+              // where it would be read as a Cairo array and gain a length in front of it
+              return (value as { toApiRequest: () => string[] })
+                .toApiRequest()
+                .map((serialized, index) => [`${prefix}${kk}.${index}`, serialized]);
+            }
+            // the one Cairo type class that cannot serialize itself: its items may be of any type,
+            // and turning those into felts without an abi is this function's job, not the class's.
+            // `compile()` gives the shape it documents for exactly this — items keyed by index, so
+            // no length is emitted before them, and each one is walked here like any other value.
+            if (value instanceof CairoFixedArray) {
+              return getEntries(value.compile(), `${prefix}${kk}.`);
+            }
             const methodsKeys = Object.getOwnPropertyNames(Object.getPrototypeOf(value));
             const keys = [...Object.getOwnPropertyNames(value), ...methodsKeys];
             if (keys.includes('isSome') && keys.includes('isNone')) {
@@ -220,8 +255,10 @@ export class CallData {
             // normal object
             return getEntries(value, `${prefix}${kk}.`);
           }
-          // no ABI here, so no declared type to arbitrate: the value is taken for whatever
-          // CairoFelt252 can make of it — number, hex or decimal string, boolean, or text
+          // a leaf carries no type of its own, and there is no abi to declare one — unlike the
+          // values above, which are arbitrated on the type their own class names. So the value is
+          // taken for whatever CairoFelt252 can make of it — number, hex or decimal string,
+          // boolean, or text. Not bigint: those are taken 40 lines above, before this branch
           return [[`${prefix}${kk}`, new CairoFelt252(value).toBigInt().toString()]];
         });
       };

--- a/src/utils/calldata/parser/parser-0-1.1.0.ts
+++ b/src/utils/calldata/parser/parser-0-1.1.0.ts
@@ -1,7 +1,7 @@
 import { Abi, AbiEntryType, FunctionAbi } from '../../../types';
 import { isLen } from '../cairo';
 import { AbiParserInterface } from './interface';
-import { fastParsingStrategy, ParsingStrategy } from './parsingStrategy';
+import { hdParsingStrategy, ParsingStrategy } from './parsingStrategy';
 
 export class AbiParser1 implements AbiParserInterface {
   abi: Abi;
@@ -10,7 +10,7 @@ export class AbiParser1 implements AbiParserInterface {
 
   constructor(abi: Abi, parsingStrategy?: ParsingStrategy) {
     this.abi = abi;
-    this.parsingStrategy = parsingStrategy || fastParsingStrategy;
+    this.parsingStrategy = parsingStrategy || hdParsingStrategy;
   }
 
   public getRequestParser(abiType: AbiEntryType): (val: unknown) => any {

--- a/src/utils/calldata/parser/parser-2.0.0.ts
+++ b/src/utils/calldata/parser/parser-2.0.0.ts
@@ -8,7 +8,7 @@ import {
   AbiEntryType,
 } from '../../../types';
 import { AbiParserInterface } from './interface';
-import { fastParsingStrategy, ParsingStrategy } from './parsingStrategy';
+import { hdParsingStrategy, ParsingStrategy } from './parsingStrategy';
 
 export class AbiParser2 implements AbiParserInterface {
   abi: Abi;
@@ -17,7 +17,7 @@ export class AbiParser2 implements AbiParserInterface {
 
   constructor(abi: Abi, parsingStrategy?: ParsingStrategy) {
     this.abi = abi;
-    this.parsingStrategy = parsingStrategy || fastParsingStrategy;
+    this.parsingStrategy = parsingStrategy || hdParsingStrategy;
   }
 
   public getRequestParser(abiType: AbiEntryType): (val: unknown) => any {

--- a/src/utils/calldata/parser/parsingStrategy.ts
+++ b/src/utils/calldata/parser/parsingStrategy.ts
@@ -1,11 +1,15 @@
 import { CairoBytes31 } from '../../cairoDataTypes/bytes31';
 import { CairoByteArray } from '../../cairoDataTypes/byteArray';
-import { AbiEntryType } from '../../../types';
+import { AbiEntryType, ETH_ADDRESS } from '../../../types';
+import { RANGE_ETH_ADDRESS } from '../../../global/constants';
+import assert from '../../assert';
+import { addCompiledFlag } from '../../helpers';
 import { CairoFelt252 } from '../../cairoDataTypes/felt';
 import { CairoUint256 } from '../../cairoDataTypes/uint256';
 import { CairoUint512 } from '../../cairoDataTypes/uint512';
 import { CairoUint8 } from '../../cairoDataTypes/uint8';
 import { CairoUint16 } from '../../cairoDataTypes/uint16';
+import { CairoUint32 } from '../../cairoDataTypes/uint32';
 import { CairoUint64 } from '../../cairoDataTypes/uint64';
 import { CairoUint96 } from '../../cairoDataTypes/uint96';
 import { CairoUint128 } from '../../cairoDataTypes/uint128';
@@ -28,7 +32,15 @@ export type ParsingStrategy = {
 // TODO: extend for complex types like structs, tuples, enums, arrays, etc.
 
 /**
- * More robust parsing strategy
+ * The default parsing strategy.
+ *
+ * A request is validated, a response is only decoded. What the caller passes in is the caller's
+ * mistake to catch, so an argument goes through the class of its declared type and is refused
+ * when it does not fit. What a node answers is not, so a response is read as it comes — the
+ * declared type is used there only where reading needs it: a negative i8..i128, which is a field
+ * element on the wire and only its own class turns back into a negative number, a u256 or u512
+ * spread over several felts, a bytes31 or a ByteArray carrying bytes.
+ *
  * Configuration mapping - data-driven approach
  * Configure parsing strategy for each abi type
  */
@@ -44,6 +56,17 @@ export const hdParsingStrategy = {
     [CairoFelt252.abiSelector]: (val: unknown) => {
       return new CairoFelt252(val).toApiRequest();
     },
+    // The one entry whose bound is spelled out here rather than delegated: an EthAddress is a felt
+    // on the wire, narrowed to the 160 bits an Ethereum address occupies, and has no class of its
+    // own to hold that range.
+    [ETH_ADDRESS]: (val: unknown) => {
+      const value = new CairoFelt252(val).toBigInt();
+      assert(
+        value >= RANGE_ETH_ADDRESS.min && value <= RANGE_ETH_ADDRESS.max,
+        `Value is out of EthAddress range [${RANGE_ETH_ADDRESS.min}, ${RANGE_ETH_ADDRESS.max}]`
+      );
+      return addCompiledFlag([value.toString()]);
+    },
     [CairoUint256.abiSelector]: (val: unknown) => {
       return new CairoUint256(val).toApiRequest();
     },
@@ -55,6 +78,9 @@ export const hdParsingStrategy = {
     },
     [CairoUint16.abiSelector]: (val: unknown) => {
       return new CairoUint16(val).toApiRequest();
+    },
+    [CairoUint32.abiSelector]: (val: unknown) => {
+      return new CairoUint32(val).toApiRequest();
     },
     [CairoUint64.abiSelector]: (val: unknown) => {
       return new CairoUint64(val).toApiRequest();
@@ -97,20 +123,28 @@ export const hdParsingStrategy = {
     [CairoUint512.abiSelector]: (responseIterator: Iterator<string>) => {
       return CairoUint512.factoryFromApiResponse(responseIterator).toBigInt();
     },
+    // These five read the felt as it comes, without their own class. What that class would add
+    // here is a range assert, and refusing a node's answer turns a remote anomaly into an
+    // exception the caller can do nothing about — where the same assert on a request catches the
+    // caller's own mistake before any calldata leaves. The signed ones below keep their class
+    // because it does not check there, it decodes: a field element back into a negative number.
     [CairoUint8.abiSelector]: (responseIterator: Iterator<string>) => {
-      return CairoUint8.factoryFromApiResponse(responseIterator).toBigInt();
+      return BigInt(getNext(responseIterator));
     },
     [CairoUint16.abiSelector]: (responseIterator: Iterator<string>) => {
-      return CairoUint16.factoryFromApiResponse(responseIterator).toBigInt();
+      return BigInt(getNext(responseIterator));
+    },
+    [CairoUint32.abiSelector]: (responseIterator: Iterator<string>) => {
+      return BigInt(getNext(responseIterator));
     },
     [CairoUint64.abiSelector]: (responseIterator: Iterator<string>) => {
-      return CairoUint64.factoryFromApiResponse(responseIterator).toBigInt();
+      return BigInt(getNext(responseIterator));
     },
     [CairoUint96.abiSelector]: (responseIterator: Iterator<string>) => {
-      return CairoUint96.factoryFromApiResponse(responseIterator).toBigInt();
+      return BigInt(getNext(responseIterator));
     },
     [CairoUint128.abiSelector]: (responseIterator: Iterator<string>) => {
-      return CairoUint128.factoryFromApiResponse(responseIterator).toBigInt();
+      return BigInt(getNext(responseIterator));
     },
     [CairoInt8.abiSelector]: (responseIterator: Iterator<string>) => {
       return CairoInt8.factoryFromApiResponse(responseIterator).toBigInt();
@@ -131,7 +165,13 @@ export const hdParsingStrategy = {
 } as const;
 
 /**
- * Faster parsing strategy
+ * A faster strategy, opt-in through the second argument of `new CallData(abi, strategy)`.
+ *
+ * It buys that speed by not going through the class of the declared type, which costs two things
+ * the caller should weigh: an out-of-range u8/u16/u64/u96/u128 is serialized rather than refused,
+ * and a negative i8..i128 comes back from a call as its raw field element rather than as a
+ * negative number.
+ *
  * Configuration mapping - data-driven approach
  * Configure parsing strategy for each abi type
  */
@@ -146,19 +186,26 @@ export const fastParsingStrategy: ParsingStrategy = {
     [CairoFelt252.abiSelector]: (val: unknown) => {
       return new CairoFelt252(val).toApiRequest();
     },
+    // no 160-bit check here, for the same reason as the integers below
+    [ETH_ADDRESS]: (val: unknown) => {
+      return new CairoFelt252(val).toBigInt().toString();
+    },
     [CairoUint256.abiSelector]: (val: unknown) => {
       return new CairoUint256(val).toApiRequest();
     },
     [CairoUint512.abiSelector]: (val: unknown) => {
       return new CairoUint512(val).toApiRequest();
     },
-    // These five skip their own CairoUintNN class, which is what makes this strategy the fast one:
+    // These six skip their own CairoUintNN class, which is what makes this strategy the fast one:
     // no range check, just the conversion to a felt. CairoFelt252 accepts the same inputs as the
     // classes it stands in for, text included.
     [CairoUint8.abiSelector]: (val: unknown) => {
       return new CairoFelt252(val).toBigInt().toString();
     },
     [CairoUint16.abiSelector]: (val: unknown) => {
+      return new CairoFelt252(val).toBigInt().toString();
+    },
+    [CairoUint32.abiSelector]: (val: unknown) => {
       return new CairoFelt252(val).toBigInt().toString();
     },
     [CairoUint64.abiSelector]: (val: unknown) => {
@@ -206,6 +253,9 @@ export const fastParsingStrategy: ParsingStrategy = {
       return BigInt(getNext(responseIterator));
     },
     [CairoUint16.abiSelector]: (responseIterator: Iterator<string>) => {
+      return BigInt(getNext(responseIterator));
+    },
+    [CairoUint32.abiSelector]: (responseIterator: Iterator<string>) => {
       return BigInt(getNext(responseIterator));
     },
     [CairoUint64.abiSelector]: (responseIterator: Iterator<string>) => {

--- a/src/utils/calldata/propertyOrder.ts
+++ b/src/utils/calldata/propertyOrder.ts
@@ -137,6 +137,11 @@ export default function orderPropsByAbi(
   function orderFixedArray(input: Array<any> | Record<string, any>, abiParam: string): Array<any> {
     const typeInFixedArray = CairoFixedArray.getFixedArrayType(abiParam);
     const arraySize = CairoFixedArray.getFixedArraySize(abiParam);
+    // an instance holds its items in `content`; its two fields are not the items. Reading them
+    // here also hands a plain array to everything downstream
+    if (input instanceof CairoFixedArray) {
+      return orderFixedArray(input.content, abiParam);
+    }
     if (Array.isArray(input)) {
       if (arraySize !== input.length) {
         throw new Error(

--- a/src/utils/calldata/requestParser.ts
+++ b/src/utils/calldata/requestParser.ts
@@ -25,6 +25,7 @@ import { CairoInt16 } from '../cairoDataTypes/int16';
 import { CairoInt32 } from '../cairoDataTypes/int32';
 import { CairoInt64 } from '../cairoDataTypes/int64';
 import { CairoInt128 } from '../cairoDataTypes/int128';
+import { unwrapCairoScalar } from '../cairoDataTypes/scalar';
 import { addHexPrefix, buf2hex, removeHexPrefix, utf8ToUint8Array } from '../encode';
 import { toHex } from '../num';
 import { isText, splitLongString } from '../shortString';
@@ -117,13 +118,16 @@ function arrayInputErrorMessage(subject: string, type: string, value: unknown): 
  */
 function parseBaseTypes({
   type,
-  val,
+  val: rawVal,
   parser,
 }: {
   type: string;
   val: unknown;
   parser: AbiParserInterface;
 }): AllowArray<string> {
+  // an instance of the very type declared here stands for the number it carries, so a value the
+  // caller has already typed is read exactly like a bare one. Every base type passes through here
+  const val = unwrapCairoScalar(rawVal, type);
   switch (true) {
     case CairoUint256.isAbiType(type):
       return parser.getRequestParser(type)(val);
@@ -228,7 +232,11 @@ function parseCalldataValue({
       const array = new CairoFixedArray(element, type);
       values = array.content;
     } else if (typeof element === 'object') {
-      values = Object.values(element as object);
+      // an instance holds its items in `content`; enumerating it would yield its two fields
+      // instead. The size is still checked against the abi, whose type prevails over the
+      // instance's own
+      values =
+        element instanceof CairoFixedArray ? element.content : Object.values(element as object);
       assert(
         values.length === CairoFixedArray.getFixedArraySize(type),
         `ABI type ${type}: object provided do not includes  ${CairoFixedArray.getFixedArraySize(type)} items. ${values.length} items provided.`
@@ -424,10 +432,16 @@ function parseCalldataValue({
     return parseBaseTypes({ type: getArrayType(type), val: element, parser });
   }
 
-  if (typeof element === 'object') {
+  // reached at any depth: a one-felt instance of the declared type is a value, not a composite to
+  // be walked into, so it is reduced before this guard rather than refused by it
+  const scalar = unwrapCairoScalar(element, type);
+  // a bytes31 stays an instance rather than becoming a number, and is the only Cairo type to reach
+  // this guard as one — ByteArray, u256, u512 and fixed arrays all return above. Its own class
+  // reads it just below
+  if (typeof scalar === 'object' && !(scalar instanceof CairoBytes31)) {
     throw Error(`Parameter ${element} do not align with abi parameter ${type}`);
   }
-  return parseBaseTypes({ type, val: element, parser });
+  return parseBaseTypes({ type, val: scalar, parser });
 }
 
 /**

--- a/src/utils/calldata/requestParser.ts
+++ b/src/utils/calldata/requestParser.ts
@@ -17,6 +17,7 @@ import { CairoUint256 } from '../cairoDataTypes/uint256';
 import { CairoUint512 } from '../cairoDataTypes/uint512';
 import { CairoUint8 } from '../cairoDataTypes/uint8';
 import { CairoUint16 } from '../cairoDataTypes/uint16';
+import { CairoUint32 } from '../cairoDataTypes/uint32';
 import { CairoUint64 } from '../cairoDataTypes/uint64';
 import { CairoUint96 } from '../cairoDataTypes/uint96';
 import { CairoUint128 } from '../cairoDataTypes/uint128';
@@ -137,6 +138,8 @@ function parseBaseTypes({
       return parser.getRequestParser(type)(val);
     case CairoUint16.isAbiType(type):
       return parser.getRequestParser(type)(val);
+    case CairoUint32.isAbiType(type):
+      return parser.getRequestParser(type)(val);
     case CairoUint64.isAbiType(type):
       return parser.getRequestParser(type)(val);
     case CairoUint96.isAbiType(type):
@@ -154,6 +157,10 @@ function parseBaseTypes({
     case CairoInt128.isAbiType(type):
       return parser.getRequestParser(type)(val);
     case CairoBytes31.isAbiType(type):
+      return parser.getRequestParser(type)(val);
+    // reached from parseCalldataField and from the struct branch of parseCalldataValue. Without
+    // this it fell to the felt252 default, which only bounds the field, not the 160 bits
+    case isTypeEthAddress(type):
       return parser.getRequestParser(type)(val);
     case isTypeSecp256k1Point(type): {
       const pubKeyETH = removeHexPrefix(toHex(val as BigNumberish)).padStart(128, '0');

--- a/src/utils/calldata/responseParser.ts
+++ b/src/utils/calldata/responseParser.ts
@@ -17,6 +17,7 @@ import { CairoUint256 } from '../cairoDataTypes/uint256';
 import { CairoUint512 } from '../cairoDataTypes/uint512';
 import { CairoUint8 } from '../cairoDataTypes/uint8';
 import { CairoUint16 } from '../cairoDataTypes/uint16';
+import { CairoUint32 } from '../cairoDataTypes/uint32';
 import { CairoUint64 } from '../cairoDataTypes/uint64';
 import { CairoUint96 } from '../cairoDataTypes/uint96';
 import { CairoUint128 } from '../cairoDataTypes/uint128';
@@ -68,6 +69,8 @@ function parseBaseTypes(type: string, it: Iterator<string>, parser: AbiParserInt
     case CairoUint8.isAbiType(type):
       return parser.getResponseParser(type)(it);
     case CairoUint16.isAbiType(type):
+      return parser.getResponseParser(type)(it);
+    case CairoUint32.isAbiType(type):
       return parser.getResponseParser(type)(it);
     case CairoUint64.isAbiType(type):
       return parser.getResponseParser(type)(it);

--- a/src/utils/calldata/validate.ts
+++ b/src/utils/calldata/validate.ts
@@ -12,6 +12,7 @@ import { CairoByteArray } from '../cairoDataTypes/byteArray';
 import { CairoBytes31 } from '../cairoDataTypes/bytes31';
 import { CairoFixedArray } from '../cairoDataTypes/fixedArray';
 import { unwrapCairoScalar } from '../cairoDataTypes/scalar';
+import { RANGE_ETH_ADDRESS } from '../../global/constants';
 import { CairoInt8 } from '../cairoDataTypes/int8';
 import { CairoInt16 } from '../cairoDataTypes/int16';
 import { CairoInt32 } from '../cairoDataTypes/int32';
@@ -120,6 +121,13 @@ const validateUint = (parameter: any, input: AbiEntry) => {
       );
       break;
 
+    case Uint.u96:
+      assert(
+        param >= 0n && param <= 2n ** 96n - 1n,
+        `Validate: arg ${input.name} cairo typed ${input.type} should be in range [0, 2^96-1]`
+      );
+      break;
+
     case Uint.u128:
       assert(
         param >= 0n && param <= 2n ** 128n - 1n,
@@ -194,8 +202,7 @@ const validateStruct = (parameter: any, input: AbiEntry, structs: AbiStructs) =>
     assert(!isObject(parameter), `EthAddress type is waiting a BigNumberish. Got "${parameter}"`);
     const param = BigInt(parameter.toString(10));
     assert(
-      // from : https://github.com/starkware-libs/starknet-specs/blob/29bab650be6b1847c92d4461d4c33008b5e50b1a/api/starknet_api_openrpc.json#L1259
-      param >= 0n && param <= 2n ** 160n - 1n,
+      param >= RANGE_ETH_ADDRESS.min && param <= RANGE_ETH_ADDRESS.max,
       `Validate: arg ${input.name} cairo typed ${input.type} should be in range [0, 2^160-1]`
     );
     return;

--- a/src/utils/calldata/validate.ts
+++ b/src/utils/calldata/validate.ts
@@ -11,6 +11,7 @@ import assert from '../assert';
 import { CairoByteArray } from '../cairoDataTypes/byteArray';
 import { CairoBytes31 } from '../cairoDataTypes/bytes31';
 import { CairoFixedArray } from '../cairoDataTypes/fixedArray';
+import { unwrapCairoScalar } from '../cairoDataTypes/scalar';
 import { CairoInt8 } from '../cairoDataTypes/int8';
 import { CairoInt16 } from '../cairoDataTypes/int16';
 import { CairoInt32 } from '../cairoDataTypes/int32';
@@ -43,12 +44,15 @@ import {
 // TODO: Something like: store_message(a -> *INVALID JS TYPE*, b, c -> *MISSING REQUIRED ARG*)
 
 const validateFelt = (parameter: any, input: AbiEntry) => {
+  // an instance of the very type declared here stands for the number it carries, and is then
+  // checked exactly like a bare one
+  const value: any = unwrapCairoScalar(parameter, input.type);
   assert(
-    isString(parameter) || isNumber(parameter) || isBigInt(parameter),
+    isString(value) || isNumber(value) || isBigInt(value),
     `Validate: arg ${input.name} should be a felt typed as (String, Number or BigInt)`
   );
-  if (isString(parameter) && !isHex(parameter)) return; // shortstring
-  const param = BigInt(parameter.toString(10));
+  if (isString(value) && !isHex(value)) return; // shortstring
+  const param = BigInt(value.toString(10));
   assert(
     // from : https://github.com/starkware-libs/starknet-specs/blob/29bab650be6b1847c92d4461d4c33008b5e50b1a/api/starknet_api_openrpc.json#L1266
     param >= 0n && param <= 2n ** 252n - 1n,
@@ -57,33 +61,35 @@ const validateFelt = (parameter: any, input: AbiEntry) => {
 };
 
 const validateUint = (parameter: any, input: AbiEntry) => {
-  if (isNumber(parameter)) {
+  // an instance of the very type declared here stands for the number it carries, and is then
+  // checked exactly like a bare one — a wider type is left untouched, so it fails below
+  const value: any = unwrapCairoScalar(parameter, input.type);
+  if (isNumber(value)) {
     assert(
-      parameter <= Number.MAX_SAFE_INTEGER,
+      value <= Number.MAX_SAFE_INTEGER,
       'Validation: Parameter is too large to be typed as Number use (BigInt or String)'
     );
   }
   assert(
-    isString(parameter) ||
-      isNumber(parameter) ||
-      isBigInt(parameter) ||
-      (isObject(parameter) && 'low' in parameter && 'high' in parameter) ||
-      (isObject(parameter) &&
-        ['limb0', 'limb1', 'limb2', 'limb3'].every((key) => key in parameter)),
+    isString(value) ||
+      isNumber(value) ||
+      isBigInt(value) ||
+      (isObject(value) && 'low' in value && 'high' in value) ||
+      (isObject(value) && ['limb0', 'limb1', 'limb2', 'limb3'].every((key) => key in value)),
     `Validate: arg ${input.name} of cairo type ${
       input.type
-    } should be type (String, Number or BigInt), but is ${typeof parameter} ${parameter}.`
+    } should be type (String, Number or BigInt), but is ${typeof value} ${value}.`
   );
   let param: bigint;
   switch (input.type) {
     case Uint.u256:
-      param = new CairoUint256(parameter as BigNumberish).toBigInt();
+      param = new CairoUint256(value as BigNumberish).toBigInt();
       break;
     case Uint.u512:
-      param = new CairoUint512(parameter as BigNumberish).toBigInt();
+      param = new CairoUint512(value as BigNumberish).toBigInt();
       break;
     default:
-      param = toBigInt(parameter as BigNumberish);
+      param = toBigInt(value as BigNumberish);
   }
   switch (input.type) {
     case Uint.u8:
@@ -262,6 +268,10 @@ const validateArray = (
         // the type cast is just for the documentation generation, TS narrowing works as expected
         parameter = parameterArray as any;
         break;
+      // an instance holds its items in `content`; enumerating it would yield its two fields instead
+      case parameterArray instanceof CairoFixedArray:
+        parameter = parameterArray.content;
+        break;
       case typeof parameterArray === 'object':
         parameter = Object.values(parameterArray);
         break;
@@ -272,7 +282,15 @@ const validateArray = (
 
   switch (true) {
     case isTypeFelt(baseType):
-      parameter.forEach((param: BigNumberish) => validateFelt(param, input));
+      // the item type, not the array type: what each item is checked against is felt252
+      parameter.forEach((param: BigNumberish) =>
+        validateFelt(param, { name: input.name, type: baseType })
+      );
+      break;
+    // the other one-felt leaf type. Without this branch the whole array falls to the default
+    // below, so an Array<bytes31> was refused here whatever it held, though it serializes fine
+    case CairoBytes31.isAbiType(baseType):
+      parameter.forEach((param: any) => CairoBytes31.validate(param));
       break;
     case isTypeTuple(baseType):
       parameter.forEach((it: any) => validateTuple(it, { name: input.name, type: baseType }));
@@ -431,20 +449,22 @@ export default function validateFields(
       case CairoByteArray.isAbiType(input.type):
         CairoByteArray.validate(parameter);
         break;
+      // these five refuse any object, so an instance of the declared type is reduced first —
+      // unlike CairoBytes31 and CairoByteArray above, whose validate adopts one as it stands
       case CairoInt8.isAbiType(input.type):
-        CairoInt8.validate(parameter);
+        CairoInt8.validate(unwrapCairoScalar(parameter, input.type));
         break;
       case CairoInt16.isAbiType(input.type):
-        CairoInt16.validate(parameter);
+        CairoInt16.validate(unwrapCairoScalar(parameter, input.type));
         break;
       case CairoInt32.isAbiType(input.type):
-        CairoInt32.validate(parameter);
+        CairoInt32.validate(unwrapCairoScalar(parameter, input.type));
         break;
       case CairoInt64.isAbiType(input.type):
-        CairoInt64.validate(parameter);
+        CairoInt64.validate(unwrapCairoScalar(parameter, input.type));
         break;
       case CairoInt128.isAbiType(input.type):
-        CairoInt128.validate(parameter);
+        CairoInt128.validate(unwrapCairoScalar(parameter, input.type));
         break;
       case isTypeArray(input.type) || CairoFixedArray.isTypeFixedArray(input.type):
         validateArray(parameter, input, structs, enums);

--- a/www/docs/guides/migrate.md
+++ b/www/docs/guides/migrate.md
@@ -15,8 +15,9 @@ v11 carries three independent workstreams. The cryptographic dependencies move t
 ESM-only generation (`@noble/curves` 1.7 → 2.3, `@noble/hashes` 1.6 → 2.3, `@scure/base` 1.2 → 2.3,
 `@scure/starknet` 1.1 → 2.3), RPC requests now travel through a pluggable transport, which lets a
 single WebSocket serve both requests and subscriptions, and the string helpers deprecated back in
-v8.2.0 are finally removed. A fourth, much smaller pass clears out what remained of the V0–V2
-transaction API.
+v8.2.0 are finally removed. Two much smaller passes follow: one clears out what remained of the
+V0–V2 transaction API, the other puts the type an abi declares back in charge of reading the values
+that cross it.
 
 **The transport layer breaks nothing** — it is added underneath the existing API. The other two do.
 
@@ -27,6 +28,8 @@ transaction API.
 | Jest: the crypto dependencies are ESM-only        | **High**   | Add one line to your `transformIgnorePatterns`          |
 | `cairo.felt()` only accepts a number              | **Medium** | Encode text yourself before passing it                  |
 | Signature objects lost their v1 encoding methods  | **Medium** | Rename `toDERHex()` and its three siblings              |
+| Signed integers decode as signed                  | **Medium** | Drop your own field-element conversion                  |
+| An out-of-range argument is refused               | **Medium** | Fix the value, or opt into `fastParsingStrategy`        |
 | `CairoFelt()` and `encode.utf8ToArray()` removed  | **Low**    | Rename to `CairoFelt252` / `utf8ToUint8Array`           |
 | `@noble` / `@scure` import paths changed          | **Low**    | Only if you import these packages directly              |
 | The `ReceiptTx` class removed                     | **Low**    | Only if you used `instanceof ReceiptTx`                 |
@@ -320,6 +323,44 @@ broadcasting. This release removes the symbols that only existed to build or des
 
 Sending a transaction is unaffected: `Account` has been building V3 transactions only since v8.
 
+### 9. The type the abi declares is the one that reads your value
+
+Both abi parsers defaulted to `fastParsingStrategy`, which reaches `CairoFelt252` instead of the
+class the abi declares. Two consequences follow, and both change in v11.
+
+**A negative `i8`…`i128` came back from a call as its field element.** It now comes back as the
+negative number it is. If you were converting it yourself, drop that conversion.
+
+```typescript
+const delta = await myContract.get_delta(); // an i128 holding -5
+// v10: 3618502788666131213697322783095070105623107215331596699973092056135872020476n
+// v11: -5n
+```
+
+**An argument that does not fit its declared type is refused rather than serialized.** This covers
+`u8`, `u16`, `u32`, `u64`, `u96`, `u128` and `EthAddress`, which reached the calldata unchecked
+when the arguments were passed as an array.
+
+```typescript
+myCallData.compile('set_age', [256]); // a u8 parameter
+// v10: ["256"], sent as it is
+// v11: throws — Value is out of u8 range [0, 255]
+```
+
+Three of those were bounded nowhere before: `u32` and `EthAddress` had no branch of their own, and
+`u96` had one only for the argument-array form. `CairoUint32.abiSelector` is corrected with them,
+from `core::u32::u32` — which no abi ever spells — to `core::integer::u32`.
+
+A **response** is not validated, only decoded. `decodeParameters()` still returns what the node
+sent, even when it does not fit the type you name: what a caller passes in is their own mistake to
+catch, what a node answers is not.
+
+The former behaviour is still available, per `CallData`:
+
+```typescript
+const myCallData = new CallData(abi, fastParsingStrategy);
+```
+
 ## Part 2 — Deprecations
 
 Neither of these breaks anything today. Existing code keeps working; migrate at your own pace.
@@ -445,6 +486,24 @@ the object returned by `byteArray.byteArrayFromString()`, which a contract call 
 ```typescript
 await contract.set_label(CairoByteArray.fromText('12345'));
 ```
+
+### A Cairo type as an argument, with or without an abi
+
+What holds for `CairoByteArray` now holds for every Cairo type class: an instance can be passed
+wherever its own type is declared, at any depth, and `CallData.compile()` serializes one through
+that class instead of walking its fields.
+
+```typescript
+await myContract.set_amount(new CairoUint64(44)); //          a u64 parameter
+CallData.compile({ label: CairoByteArray.fromText('hi') }); // and with no abi at all
+```
+
+Without an abi this used to produce silently wrong calldata — a `CairoByteArray` came out with its
+pending word spelled one felt per byte, a `CairoBytes31` as its 31-byte buffer. It now produces the
+felts the abi path produces.
+
+An instance fills the slot of its own type only: a `CairoUint128` handed to a `u64` parameter is
+refused, whatever number it holds.
 
 ## Need Help?
 


### PR DESCRIPTION
## Motivation and Resolution

`CallData.compile()` without an ABI produced wrong calldata, silently, when given an instance of a
Cairo type class:

```typescript
CallData.compile({ v: CairoByteArray.fromText('12345') });
// ["0","49","50","51","52","53","5"]   the pending word, spelled one felt per byte
// expected ["0","211295614005","5"]
```

`createTree()` walks any object and enumerates its keys. It already recognised `CairoOption`,
`CairoResult` and `CairoCustomEnum`, but none of the classes in `src/utils/cairoDataTypes/`, so
their internals — the byte buffer of a `felt252`, the three fields of a `ByteArray` — were emitted
one felt at a time. It now delegates to `toApiRequest()`, the serialization the ABI path already
uses, and reads a `CairoFixedArray` through its own `compile()`.

Measuring every class then showed the problem was wider than the report, in three directions, one
commit each:

1. **No ABI.** Beyond `ByteArray` and `bytes31`, `CairoFelt252` emitted its bytes one by one, the
   five signed integers threw, and `CairoFixedArray` produced two spurious felts — an array length
   a fixed array does not carry, and its type string serialized as a felt.
2. **With an ABI.** The premise that this path was correct held for only 4 of the 16 classes. An
   instance was refused from four distinct places: field validation, the object guard of
   `parseCalldataValue` at any depth, the class constructors reached through the parsing strategy,
   and property ordering in the named form.
3. **The parsing strategy.** Both ABI parsers defaulted to `fastParsingStrategy`, which reaches
   `CairoFelt252` instead of the class the ABI declares. A negative `i8`..`i128` therefore came
   back from a call as its raw field element, silently, and an out-of-range unsigned argument was
   serialized rather than refused. Three types were bounded nowhere at all: `u32` and `EthAddress`
   had no branch of their own, `u96` had one only for the argument-array form.

The rule the third commit settles on: **a request is validated, a response is only decoded**. What
a caller passes in is their own mistake to catch before any calldata leaves; what a node answers is
not, so `decodeParameters()` still returns what it was sent.

Targeting `beta` because the third commit changes results for existing code.

### RPC version (if applicable)

Not applicable — no RPC method, type or spec version is touched.

## Usage related changes

- An instance of a Cairo type class can be passed wherever its own type is declared, at any depth,
  and `CallData.compile()` without an ABI serializes it through that class. Both used to produce
  wrong calldata or throw.
- An instance fills the slot of its own type only: a `CairoUint128` handed to a `u64` parameter is
  refused, whatever number it holds.
- A negative `i8`..`i128` returned by a call comes back as a negative number instead of its field
  element. **Drop any manual `PRIME` conversion**, or it will be applied twice.
- An out-of-range argument for `u8`, `u16`, `u32`, `u64`, `u96`, `u128` or `EthAddress` is refused
  instead of being serialized.
- `decodeParameters()` is unchanged: it still returns what the node sent, even out of range.
- `CairoUint32.abiSelector` is corrected from `core::u32::u32`, which no ABI spells, to
  `core::integer::u32`. Its constructor, `validate()` and `is()` now accept the same inputs as its
  siblings.
- The previous leniency stays available per `CallData`: `new CallData(abi, fastParsingStrategy)`.

## Development related changes

- New internal module `src/utils/cairoDataTypes/scalar.ts`, holding the list of one-felt Cairo
  types and reducing an instance to its number when it is the type the ABI declares. Not exported
  from `cairoDataTypes/index.ts`, so the public API is unchanged.
- `RANGE_ETH_ADDRESS` added to `src/global/constants.ts`; the 160-bit bound was written inline in
  `validate.ts` and is now read from one place by both the validator and the parsing strategy.
- Three new test files, 70 tests: `__tests__/utils/calldata/compile.test.ts` (the ABI-less path),
  `typedArguments.test.ts` (the ABI path, both call forms), and
  `parser/parsingStrategy.test.ts` (the default strategy, both parser versions).
- Each test file was run against the unmodified sources to confirm it fails there: 14 of 20, 17 of
  25 and 17 of 25 respectively, the survivors being the controls and the refusals.
- `www/docs/guides/migrate.md`: a Part 1 entry with two rows in the summary table, and a Part 3
  entry for the Cairo type arguments.
- Verified against a local devnet: 116 suites, 2394 tests, plus 62 suites / 1548 tests of the
  infra-free unit config.

## Checklist:

- [x] Performed a self-review of the code
- [x] Documented the changes in code (API docs will be generated automatically)
- [x] Updated the tests
- [x] All tests are passing
