### PR TITLE
test: use test() instead of it() in all test declarations

### DIFF
--- a/__tests__/accountPaymaster.test.ts
+++ b/__tests__/accountPaymaster.test.ts
@@ -162,7 +162,7 @@ describe('Account - Paymaster integration', () => {
   });
 
   describe('estimatePaymasterTransactionFee', () => {
-    it('should return estimated transaction fee from paymaster', async () => {
+    test('should return estimated transaction fee from paymaster', async () => {
       const result = await getAccount().estimatePaymasterTransactionFee(originalCalls, {
         feeMode: { mode: 'default', gasToken: '0x456' },
       });
@@ -184,7 +184,7 @@ describe('Account - Paymaster integration', () => {
   });
 
   describe('executePaymasterTransaction', () => {
-    it('should sign and execute transaction via paymaster without checking gas fees', async () => {
+    test('should sign and execute transaction via paymaster without checking gas fees', async () => {
       const details: PaymasterDetails = {
         feeMode: { mode: 'default', gasToken: '0x456' },
       };
@@ -211,7 +211,7 @@ describe('Account - Paymaster integration', () => {
       expect(result).toEqual({ transaction_hash: '0x123' });
     });
 
-    it('should sign and execute transaction via paymaster', async () => {
+    test('should sign and execute transaction via paymaster', async () => {
       const details: PaymasterDetails = {
         feeMode: { mode: 'default', gasToken: '0x456' },
       };
@@ -224,7 +224,7 @@ describe('Account - Paymaster integration', () => {
       expect(result).toEqual({ transaction_hash: '0x123' });
     });
 
-    it('should not throw if token price exceeds maxPriceInGasToken but transaction is sponsored', async () => {
+    test('should not throw if token price exceeds maxPriceInGasToken but transaction is sponsored', async () => {
       const details: PaymasterDetails = {
         feeMode: { mode: 'sponsored' },
       };
@@ -238,7 +238,7 @@ describe('Account - Paymaster integration', () => {
       });
     });
 
-    it('should throw if token price exceeds maxPriceInGasToken', async () => {
+    test('should throw if token price exceeds maxPriceInGasToken', async () => {
       const details: PaymasterDetails = {
         feeMode: { mode: 'default', gasToken: '0x456' },
       };
@@ -248,7 +248,7 @@ describe('Account - Paymaster integration', () => {
       ).rejects.toThrow('Gas token price is too high');
     });
 
-    it('should throw if Gas token value is not equal to the provided gas fees', async () => {
+    test('should throw if Gas token value is not equal to the provided gas fees', async () => {
       const details: PaymasterDetails = {
         feeMode: { mode: 'default', gasToken: '0x456' },
       };
@@ -258,7 +258,7 @@ describe('Account - Paymaster integration', () => {
       ).rejects.toThrow('Gas token value is not equal to the provided gas fees');
     });
 
-    it('should throw if Gas token address is not equal to the provided gas token', async () => {
+    test('should throw if Gas token address is not equal to the provided gas token', async () => {
       const details: PaymasterDetails = {
         feeMode: { mode: 'default', gasToken: '0x456' },
       };
@@ -268,7 +268,7 @@ describe('Account - Paymaster integration', () => {
       ).rejects.toThrow('Gas token address is not equal to the provided gas token');
     });
 
-    it('should throw if provided calls are not strictly equal to the returned calls', async () => {
+    test('should throw if provided calls are not strictly equal to the returned calls', async () => {
       const details: PaymasterDetails = {
         feeMode: { mode: 'default', gasToken: '0x456' },
       };

--- a/__tests__/defaultNodes.test.ts
+++ b/__tests__/defaultNodes.test.ts
@@ -4,7 +4,7 @@ import { getDefaultNodes, getSupportedRpcVersions } from '../src/utils/provider'
 
 describe('unit tests', () => {
   xdescribe('getDefaultNodes', () => {
-    it('constructs correct URLs for all supported RPC versions', () => {
+    test('constructs correct URLs for all supported RPC versions', () => {
       const supportedVersions = getSupportedRpcVersions();
       supportedVersions.forEach((version) => {
         const rpcNodes = getDefaultNodes(version);
@@ -19,7 +19,7 @@ describe('unit tests', () => {
     });
   });
   describe('getSupportedRpcVersions', () => {
-    it('should return a non-empty array of strings', () => {
+    test('should return a non-empty array of strings', () => {
       const versions = getSupportedRpcVersions();
       expect(Array.isArray(versions)).toBe(true);
       expect(versions.length).toBeGreaterThan(0);
@@ -28,7 +28,7 @@ describe('unit tests', () => {
       });
     });
 
-    it('should return an array with unique values', () => {
+    test('should return an array with unique values', () => {
       const versions = getSupportedRpcVersions();
       const uniqueVersions = [...new Set(versions)];
       expect(versions.length).toEqual(uniqueVersions.length);

--- a/__tests__/defaultPaymaster.test.ts
+++ b/__tests__/defaultPaymaster.test.ts
@@ -26,7 +26,7 @@ describe('PaymasterRpc', () => {
   });
 
   describe('constructor', () => {
-    it('should initialize with default values', () => {
+    test('should initialize with default values', () => {
       // When
       const client = new PaymasterRpc();
 
@@ -37,7 +37,7 @@ describe('PaymasterRpc', () => {
   });
 
   describe('isAvailable', () => {
-    it('should return true when paymaster is available', async () => {
+    test('should return true when paymaster is available', async () => {
       // Given
       const client = new PaymasterRpc();
       mockFetch.mockResolvedValueOnce({
@@ -57,7 +57,7 @@ describe('PaymasterRpc', () => {
       );
     });
 
-    it('should return false when paymaster is not available', async () => {
+    test('should return false when paymaster is not available', async () => {
       // Given
       const client = new PaymasterRpc();
       mockFetch.mockResolvedValueOnce({
@@ -71,7 +71,7 @@ describe('PaymasterRpc', () => {
       expect(result).toBe(false);
     });
 
-    it('should throw RpcError when RPC returns error', async () => {
+    test('should throw RpcError when RPC returns error', async () => {
       // Given
       const client = new PaymasterRpc();
       mockFetch.mockResolvedValueOnce({
@@ -82,7 +82,7 @@ describe('PaymasterRpc', () => {
       await expect(client.isAvailable()).rejects.toThrow(RpcError);
     });
 
-    it('should throw on network error', async () => {
+    test('should throw on network error', async () => {
       // Given
       const client = new PaymasterRpc();
       mockFetch.mockRejectedValueOnce(new Error('Network down'));
@@ -93,7 +93,7 @@ describe('PaymasterRpc', () => {
   });
 
   describe('buildTransaction', () => {
-    it('should return typedData and parsed tokenAmountAndPrice', async () => {
+    test('should return typedData and parsed tokenAmountAndPrice', async () => {
       // Given
       const client = new PaymasterRpc();
       const mockCall = {
@@ -155,7 +155,7 @@ describe('PaymasterRpc', () => {
   });
 
   describe('executeTransaction', () => {
-    it('should send execution request and return transaction hash', async () => {
+    test('should send execution request and return transaction hash', async () => {
       // Given
       const client = new PaymasterRpc();
       const mockSignature = ['0x1', '0x2'];
@@ -207,7 +207,7 @@ describe('PaymasterRpc', () => {
   });
 
   describe('getSupportedTokens', () => {
-    it('should return supported tokens and prices', async () => {
+    test('should return supported tokens and prices', async () => {
       // Given
       const client = new PaymasterRpc();
       const rpc_response = [

--- a/__tests__/utils/config.test.ts
+++ b/__tests__/utils/config.test.ts
@@ -7,7 +7,7 @@ describe('Configuration', () => {
   });
 
   describe('Initial Configuration', () => {
-    it('should initialize with default values', () => {
+    test('should initialize with default values', () => {
       expect(config.get('transactionVersion')).toBe(
         constants.DEFAULT_GLOBAL_CONFIG.transactionVersion
       );
@@ -16,33 +16,33 @@ describe('Configuration', () => {
   });
 
   describe('get()', () => {
-    it('should retrieve the value of an existing key', () => {
+    test('should retrieve the value of an existing key', () => {
       expect(config.get('logLevel')).toBe(constants.DEFAULT_GLOBAL_CONFIG.logLevel);
     });
 
-    it('should return the default value for a non-existent key', () => {
+    test('should return the default value for a non-existent key', () => {
       expect(config.get('nonExistentKey', 'default')).toBe('default');
     });
 
-    it('should return undefined for a non-existent key without a default', () => {
+    test('should return undefined for a non-existent key without a default', () => {
       expect(config.get('nonExistentKey')).toBeUndefined();
     });
   });
 
   describe('set()', () => {
-    it('should update the value of an existing key', () => {
+    test('should update the value of an existing key', () => {
       config.set('logLevel', 'DEBUG');
       expect(config.get('logLevel')).toBe('DEBUG');
     });
 
-    it('should add a new key-value pair', () => {
+    test('should add a new key-value pair', () => {
       config.set('newKey', 'value');
       expect(config.get('newKey')).toBe('value');
     });
   });
 
   describe('update()', () => {
-    it('should merge provided configuration with existing values', () => {
+    test('should merge provided configuration with existing values', () => {
       config.update({ legacyMode: true, newKey: 'value' });
       expect(config.get('legacyMode')).toBe(true);
       expect(config.get('newKey')).toBe('value');
@@ -51,7 +51,7 @@ describe('Configuration', () => {
   });
 
   describe('getAll()', () => {
-    it('should return a copy of the configuration', () => {
+    test('should return a copy of the configuration', () => {
       const all = config.getAll();
       all.rpcVersion = '0.9.0'; // Modify the copy
       expect(config.get('rpcVersion')).toBe('0.10.0'); // Original remains unaffected
@@ -59,7 +59,7 @@ describe('Configuration', () => {
   });
 
   describe('reset()', () => {
-    it('should restore the configuration to initial defaults', () => {
+    test('should restore the configuration to initial defaults', () => {
       config.set('logLevel', 'ERROR');
       config.reset();
       expect(config.get('logLevel')).toBe('INFO');
@@ -67,41 +67,41 @@ describe('Configuration', () => {
   });
 
   describe('delete()', () => {
-    it('should remove a key from the configuration', () => {
+    test('should remove a key from the configuration', () => {
       config.set('newKey', 'value');
       config.delete('newKey');
       expect(config.hasKey('newKey')).toBe(false);
     });
 
-    it('should do nothing if the key does not exist', () => {
+    test('should do nothing if the key does not exist', () => {
       config.delete('nonExistentKey');
       expect(config.hasKey('nonExistentKey')).toBe(false);
     });
   });
 
   describe('hasKey()', () => {
-    it('should return true for existing keys', () => {
+    test('should return true for existing keys', () => {
       expect(config.hasKey('logLevel')).toBe(true);
     });
 
-    it('should return false for non-existent keys', () => {
+    test('should return false for non-existent keys', () => {
       expect(config.hasKey('nonExistentKey')).toBe(false);
     });
   });
 
   describe('Edge Cases', () => {
-    it('should handle undefined values with default in get()', () => {
+    test('should handle undefined values with default in get()', () => {
       config.set('someKey', undefined);
       expect(config.get('someKey', 'DEFAULT')).toBe('DEFAULT');
     });
 
-    it('should treat keys as case-sensitive', () => {
+    test('should treat keys as case-sensitive', () => {
       config.set('LogLevel', 'DEBUG');
       expect(config.hasKey('LogLevel')).toBe(true);
       expect(config.hasKey('logLevel')).toBe(true); // Original key still exists
     });
 
-    it('should handle nested configuration', () => {
+    test('should handle nested configuration', () => {
       config.set('channelDefaults.options.blockIdentifier', BlockTag.PRE_CONFIRMED);
       expect(config.get('channelDefaults.options.blockIdentifier')).toBe(BlockTag.PRE_CONFIRMED);
 

--- a/__tests__/utils/logger.test.ts
+++ b/__tests__/utils/logger.test.ts
@@ -73,41 +73,41 @@ describe('Logger', () => {
   });
 
   describe('Log Level Configuration', () => {
-    it('should have config log level', () => {
+    test('should have config log level', () => {
       expect(logger.getLogLevel()).toBe('INFO');
     });
 
-    it('should set and get log level OFF', () => {
+    test('should set and get log level OFF', () => {
       logger.setLogLevel('OFF');
       expect(logger.getLogLevel()).toBe('OFF');
       expect(logger.getEnabledLogLevels()).toStrictEqual([]);
     });
 
-    it('should set and get log level FATAL', () => {
+    test('should set and get log level FATAL', () => {
       logger.setLogLevel('FATAL');
       expect(logger.getLogLevel()).toBe('FATAL');
       expect(logger.getEnabledLogLevels()).toStrictEqual(['FATAL']);
     });
 
-    it('should set and get log level ERROR', () => {
+    test('should set and get log level ERROR', () => {
       logger.setLogLevel('ERROR');
       expect(logger.getLogLevel()).toBe('ERROR');
       expect(logger.getEnabledLogLevels()).toStrictEqual(['ERROR', 'FATAL']);
     });
 
-    it('should set and get log level WARN', () => {
+    test('should set and get log level WARN', () => {
       logger.setLogLevel('WARN');
       expect(logger.getLogLevel()).toBe('WARN');
       expect(logger.getEnabledLogLevels()).toStrictEqual(['WARN', 'ERROR', 'FATAL']);
     });
 
-    it('should set and get log level INFO', () => {
+    test('should set and get log level INFO', () => {
       logger.setLogLevel('INFO');
       expect(logger.getLogLevel()).toBe('INFO');
       expect(logger.getEnabledLogLevels()).toStrictEqual(['INFO', 'WARN', 'ERROR', 'FATAL']);
     });
 
-    it('should set and get log level DEBUG', () => {
+    test('should set and get log level DEBUG', () => {
       logger.setLogLevel('DEBUG');
       expect(logger.getLogLevel()).toBe('DEBUG');
       expect(logger.getEnabledLogLevels()).toStrictEqual([
@@ -121,7 +121,7 @@ describe('Logger', () => {
   });
 
   describe('Log Filtering', () => {
-    it('should log messages at or above current level', () => {
+    test('should log messages at or above current level', () => {
       logger.setLogLevel('WARN');
 
       logger.debug('Debug message');
@@ -131,7 +131,7 @@ describe('Logger', () => {
       expect(gWarn).toHaveBeenCalled();
     });
 
-    it('should not log when level is OFF', () => {
+    test('should not log when level is OFF', () => {
       logger.setLogLevel('OFF');
 
       logger.error('Error message');
@@ -143,14 +143,14 @@ describe('Logger', () => {
   });
 
   describe('Log Methods', () => {
-    it('should format messages correctly', () => {
+    test('should format messages correctly', () => {
       logger.info('Test message', { key: 'value' });
 
       const expectedMessage = `[2024-01-01T00:00:00.000Z] INFO: Test message\n${JSON.stringify({ key: 'value' }, null, 2)}`;
       expect(gInfo).toHaveBeenCalledWith(expectedMessage);
     });
 
-    it('should use appropriate console methods', () => {
+    test('should use appropriate console methods', () => {
       logger.setLogLevel('DEBUG');
       logger.debug('Debug');
       logger.info('Info');
@@ -166,13 +166,13 @@ describe('Logger', () => {
   });
 
   describe('Edge Cases', () => {
-    it('should handle empty data', () => {
+    test('should handle empty data', () => {
       logger.info('Message without data');
       const expectedMessage = '[2024-01-01T00:00:00.000Z] INFO: Message without data';
       expect(gInfo).toHaveBeenCalledWith(expectedMessage);
     });
 
-    it('should handle circular data structures', () => {
+    test('should handle circular data structures', () => {
       logger.setLogLevel('DEBUG');
       const circularObj: any = { a: 'test' };
       circularObj.myself = circularObj;

--- a/__tests__/utils/resolve.test.ts
+++ b/__tests__/utils/resolve.test.ts
@@ -19,7 +19,7 @@ import type {
 } from '../../src';
 
 describe('isVersion', () => {
-  it('matches exact versions', () => {
+  test('matches exact versions', () => {
     expect(isVersion('0.7.0', '0.7.0')).toBe(true);
     expect(isVersion('0.7', '0.7')).toBe(true);
     expect(isVersion('1.2.3', '1.2.3')).toBe(true);
@@ -29,21 +29,21 @@ describe('isVersion', () => {
     expect(isVersion('1.0.0', '2.0.0')).toBe(false);
   });
 
-  it('handles wildcard in major version', () => {
+  test('handles wildcard in major version', () => {
     expect(isVersion('*.7.0', '0.7.0')).toBe(true);
     expect(isVersion('*.7.0', '1.7.0')).toBe(true);
     expect(isVersion('*.7.0', '2.7.0')).toBe(true);
     expect(isVersion('*.7.0', '0.8.0')).toBe(false);
   });
 
-  it('handles wildcard in minor version', () => {
+  test('handles wildcard in minor version', () => {
     expect(isVersion('0.*.0', '0.7.0')).toBe(true);
     expect(isVersion('0.*.0', '0.8.0')).toBe(true);
     expect(isVersion('0.*.0', '0.9.0')).toBe(true);
     expect(isVersion('0.*.0', '1.7.0')).toBe(false);
   });
 
-  it('handles wildcard in patch version', () => {
+  test('handles wildcard in patch version', () => {
     expect(isVersion('0.7.*', '0.7.0')).toBe(true);
     expect(isVersion('0.7.*', '0.7.1')).toBe(true);
     expect(isVersion('0.7', '0.7.1')).toBe(true);
@@ -56,7 +56,7 @@ describe('isVersion', () => {
     expect(isVersion('0.7', '0.8.1')).toBe(false);
   });
 
-  it('handles multiple wildcards', () => {
+  test('handles multiple wildcards', () => {
     expect(isVersion('*.*.0', '0.7.0')).toBe(true);
     expect(isVersion('*.*.0', '1.8.0')).toBe(true);
     expect(isVersion('*.*.0', '0.7.1')).toBe(false);
@@ -74,30 +74,30 @@ describe('isVersion', () => {
     expect(isVersion('*.3.4', '2.3.4')).toBe(true);
   });
 
-  it('handles shorter provided version', () => {
+  test('handles shorter provided version', () => {
     expect(isVersion('0.7.1', '0.7')).toBe(false);
   });
 });
 
 describe('toAnyPatchVersion', () => {
-  it('converts version strings to wildcard patch versions', () => {
+  test('converts version strings to wildcard patch versions', () => {
     expect(toAnyPatchVersion('0.7.0')).toBe('0.7.*');
     expect(toAnyPatchVersion('1.2.3')).toBe('1.2.*');
     expect(toAnyPatchVersion('0.8')).toBe('0.8');
     expect(toAnyPatchVersion('2.0')).toBe('2.0');
   });
 
-  it('handles versions with pre-release tags', () => {
+  test('handles versions with pre-release tags', () => {
     expect(toAnyPatchVersion('1.2.3-rc1')).toBe('1.2.*');
   });
 
-  it('handles invalid or empty version strings', () => {
+  test('handles invalid or empty version strings', () => {
     expect(toAnyPatchVersion('')).toBe('');
     expect(toAnyPatchVersion('invalid')).toBe('invalid');
     expect(toAnyPatchVersion('0')).toBe('0');
   });
 
-  it('handles already wildcarded versions', () => {
+  test('handles already wildcarded versions', () => {
     expect(toAnyPatchVersion('0.7.*')).toBe('0.7.*');
     expect(toAnyPatchVersion('1.*')).toBe('1.*');
     expect(toAnyPatchVersion('*')).toBe('*');
@@ -105,70 +105,70 @@ describe('toAnyPatchVersion', () => {
 });
 
 describe('isSupportedSpecVersion', () => {
-  it('returns true for supported spec versions', () => {
+  test('returns true for supported spec versions', () => {
     expect(isSupportedSpecVersion('0.9.0')).toBe(true);
     expect(isSupportedSpecVersion('0.10.0')).toBe(true);
     expect(isSupportedSpecVersion('0.9', { allowAnyPatchVersion: true })).toBe(true);
     expect(isSupportedSpecVersion('0.10', { allowAnyPatchVersion: true })).toBe(true);
   });
 
-  it('returns false for unsupported spec versions', () => {
+  test('returns false for unsupported spec versions', () => {
     expect(isSupportedSpecVersion('0.6')).toBe(false);
     expect(isSupportedSpecVersion('2.0')).toBe(false);
     expect(isSupportedSpecVersion('')).toBe(false);
     expect(isSupportedSpecVersion('invalid')).toBe(false);
   });
 
-  it('handles wildcard and partial versions', () => {
+  test('handles wildcard and partial versions', () => {
     expect(isSupportedSpecVersion('*')).toBe(false);
     expect(isSupportedSpecVersion('0.*')).toBe(false);
     expect(isSupportedSpecVersion('*.8')).toBe(false);
   });
 
   describe('isSupportedSpecVersion', () => {
-    it('returns true for exact supported version', () => {
+    test('returns true for exact supported version', () => {
       expect(isSupportedSpecVersion(constants.SupportedRpcVersion.v0_9_0)).toBe(true);
     });
 
-    it('returns false for unsupported version', () => {
+    test('returns false for unsupported version', () => {
       expect(isSupportedSpecVersion('9.9.9')).toBe(false);
     });
 
-    it('returns true for supported version with allowAnyPatchVersion=true', () => {
+    test('returns true for supported version with allowAnyPatchVersion=true', () => {
       expect(isSupportedSpecVersion('0.9.5', { allowAnyPatchVersion: true })).toBe(true);
     });
 
-    it('returns false for supported version with allowAnyPatchVersion=false and mismatched patch', () => {
+    test('returns false for supported version with allowAnyPatchVersion=false and mismatched patch', () => {
       expect(isSupportedSpecVersion('0.7.444', { allowAnyPatchVersion: false })).toBe(false);
     });
 
-    it('returns true for supported version with wildcard in SupportedRpcVersion', () => {
+    test('returns true for supported version with wildcard in SupportedRpcVersion', () => {
       // Simulate a SupportedRpcVersion with a wildcard
       expect(isSupportedSpecVersion('0.9.123', { allowAnyPatchVersion: true })).toBe(true);
     });
 
-    it('returns false for empty version', () => {
+    test('returns false for empty version', () => {
       expect(isSupportedSpecVersion('')).toBe(false);
     });
 
-    it('returns false for malformed version', () => {
+    test('returns false for malformed version', () => {
       expect(isSupportedSpecVersion('abc.def.ghi')).toBe(false);
     });
 
-    it('returns true for supported version with allowAnyPatchVersion explicitly set to true', () => {
+    test('returns true for supported version with allowAnyPatchVersion explicitly set to true', () => {
       expect(isSupportedSpecVersion('0.9.2', { allowAnyPatchVersion: true })).toBe(true);
     });
 
-    it('returns false for supported version with allowAnyPatchVersion explicitly set to false', () => {
+    test('returns false for supported version with allowAnyPatchVersion explicitly set to false', () => {
       expect(isSupportedSpecVersion('0.7.2', { allowAnyPatchVersion: false })).toBe(false);
     });
 
-    it('returns true for supported version when options is omitted (defaults to false)', () => {
+    test('returns true for supported version when options is omitted (defaults to false)', () => {
       expect(isSupportedSpecVersion('0.9.0')).toBe(true);
       expect(isSupportedSpecVersion('0.9.11')).toBe(false);
     });
 
-    it('returns false for unsupported version regardless of options', () => {
+    test('returns false for unsupported version regardless of options', () => {
       expect(isSupportedSpecVersion('1.2.3', { allowAnyPatchVersion: true })).toBe(false);
       expect(isSupportedSpecVersion('1.2.3', { allowAnyPatchVersion: false })).toBe(false);
     });
@@ -176,7 +176,7 @@ describe('isSupportedSpecVersion', () => {
 });
 
 describe('toApiVersion', () => {
-  it('converts version strings like "0.8.1" or "0.8" to "v0_8"', () => {
+  test('converts version strings like "0.8.1" or "0.8" to "v0_8"', () => {
     expect(toApiVersion('0.8.1')).toBe('v0_8');
     expect(toApiVersion('0.8')).toBe('v0_8');
     expect(toApiVersion('1.2.3')).toBe('v1_2');
@@ -187,28 +187,28 @@ describe('toApiVersion', () => {
 
 describe('compareVersions', () => {
   describe('basic comparisons', () => {
-    it('correctly compares patch versions', () => {
+    test('correctly compares patch versions', () => {
       expect(compareVersions('0.0.9', '0.0.10')).toBe(-1);
       expect(compareVersions('0.0.10', '0.0.9')).toBe(1);
       expect(compareVersions('1.2.3', '1.2.4')).toBe(-1);
       expect(compareVersions('1.2.4', '1.2.3')).toBe(1);
     });
 
-    it('correctly compares minor versions', () => {
+    test('correctly compares minor versions', () => {
       expect(compareVersions('0.1.0', '0.2.0')).toBe(-1);
       expect(compareVersions('0.2.0', '0.1.0')).toBe(1);
       expect(compareVersions('1.1.5', '1.2.0')).toBe(-1);
       expect(compareVersions('1.2.0', '1.1.5')).toBe(1);
     });
 
-    it('correctly compares major versions', () => {
+    test('correctly compares major versions', () => {
       expect(compareVersions('1.0.0', '2.0.0')).toBe(-1);
       expect(compareVersions('2.0.0', '1.0.0')).toBe(1);
       expect(compareVersions('0.9.9', '1.0.0')).toBe(-1);
       expect(compareVersions('1.0.0', '0.9.9')).toBe(1);
     });
 
-    it('returns 0 for equal versions', () => {
+    test('returns 0 for equal versions', () => {
       expect(compareVersions('0.0.9', '0.0.9')).toBe(0);
       expect(compareVersions('1.2.3', '1.2.3')).toBe(0);
       expect(compareVersions('0.14.1', '0.14.1')).toBe(0);
@@ -216,7 +216,7 @@ describe('compareVersions', () => {
   });
 
   describe('edge cases', () => {
-    it('handles missing version segments (treats as 0)', () => {
+    test('handles missing version segments (treats as 0)', () => {
       expect(compareVersions('0.1', '0.1.0')).toBe(0);
       expect(compareVersions('0.1.0', '0.1')).toBe(0);
       expect(compareVersions('1', '1.0.0')).toBe(0);
@@ -225,14 +225,14 @@ describe('compareVersions', () => {
       expect(compareVersions('0.1.1', '0.1')).toBe(1);
     });
 
-    it('correctly handles versions with different segment counts', () => {
+    test('correctly handles versions with different segment counts', () => {
       expect(compareVersions('0.0.99', '0.1')).toBe(-1);
       expect(compareVersions('0.1', '0.0.99')).toBe(1);
       expect(compareVersions('1.2', '1.2.3')).toBe(-1);
       expect(compareVersions('1.2.3', '1.2')).toBe(1);
     });
 
-    it('safely avoids collision between versions like 0.0.1000 and 0.1.0', () => {
+    test('safely avoids collision between versions like 0.0.1000 and 0.1.0', () => {
       // This is the key safety test - these should NOT be equal
       expect(compareVersions('0.0.1000', '0.1.0')).toBe(-1);
       expect(compareVersions('0.1.0', '0.0.1000')).toBe(1);
@@ -240,7 +240,7 @@ describe('compareVersions', () => {
       expect(compareVersions('0.1.0', '0.1.0')).toBe(0);
     });
 
-    it('handles large version numbers', () => {
+    test('handles large version numbers', () => {
       expect(compareVersions('0.0.999', '0.1.0')).toBe(-1);
       expect(compareVersions('0.999.0', '1.0.0')).toBe(-1);
       expect(compareVersions('10.500.2000', '10.500.2001')).toBe(-1);
@@ -249,14 +249,14 @@ describe('compareVersions', () => {
   });
 
   describe('real-world starknet version comparisons', () => {
-    it('compares starknet RPC versions correctly', () => {
+    test('compares starknet RPC versions correctly', () => {
       expect(compareVersions('0.8.1', '0.9.0')).toBe(-1);
       expect(compareVersions('0.9.0', '0.8.1')).toBe(1);
       expect(compareVersions('0.14.0', '0.14.1')).toBe(-1);
       expect(compareVersions('0.14.1', '0.14.0')).toBe(1);
     });
 
-    it('can be used for version threshold checks', () => {
+    test('can be used for version threshold checks', () => {
       // Example: Blake2s should be used for version >= 0.14.1
       const useBlake = (version: string) => compareVersions(version, '0.14.1') >= 0;
 
@@ -271,7 +271,7 @@ describe('compareVersions', () => {
 });
 
 describe('isV3Tx', () => {
-  it('returns true for V3 transactions with explicit version 3', () => {
+  test('returns true for V3 transactions with explicit version 3', () => {
     const v3Details: InvocationsDetailsWithNonce = {
       nonce: 1,
       version: 3,
@@ -279,7 +279,7 @@ describe('isV3Tx', () => {
     expect(isV3Tx(v3Details)).toBe(true);
   });
 
-  it('returns true for V3 transactions with hex version 0x3', () => {
+  test('returns true for V3 transactions with hex version 0x3', () => {
     const v3Details: InvocationsDetailsWithNonce = {
       nonce: 1,
       version: '0x3',
@@ -287,7 +287,7 @@ describe('isV3Tx', () => {
     expect(isV3Tx(v3Details)).toBe(true);
   });
 
-  it('returns true for F3 transactions (feemarket version)', () => {
+  test('returns true for F3 transactions (feemarket version)', () => {
     const f3Details: InvocationsDetailsWithNonce = {
       nonce: 1,
       version: ETransactionVersion.F3,
@@ -295,14 +295,14 @@ describe('isV3Tx', () => {
     expect(isV3Tx(f3Details)).toBe(true);
   });
 
-  it('returns true when version is not specified (defaults to V3)', () => {
+  test('returns true when version is not specified (defaults to V3)', () => {
     const defaultDetails: InvocationsDetailsWithNonce = {
       nonce: 1,
     };
     expect(isV3Tx(defaultDetails)).toBe(true);
   });
 
-  it('returns false for V2 transactions', () => {
+  test('returns false for V2 transactions', () => {
     const v2Details: InvocationsDetailsWithNonce = {
       nonce: 1,
       version: 2,
@@ -310,7 +310,7 @@ describe('isV3Tx', () => {
     expect(isV3Tx(v2Details)).toBe(false);
   });
 
-  it('returns false for V1 transactions', () => {
+  test('returns false for V1 transactions', () => {
     const v1Details: InvocationsDetailsWithNonce = {
       nonce: 1,
       version: 1,
@@ -318,7 +318,7 @@ describe('isV3Tx', () => {
     expect(isV3Tx(v1Details)).toBe(false);
   });
 
-  it('returns false for hex version 0x1', () => {
+  test('returns false for hex version 0x1', () => {
     const v1Details: InvocationsDetailsWithNonce = {
       nonce: 1,
       version: '0x1',
@@ -328,7 +328,7 @@ describe('isV3Tx', () => {
 });
 
 describe('isPreConfirmedBlock', () => {
-  it('returns true for blocks with PRE_CONFIRMED status', () => {
+  test('returns true for blocks with PRE_CONFIRMED status', () => {
     const preConfirmedBlock = {
       status: 'PRE_CONFIRMED',
       transactions: [],
@@ -337,7 +337,7 @@ describe('isPreConfirmedBlock', () => {
     expect(isPreConfirmedBlock(preConfirmedBlock)).toBe(true);
   });
 
-  it('returns false for blocks with ACCEPTED_ON_L2 status', () => {
+  test('returns false for blocks with ACCEPTED_ON_L2 status', () => {
     const acceptedBlock = {
       status: 'ACCEPTED_ON_L2',
       block_hash: '0x123',
@@ -347,7 +347,7 @@ describe('isPreConfirmedBlock', () => {
     expect(isPreConfirmedBlock(acceptedBlock)).toBe(false);
   });
 
-  it('returns false for blocks with ACCEPTED_ON_L1 status', () => {
+  test('returns false for blocks with ACCEPTED_ON_L1 status', () => {
     const acceptedBlock = {
       status: 'ACCEPTED_ON_L1',
       block_hash: '0x123',
@@ -357,7 +357,7 @@ describe('isPreConfirmedBlock', () => {
     expect(isPreConfirmedBlock(acceptedBlock)).toBe(false);
   });
 
-  it('returns false for blocks with REJECTED status', () => {
+  test('returns false for blocks with REJECTED status', () => {
     const rejectedBlock = {
       status: 'REJECTED',
       transactions: [],
@@ -368,7 +368,7 @@ describe('isPreConfirmedBlock', () => {
 });
 
 describe('isPreConfirmedTransaction', () => {
-  it('returns true for transactions without block_hash', () => {
+  test('returns true for transactions without block_hash', () => {
     const preConfirmedTx = {
       transaction_hash: '0x123',
       execution_status: 'SUCCEEDED',
@@ -377,7 +377,7 @@ describe('isPreConfirmedTransaction', () => {
     expect(isPreConfirmedTransaction(preConfirmedTx)).toBe(true);
   });
 
-  it('returns false for transactions with block_hash', () => {
+  test('returns false for transactions with block_hash', () => {
     const confirmedTx = {
       transaction_hash: '0x123',
       block_hash: '0xabc',
@@ -387,7 +387,7 @@ describe('isPreConfirmedTransaction', () => {
     expect(isPreConfirmedTransaction(confirmedTx)).toBe(false);
   });
 
-  it('returns true for transactions with undefined block_hash', () => {
+  test('returns true for transactions with undefined block_hash', () => {
     const tx = {
       transaction_hash: '0x123',
       execution_status: 'SUCCEEDED',
@@ -398,7 +398,7 @@ describe('isPreConfirmedTransaction', () => {
     expect(isPreConfirmedTransaction(tx)).toBe(false);
   });
 
-  it('returns false for reverted transactions with block_hash', () => {
+  test('returns false for reverted transactions with block_hash', () => {
     const revertedTx = {
       transaction_hash: '0x123',
       block_hash: '0xdef',
@@ -411,7 +411,7 @@ describe('isPreConfirmedTransaction', () => {
 });
 
 describe('isPreConfirmedStateUpdate', () => {
-  it('returns true for state updates without block_hash', () => {
+  test('returns true for state updates without block_hash', () => {
     const preConfirmedState = {
       old_root: '0x123',
       new_root: '0x456',
@@ -426,7 +426,7 @@ describe('isPreConfirmedStateUpdate', () => {
     expect(isPreConfirmedStateUpdate(preConfirmedState)).toBe(true);
   });
 
-  it('returns false for state updates with block_hash', () => {
+  test('returns false for state updates with block_hash', () => {
     const confirmedState = {
       block_hash: '0xabc',
       old_root: '0x123',
@@ -442,7 +442,7 @@ describe('isPreConfirmedStateUpdate', () => {
     expect(isPreConfirmedStateUpdate(confirmedState)).toBe(false);
   });
 
-  it('returns true for minimal pre-confirmed state update', () => {
+  test('returns true for minimal pre-confirmed state update', () => {
     const minimalState = {
       new_root: '0x789',
       old_root: '0x012',
@@ -451,7 +451,7 @@ describe('isPreConfirmedStateUpdate', () => {
     expect(isPreConfirmedStateUpdate(minimalState)).toBe(true);
   });
 
-  it('returns false for state update with undefined block_hash', () => {
+  test('returns false for state update with undefined block_hash', () => {
     const state = {
       block_hash: undefined,
       old_root: '0x123',

--- a/__tests__/utils/transaction.test.ts
+++ b/__tests__/utils/transaction.test.ts
@@ -3,11 +3,11 @@ import { fromCallsToExecuteCalldata_cairo1, getVersionsByType } from '../../src/
 import { ETransactionVersion } from '../../src';
 
 describe('fromCallsToExecuteCalldata_cairo1', () => {
-  it('should return an array with a length of one when given an empty input', () => {
+  test('should return an array with a length of one when given an empty input', () => {
     expect(fromCallsToExecuteCalldata_cairo1([])).toEqual(['0']);
   });
 
-  it('should transform a list of calls into the full flattened calldata', () => {
+  test('should transform a list of calls into the full flattened calldata', () => {
     const calls: Call[] = [
       {
         contractAddress: '0x123',
@@ -37,21 +37,21 @@ describe('fromCallsToExecuteCalldata_cairo1', () => {
 });
 
 describe('getVersionsByType', () => {
-  it("should return fee versions when versionType is 'fee'", () => {
+  test("should return fee versions when versionType is 'fee'", () => {
     const versions = getVersionsByType('fee');
     expect(versions).toEqual({
       v3: ETransactionVersion.F3,
     });
   });
 
-  it("should return transaction versions when versionType is 'transaction'", () => {
+  test("should return transaction versions when versionType is 'transaction'", () => {
     const versions = getVersionsByType('transaction');
     expect(versions).toEqual({
       v3: ETransactionVersion.V3,
     });
   });
 
-  it('should return transaction versions when versionType is undefined', () => {
+  test('should return transaction versions when versionType is undefined', () => {
     const versions = getVersionsByType();
     expect(versions).toEqual({
       v3: ETransactionVersion.V3,


### PR DESCRIPTION
## Motivation and Resolution

The suite declared its tests with two interchangeable Jest globals. Most files already used
`test()`; 107 declarations across 7 files still used the `it()` alias. This settles the suite on
`test()`.

Pure rename of the declaration keyword: no title, body, assertion or `describe` block changed, and
no test added, removed or skipped. Occurrences of `it` that are not declarations — callback
parameters named `it`, and comments where "it" is a pronoun — were left untouched.

### RPC version (if applicable)

Not applicable.

## Usage related changes


- None. No file under `src/` is touched.

## Development related changes


- 107 `it(` declarations replaced with `test(` across 7 test files; a test declaration is now
  greppable with a single pattern.
- Diff is exactly symmetrical (107 insertions, 107 deletions) — one line per declaration, no
  collateral edit. No CI or tooling change.

## Checklist:

- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Updated the tests
- [x] All tests are passing
