### PR TITLE
feat(constants)!: remove the feeder gateway BaseUrl constant

### DIFF
--- a/src/global/constants.ts
+++ b/src/global/constants.ts
@@ -70,13 +70,6 @@ export const HARDENING_4BYTES = 2147483648n;
 
 // NOTE: the enum alias exports are made so both the 'const' and 'type' are reachable in the published '.d.ts' file,
 // otherwise the last export hides the preceding export with the same name in this file
-const _BaseUrl = {
-  SN_MAIN: 'https://alpha-mainnet.starknet.io',
-  SN_SEPOLIA: 'https://alpha-sepolia.starknet.io',
-} as const;
-type _BaseUrl = ValuesType<typeof _BaseUrl>;
-export { _BaseUrl as BaseUrl };
-
 const _NetworkName = {
   SN_MAIN: 'SN_MAIN',
   SN_SEPOLIA: 'SN_SEPOLIA',

--- a/www/docs/guides/migrate.md
+++ b/www/docs/guides/migrate.md
@@ -36,6 +36,7 @@ encoding a different one.
 | The `ReceiptTx` class removed                     | **Low**    | Only if you used `instanceof ReceiptTx`                 |
 | The leftover v1 transaction API removed           | **Low**    | Only if you imported `v2hash` or `ETransactionVersion2` |
 | Starknet ID names are validated, not truncated    | **Low**    | Only if you resolve or encode `.stark` names            |
+| The feeder gateway `BaseUrl` constant removed     | **Low**    | Only if you imported `constants.BaseUrl`                |
 
 Two deprecations ship with the release — `stark.randomAddress()` and `Provider` — but neither of
 them breaks existing code. They are covered in [Part 2](#part-2--deprecations).
@@ -389,6 +390,39 @@ and 20 for `来`.
 `getAddressFromStarkName()` already threw on a name its guard turned down, so nothing changes in
 its shape — only in which names it turns down. If you hand it user input, keep it wrapped: an
 unencodable name is an exception, never a silent resolution to the wrong account.
+
+### 11. The feeder gateway `BaseUrl` constant is removed
+
+`constants.BaseUrl` held the two roots of the feeder gateway, `https://alpha-mainnet.starknet.io`
+and `https://alpha-sepolia.starknet.io`. Starknet v0.14.4 removes six of that gateway's endpoints —
+`call`, `get_storage_at`, `get_nonce`, `get_class_hash_at`, `get_code` and `get_full_contract`. The
+library has spoken JSON-RPC only since v7 and no longer read this constant anywhere, so all it
+exported was a pair of urls about to stop answering.
+
+The replacement depends on what you took from it. To name a network and let the library pick a
+public RPC node for it, use `constants.NetworkName`:
+
+```typescript
+// v10
+const nodeUrl = constants.BaseUrl.SN_MAIN;
+// v11
+const nodeUrl = provider.getDefaultNodeUrl(constants.NetworkName.SN_MAIN);
+```
+
+`RpcProvider` accepts that network name directly, and resolves it the same way:
+
+```typescript
+const myProvider = new RpcProvider({ nodeUrl: constants.NetworkName.SN_MAIN });
+```
+
+To reach a node you chose yourself — the better approach, as the public ones are shared and
+throttled — pass its RPC url:
+
+```typescript
+const myProvider = new RpcProvider({
+  nodeUrl: 'https://api.zan.top/public/starknet-mainnet/rpc/v0_10',
+});
+```
 
 ## Part 2 — Deprecations
 


### PR DESCRIPTION
## Motivation and Resolution

`constants.BaseUrl` exposed the two feeder gateway roots (`https://alpha-mainnet.starknet.io`, `https://alpha-sepolia.starknet.io`).

The library has been JSON-RPC only since v7 and read this constant nowhere, so all it exported was a pair of urls about to stop answering. v11 is still in beta, which makes this the right window to drop it.

### RPC version (if applicable)

Not applicable — no RPC spec change.

## Usage related changes

- `constants.BaseUrl` is removed. Replacements, depending on the use: `provider.getDefaultNodeUrl(constants.NetworkName.SN_MAIN)` (or `new RpcProvider({ nodeUrl: constants.NetworkName.SN_MAIN })`) to let the library pick a public RPC node, or your own node's RPC url passed to `RpcProvider`.
- `constants.NetworkName` and `RPC_DEFAULT_NODES` are untouched.
- Documented as breaking change 11 in the *Migrate from v10 to v11* guide, plus a row in its quick summary table.

## Development related changes

- None. No internal consumer existed, so no test or CI change was needed.

## Checklist:

- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Documented the changes in code (API docs will be generated automatically)
- [x] All tests are passing
