### PR TITLE
docs: document every member of the Cairo data type classes

### DIFF
--- a/src/utils/cairoDataTypes/felt.ts
+++ b/src/utils/cairoDataTypes/felt.ts
@@ -14,19 +14,60 @@ import assert from '../assert';
 import { addCompiledFlag } from '../helpers';
 
 /**
- * felt252 is the basic field element used in Cairo.
- * It corresponds to an integer in the range 0 ≤ x < P where P is a very large prime number currently equal to 2^251 + 17⋅2^192 + 1.
- * Any operation that uses felt252 will be computed modulo P.
- * 63 hex symbols (31 bytes + 4 bits), 252 bits
+ * A Cairo `core::felt252` : the basic field element, an integer in [0, P).
+ *
+ * P is the prime 2^251 + 17⋅2^192 + 1, so a felt252 is 252 bits — 63 hex symbols, or 31 bytes plus
+ * 4 bits. Every operation Cairo performs on a felt252 is computed modulo P.
+ *
+ * A string is read the way calldata reads it : `'0x3039'` as a hexadecimal number, `'12345'` as a
+ * decimal one, anything else as UTF-8 text. Unlike `CairoBytes31` and `CairoByteArray` this class
+ * has no door reserved for text, so a string that spells a number is always read as that number.
+ * @example
+ * ```typescript
+ * // the same five characters, read two ways
+ * new CairoFelt252('12345').toBigInt(); // 12345n         the number 12345
+ * new CairoFelt252('Hello').toBigInt(); // 310939249775n  the text, as UTF-8 bytes
+ * ```
  */
 export class CairoFelt252 {
   /**
-   * byte representation of the felt252
+   * The bytes of the value, big-endian and without leading zeros.
+   *
+   * The length is that of the value, not a fixed width : a felt252 holding 0 is one byte, and one
+   * holding `'Hello'` is five. Nothing here records how wide the input was written.
+   * @example
+   * ```typescript
+   * const result = new CairoFelt252('Hello').data.length;
+   * // result = 5
+   * const result2 = new CairoFelt252(0).data.length;
+   * // result2 = 1     (the single byte 0x00)
+   * ```
    */
   data: Uint8Array;
 
+  /**
+   * The abi type this class serializes.
+   * @example
+   * ```typescript
+   * const result = CairoFelt252.abiSelector;
+   * // result = "core::felt252"
+   * ```
+   */
   static abiSelector = 'core::felt252' as const;
 
+  /**
+   * Build from a number, a string or a boolean, refusing anything outside [0, P).
+   *
+   * The bytes are stored without their leading zeros, so `'0x0041'` and `'0x41'` give the same
+   * felt252. A boolean is carried as 1 or 0.
+   * @param {BigNumberish | boolean} data the value to carry, within [0, P)
+   * @throws {Error} when the value is null, undefined, of an unread type, or outside [0, P)
+   * @example
+   * ```typescript
+   * const result = new CairoFelt252('Hello').toApiRequest();
+   * // result = ["310939249775"]
+   * ```
+   */
   constructor(data: BigNumberish | boolean | unknown) {
     CairoFelt252.validate(data);
     const processedData = CairoFelt252.__processData(data as BigNumberish | boolean);
@@ -34,6 +75,22 @@ export class CairoFelt252 {
     this.data = processedData.subarray(processedData.findIndex((x) => x > 0));
   }
 
+  /**
+   * Turn an accepted input into its bytes, before the constructor strips their leading zeros.
+   *
+   * The range is not checked here : `validate` is what reads these bytes and decides. Only the
+   * type is, and an input this class does not read raises rather than coming back.
+   * @param {BigNumberish | boolean} data the value to convert
+   * @returns {Uint8Array} the bytes of the value, of whatever length it implies
+   * @throws {Error} when the input is neither a string, an integer, a bigint nor a boolean
+   * @example
+   * ```typescript
+   * const result = CairoFelt252.__processData('Hello').length;
+   * // result = 5
+   * CairoFelt252.__processData(1.5);
+   * // throws Error("1.5 can't be computed by felt()")
+   * ```
+   */
   static __processData(data: BigNumberish | boolean): Uint8Array {
     if (isString(data)) {
       return stringToUint8Array(data);
@@ -50,29 +107,100 @@ export class CairoFelt252 {
     throw new Error(`${data} can't be computed by felt()`);
   }
 
+  /**
+   * The bytes read as one big-endian number.
+   * @returns {bigint} the value this felt252 holds
+   * @example
+   * ```typescript
+   * const result = new CairoFelt252('Hello').toBigInt();
+   * // result = 310939249775n
+   * ```
+   */
   toBigInt() {
     return uint8ArrayToBigInt(this.data);
   }
 
+  /**
+   * Read the bytes back as UTF-8 text.
+   *
+   * Only a value that was text to begin with comes back as readable text : the bytes of a number
+   * are decoded all the same, and what they spell is rarely what was meant.
+   * @returns {string} the bytes decoded as UTF-8
+   * @example
+   * ```typescript
+   * const result = new CairoFelt252('Hello').decodeUtf8();
+   * // result = "Hello"
+   * const result2 = new CairoFelt252('12345').decodeUtf8();
+   * // result2 = "09"    (the number 12345 is the two bytes 0x30 0x39)
+   * ```
+   */
   decodeUtf8() {
     return new TextDecoder().decode(this.data);
   }
 
+  /**
+   * The value in hexadecimal, without padding.
+   * @returns {string} the value as a 0x-prefixed hex string
+   * @example
+   * ```typescript
+   * const result = new CairoFelt252('Hello').toHexString();
+   * // result = "0x48656c6c6f"
+   * const result2 = new CairoFelt252(0).toHexString();
+   * // result2 = "0x0"     (one digit, not "0x00")
+   * ```
+   */
   toHexString() {
     return addHexPrefix(this.toBigInt().toString(16));
   }
 
+  /**
+   * Serialize to the single felt a contract call carries.
+   * @returns {string[]} one decimal-string felt, flagged as compiled
+   * @example
+   * ```typescript
+   * const result = new CairoFelt252('Hello').toApiRequest();
+   * // result = ["310939249775"]
+   * ```
+   */
   toApiRequest(): string[] {
-    /**
-     * HexString representation of the felt252
-     */
     return addCompiledFlag([BigInt(this.toHexString()).toString()]);
   }
 
+  /**
+   * Throw unless a number falls in the felt252 range [0, P).
+   *
+   * This takes the number itself, where {@link CairoFelt252.validate} takes whatever a caller
+   * hands over. P is excluded : the largest felt252 is P - 1.
+   * @param {bigint} val the number to check
+   * @throws {Error} when the number is negative or greater than or equal to P
+   * @example
+   * ```typescript
+   * CairoFelt252.assertRange(0n); // passes
+   * CairoFelt252.assertRange(-1n);
+   * // throws Error("Value -1 is out of felt252 range [0, 3618502788666131213697322783095070105623107215331596699973092056135872020481)")
+   * ```
+   */
   static assertRange(val: bigint): void {
     assert(val >= 0n && val < PRIME, `Value ${val} is out of felt252 range [0, ${PRIME})`);
   }
 
+  /**
+   * Throw unless the value can be carried by a felt252.
+   *
+   * Null, undefined and any type this class does not read are refused first, each with its own
+   * message, then the value is converted and its range checked. A negative number does not reach
+   * that range check : converting it fails earlier, and the message comes from the conversion.
+   * @param {BigNumberish | boolean} data the value to check
+   * @throws {Error} when the value is null, undefined, of an unread type, or outside [0, P)
+   * @example
+   * ```typescript
+   * CairoFelt252.validate('Hello'); // passes
+   * CairoFelt252.validate({});
+   * // throws Error("Unsupported data type 'object' for felt252. Expected string, number, bigint, or boolean")
+   * CairoFelt252.validate(-1);
+   * // throws Error("Cannot convert negative bigint -1 to Uint8Array")
+   * ```
+   */
   static validate(data: BigNumberish | boolean | unknown): void {
     assert(data !== null, 'null value is not allowed for felt252');
     assert(data !== undefined, 'undefined value is not allowed for felt252');
@@ -86,6 +214,21 @@ export class CairoFelt252 {
     CairoFelt252.assertRange(bn);
   }
 
+  /**
+   * Can this value be carried by a felt252?
+   *
+   * The non-throwing form of {@link CairoFelt252.validate}, so it answers false for every input
+   * that one refuses, whatever the reason.
+   * @param {BigNumberish | boolean} data the value to test
+   * @returns {boolean} true when the value fits in a felt252
+   * @example
+   * ```typescript
+   * const result = CairoFelt252.is('Hello');
+   * // result = true
+   * const result2 = CairoFelt252.is(-1);
+   * // result2 = false
+   * ```
+   */
   static is(data: BigNumberish | boolean | unknown): boolean {
     try {
       CairoFelt252.validate(data);
@@ -95,14 +238,37 @@ export class CairoFelt252 {
     }
   }
 
+  /**
+   * Is this abi type the one this class serializes?
+   * @param {string} abiType the abi type to test
+   * @returns {boolean} true for `core::felt252`
+   * @example
+   * ```typescript
+   * const result = CairoFelt252.isAbiType('core::felt252');
+   * // result = true
+   * const result2 = CairoFelt252.isAbiType('core::integer::u8');
+   * // result2 = false
+   * ```
+   */
   static isAbiType(abiType: string): boolean {
     return abiType === CairoFelt252.abiSelector;
   }
 
+  /**
+   * Read one felt252 off a contract response, advancing the iterator past it.
+   *
+   * The felts a node returns are hex strings, and one is consumed per call, so successive calls
+   * read successive return values.
+   * @param {Iterator<string>} responseIterator the response felts, positioned on this felt252
+   * @returns {CairoFelt252} the felt252 that was read
+   * @example
+   * ```typescript
+   * const response = ['0x48656c6c6f'];
+   * const result = CairoFelt252.factoryFromApiResponse(response.values()).decodeUtf8();
+   * // result = "Hello"
+   * ```
+   */
   static factoryFromApiResponse(responseIterator: Iterator<string>): CairoFelt252 {
-    /**
-     * The API response is HexString
-     */
     return new CairoFelt252(getNext(responseIterator));
   }
 }

--- a/src/utils/cairoDataTypes/fixedArray.ts
+++ b/src/utils/cairoDataTypes/fixedArray.ts
@@ -1,16 +1,60 @@
 import assert from '../assert';
 
+/**
+ * A Cairo fixed array : a known number of items, all of the same type.
+ *
+ * Its abi type is written `[itemType; length]`, and both halves matter — the length is part of the
+ * type, so an array of the wrong size is refused rather than padded or cut. Unlike the other classes
+ * here this one does not serialize itself : {@link CairoFixedArray.compile} turns it into the struct
+ * `CallData.compile` expects, where each index is a key.
+ * @example
+ * ```typescript
+ * const fArray = new CairoFixedArray([10, 20, 30], '[core::integer::u32; 3]');
+ * const result = fArray.compile();
+ * // result = { '0': 10, '1': 20, '2': 30 }
+ * ```
+ */
 export class CairoFixedArray {
   /**
    * JS array representing a Cairo fixed array.
+   * @example
+   * ```typescript
+   * const result = new CairoFixedArray([10, 20, 30], '[core::integer::u32; 3]').content;
+   * // result = [10, 20, 30]
+   * ```
    */
   public readonly content: any[];
 
   /**
    * Cairo fixed array type.
+   * @example
+   * ```typescript
+   * const result = new CairoFixedArray([10, 20, 30], '[core::integer::u32; 3]').arrayType;
+   * // result = "[core::integer::u32; 3]"
+   * ```
    */
   public readonly arrayType: string;
 
+  /**
+   * Split a `[itemType; length]` type into its two halves, or say it is not one.
+   *
+   * The separator is the **last** `'; '` of the string, so a fixed array of fixed arrays splits on
+   * its outer level and its inner type comes back whole. A type that is not bracketed, that has no
+   * item type, or whose length is not made of digits is not one : `undefined` comes back, and it is
+   * the callers that decide whether to raise.
+   * @param {string} type the abi type to split
+   * @returns {{itemType: string, size: string} | undefined} the two halves, or undefined
+   * @example
+   * ```typescript
+   * // called from within the class
+   * CairoFixedArray.parseFixedArrayType('[core::integer::u32; 8]');
+   * // { itemType: 'core::integer::u32', size: '8' }
+   * CairoFixedArray.parseFixedArrayType('[[core::integer::u8; 2]; 3]');
+   * // { itemType: '[core::integer::u8; 2]', size: '3' }     the inner array, kept whole
+   * CairoFixedArray.parseFixedArrayType('core::integer::u32');
+   * // undefined
+   * ```
+   */
   private static parseFixedArrayType(type: string) {
     if (!type.startsWith('[') || !type.endsWith(']')) {
       return undefined;
@@ -33,8 +77,19 @@ export class CairoFixedArray {
 
   /**
    * Create an instance representing a Cairo fixed Array.
+   *
+   * The type is checked first, then the item count against the length the type declares : an array
+   * whose size does not match is refused, since that size is part of the type.
    * @param {any[]} content JS array representing a Cairo fixed array.
    * @param {string} arrayType Cairo fixed array type.
+   * @throws {Error} when the type is not a `[type; length]`, or when the item count does not match
+   * @example
+   * ```typescript
+   * const result = new CairoFixedArray([10, 20, 30], '[core::integer::u32; 3]').content;
+   * // result = [10, 20, 30]
+   * new CairoFixedArray([10, 20], '[core::integer::u32; 3]');
+   * // throws Error("The ABI type [core::integer::u32; 3] is expecting 3 items. 2 items provided.")
+   * ```
    */
   constructor(content: any[], arrayType: string) {
     assert(
@@ -167,12 +222,13 @@ export class CairoFixedArray {
   /**
    * Checks if the given Cairo type is a fixed-array type.
    * structure: [string; number]
-   *
    * @param {string} type - The type to check.
-   * @returns - `true` if the type is a fixed array type, `false` otherwise.
+   * @returns {boolean} `true` if the type is a fixed array type, `false` otherwise.
+   * @example
    * ```typescript
    * const result = CairoFixedArray.isTypeFixedArray("[core::integer::u32; 8]");
    * // result = true
+   * ```
    */
   static isTypeFixedArray(type: string) {
     return CairoFixedArray.parseFixedArrayType(type) !== undefined;

--- a/src/utils/cairoDataTypes/int128.ts
+++ b/src/utils/cairoDataTypes/int128.ts
@@ -8,16 +8,80 @@ import assert from '../assert';
 import { RANGE_I128, PRIME } from '../../global/constants';
 import { addCompiledFlag } from '../helpers';
 
+/**
+ * A Cairo `core::integer::i128` : a whole number in [-170141183460469231731687303715884105728, 170141183460469231731687303715884105727], carried in one felt252.
+ *
+ * The value is kept as a bigint, so the shape of the input does not survive — `129445976596022050476432668810952994672`,
+ * `'129445976596022050476432668810952994672'` and `'0x6162636465666768696a6b6c6d6e6f70'` give the same i128. A string that reads as text rather than as a
+ * number is taken for its UTF-8 bytes, which is why `'abcdefghijklmnop'` is 129445976596022050476432668810952994672 and not a rejected input.
+ *
+ * An already built instance is **not** an accepted input : handed back to the constructor it is
+ * seen as an object and refused. Inside the library it is `unwrapCairoScalar` that reduces an
+ * instance to its number before an abi slot receives it.
+ * @example
+ * ```typescript
+ * // the same value, reached four ways
+ * new CairoInt128(129445976596022050476432668810952994672).toBigInt(); //     129445976596022050476432668810952994672n
+ * new CairoInt128('129445976596022050476432668810952994672').toBigInt(); //   129445976596022050476432668810952994672n
+ * new CairoInt128('0x6162636465666768696a6b6c6d6e6f70').toBigInt(); // 129445976596022050476432668810952994672n
+ * new CairoInt128('abcdefghijklmnop').toBigInt(); //    129445976596022050476432668810952994672n     the UTF-8 bytes of the text
+ * ```
+ */
 export class CairoInt128 {
+  /**
+   * The value, always as a bigint.
+   * @example
+   * ```typescript
+   * const result = new CairoInt128('0x6162636465666768696a6b6c6d6e6f70').data;
+   * // result = 129445976596022050476432668810952994672n
+   * ```
+   */
   data: bigint;
 
+  /**
+   * The abi type this class serializes.
+   * @example
+   * ```typescript
+   * const result = CairoInt128.abiSelector;
+   * // result = "core::integer::i128"
+   * ```
+   */
   static abiSelector = 'core::integer::i128';
 
+  /**
+   * Build from a number, a string or a boolean, refusing anything out of the i128 range.
+   *
+   * A string is read as a number when it spells one — decimal or hexadecimal — and as UTF-8 text
+   * otherwise. Text therefore only fits here up to 16 ASCII characters : one more already
+   * makes a number past 170141183460469231731687303715884105727.
+   * @param {BigNumberish | boolean} data the value to carry, within [-170141183460469231731687303715884105728, 170141183460469231731687303715884105727]
+   * @throws {Error} when the value is null, undefined, an object, a decimal number, or out of range
+   * @example
+   * ```typescript
+   * const result = new CairoInt128('abcdefghijklmnop').toApiRequest();
+   * // result = ["129445976596022050476432668810952994672"]
+   * ```
+   */
   constructor(data: BigNumberish | boolean | unknown) {
     CairoInt128.validate(data);
     this.data = CairoInt128.__processData(data);
   }
 
+  /**
+   * Turn an accepted input into its number, before the range is checked.
+   *
+   * Nothing here refuses a value : `validate` is what reads this number and decides. So an input
+   * far outside the i128 range comes back untouched rather than raising.
+   * @param {BigNumberish | boolean} data the value to convert
+   * @returns {bigint} the number the input spells, of whatever size
+   * @example
+   * ```typescript
+   * const result = CairoInt128.__processData('abcdefghijklmnop');
+   * // result = 129445976596022050476432668810952994672n
+   * const result2 = CairoInt128.__processData('abcdefghijklmnopq');
+   * // result2 = 33138170008581644921966763215603966636145n     (past the i128 range, and returned all the same)
+   * ```
+   */
   static __processData(data: BigNumberish | boolean | unknown): bigint {
     if (isString(data) && isText(data)) {
       // Only allow text strings that represent valid UTF-8 byte sequences for specific use cases
@@ -28,14 +92,51 @@ export class CairoInt128 {
     return BigInt(data as BigNumberish);
   }
 
+  /**
+   * Serialize to the single felt a contract call carries.
+   *
+   * A negative value goes out as its field element, `PRIME + value`, which is what Cairo reads
+   * back as the negative number.
+   * @returns {string[]} one decimal-string felt, flagged as compiled
+   * @example
+   * ```typescript
+   * const result = new CairoInt128(5000000000).toApiRequest();
+   * // result = ["5000000000"]
+   * const result2 = new CairoInt128(-5000000000).toApiRequest();
+   * // result2 = ["3618502788666131213697322783095070105623107215331596699973092056130872020481"]
+   * ```
+   */
   toApiRequest(): string[] {
     return addCompiledFlag([BigInt(this.toHexString()).toString()]);
   }
 
+  /**
+   * The value as a number.
+   * @returns {bigint} the number this i128 holds, negative included
+   * @example
+   * ```typescript
+   * const result = new CairoInt128(-5000000000).toBigInt();
+   * // result = -5000000000n
+   * ```
+   */
   toBigInt() {
     return this.data;
   }
 
+  /**
+   * Read the value back as the UTF-8 text its bytes spell.
+   *
+   * Only a value that was text to begin with comes back as readable text. Any other number is
+   * decoded all the same, and what it gives is whatever its bytes happen to mean — a
+   * negative value is first wrapped to its two's complement, which rarely spells valid UTF-8 and
+   * so comes back as replacement characters.
+   * @returns {string} the bytes decoded as UTF-8
+   * @example
+   * ```typescript
+   * const result = new CairoInt128('abcdefghijklmnop').decodeUtf8();
+   * // result = "abcdefghijklmnop"
+   * ```
+   */
   decodeUtf8() {
     return new TextDecoder().decode(
       bigIntToUint8Array(this.data >= 0n ? this.data : 2n ** 128n + this.data)
@@ -43,8 +144,18 @@ export class CairoInt128 {
   }
 
   /**
-   * For negative values field element representation as positive hex string.
-   * @returns cairo field arithmetic hex string
+   * The value in hexadecimal, without padding.
+   *
+   * A negative value has no hexadecimal form of its own here : it is written as its field element,
+   * `PRIME + value`, the positive number Cairo actually carries.
+   * @returns {string} the number as a 0x-prefixed hex string
+   * @example
+   * ```typescript
+   * const result = new CairoInt128(5000000000).toHexString();
+   * // result = "0x12a05f200"
+   * const result2 = new CairoInt128(-5000000000).toHexString();
+   * // result2 = "0x800000000000010fffffffffffffffffffffffffffffffffffffffed5fa0e01"
+   * ```
    */
   toHexString() {
     const value = this.toBigInt();
@@ -56,6 +167,21 @@ export class CairoInt128 {
     return addHexPrefix(value.toString(16));
   }
 
+  /**
+   * Throw unless the value can be carried by an i128.
+   *
+   * Four things are refused, each with its own message : a null or undefined value, an object or
+   * an array, a number with a decimal part, and a value outside [-170141183460469231731687303715884105728, 170141183460469231731687303715884105727]. A text string reaches
+   * that last check as the number its bytes spell, so `'abcdefghijklmnopq'` is refused for being out of range.
+   * @param {BigNumberish | boolean} data the value to check
+   * @throws {Error} when the value is null, undefined, an object, a decimal number, or out of range
+   * @example
+   * ```typescript
+   * CairoInt128.validate(5000000000); // passes
+   * CairoInt128.validate(170141183460469231731687303715884105728);
+   * // throws Error("Value is out of i128 range [-170141183460469231731687303715884105728, 170141183460469231731687303715884105727]")
+   * ```
+   */
   static validate(data: BigNumberish | boolean | unknown): void {
     assert(data !== null && data !== undefined, 'Invalid input: null or undefined');
     assert(!isObject(data) && !Array.isArray(data), 'Invalid input: objects are not supported');
@@ -71,6 +197,21 @@ export class CairoInt128 {
     );
   }
 
+  /**
+   * Can this value be carried by an i128?
+   *
+   * The non-throwing form of {@link CairoInt128.validate}, so it answers false for every input that
+   * one refuses, whatever the reason.
+   * @param {BigNumberish | boolean} data the value to test
+   * @returns {boolean} true when the value fits in an i128
+   * @example
+   * ```typescript
+   * const result = CairoInt128.is('abcdefghijklmnop');
+   * // result = true     (129445976596022050476432668810952994672, the UTF-8 bytes of the text)
+   * const result2 = CairoInt128.is('abcdefghijklmnopq');
+   * // result2 = false   (33138170008581644921966763215603966636145, past the i128 range)
+   * ```
+   */
   static is(data: BigNumberish | boolean | unknown): boolean {
     try {
       CairoInt128.validate(data);
@@ -81,12 +222,36 @@ export class CairoInt128 {
   }
 
   /**
-   * Check if provided abi type is this data type
+   * Is this abi type the one this class serializes?
+   * @param {string} abiType the abi type to test
+   * @returns {boolean} true for `core::integer::i128`
+   * @example
+   * ```typescript
+   * const result = CairoInt128.isAbiType('core::integer::i128');
+   * // result = true
+   * const result2 = CairoInt128.isAbiType('core::felt252');
+   * // result2 = false
+   * ```
    */
   static isAbiType(abiType: string): boolean {
     return abiType === CairoInt128.abiSelector;
   }
 
+  /**
+   * Read one i128 off a contract response, advancing the iterator past it.
+   *
+   * The felts a node returns are hex strings, and one is consumed per call, so successive calls
+   * read successive return values. A felt past half the prime is a negative number
+   * written as its field element, and is brought back below zero here.
+   * @param {Iterator<string>} responseIterator the response felts, positioned on this i128
+   * @returns {CairoInt128} the i128 that was read
+   * @example
+   * ```typescript
+   * const response = ['0x12a05f200'];
+   * const result = CairoInt128.factoryFromApiResponse(response.values()).toBigInt();
+   * // result = 5000000000n
+   * ```
+   */
   static factoryFromApiResponse(responseIterator: Iterator<string>): CairoInt128 {
     const response = getNext(responseIterator);
     const value = BigInt(response);

--- a/src/utils/cairoDataTypes/int16.ts
+++ b/src/utils/cairoDataTypes/int16.ts
@@ -8,16 +8,80 @@ import assert from '../assert';
 import { RANGE_I16, PRIME } from '../../global/constants';
 import { addCompiledFlag } from '../helpers';
 
+/**
+ * A Cairo `core::integer::i16` : a whole number in [-32768, 32767], carried in one felt252.
+ *
+ * The value is kept as a bigint, so the shape of the input does not survive — `24930`,
+ * `'24930'` and `'0x6162'` give the same i16. A string that reads as text rather than as a
+ * number is taken for its UTF-8 bytes, which is why `'ab'` is 24930 and not a rejected input.
+ *
+ * An already built instance is **not** an accepted input : handed back to the constructor it is
+ * seen as an object and refused. Inside the library it is `unwrapCairoScalar` that reduces an
+ * instance to its number before an abi slot receives it.
+ * @example
+ * ```typescript
+ * // the same value, reached four ways
+ * new CairoInt16(24930).toBigInt(); //     24930n
+ * new CairoInt16('24930').toBigInt(); //   24930n
+ * new CairoInt16('0x6162').toBigInt(); // 24930n
+ * new CairoInt16('ab').toBigInt(); //    24930n     the UTF-8 bytes of the text
+ * ```
+ */
 export class CairoInt16 {
+  /**
+   * The value, always as a bigint.
+   * @example
+   * ```typescript
+   * const result = new CairoInt16('0x6162').data;
+   * // result = 24930n
+   * ```
+   */
   data: bigint;
 
+  /**
+   * The abi type this class serializes.
+   * @example
+   * ```typescript
+   * const result = CairoInt16.abiSelector;
+   * // result = "core::integer::i16"
+   * ```
+   */
   static abiSelector = 'core::integer::i16';
 
+  /**
+   * Build from a number, a string or a boolean, refusing anything out of the i16 range.
+   *
+   * A string is read as a number when it spells one — decimal or hexadecimal — and as UTF-8 text
+   * otherwise. Text therefore only fits here up to 2 ASCII characters : one more already
+   * makes a number past 32767.
+   * @param {BigNumberish | boolean} data the value to carry, within [-32768, 32767]
+   * @throws {Error} when the value is null, undefined, an object, a decimal number, or out of range
+   * @example
+   * ```typescript
+   * const result = new CairoInt16('ab').toApiRequest();
+   * // result = ["24930"]
+   * ```
+   */
   constructor(data: BigNumberish | boolean | unknown) {
     CairoInt16.validate(data);
     this.data = CairoInt16.__processData(data);
   }
 
+  /**
+   * Turn an accepted input into its number, before the range is checked.
+   *
+   * Nothing here refuses a value : `validate` is what reads this number and decides. So an input
+   * far outside the i16 range comes back untouched rather than raising.
+   * @param {BigNumberish | boolean} data the value to convert
+   * @returns {bigint} the number the input spells, of whatever size
+   * @example
+   * ```typescript
+   * const result = CairoInt16.__processData('ab');
+   * // result = 24930n
+   * const result2 = CairoInt16.__processData('abc');
+   * // result2 = 6382179n     (past the i16 range, and returned all the same)
+   * ```
+   */
   static __processData(data: BigNumberish | boolean | unknown): bigint {
     if (isString(data) && isText(data)) {
       // Only allow text strings that represent valid UTF-8 byte sequences for specific use cases
@@ -28,14 +92,51 @@ export class CairoInt16 {
     return BigInt(data as BigNumberish);
   }
 
+  /**
+   * Serialize to the single felt a contract call carries.
+   *
+   * A negative value goes out as its field element, `PRIME + value`, which is what Cairo reads
+   * back as the negative number.
+   * @returns {string[]} one decimal-string felt, flagged as compiled
+   * @example
+   * ```typescript
+   * const result = new CairoInt16(300).toApiRequest();
+   * // result = ["300"]
+   * const result2 = new CairoInt16(-300).toApiRequest();
+   * // result2 = ["3618502788666131213697322783095070105623107215331596699973092056135872020181"]
+   * ```
+   */
   toApiRequest(): string[] {
     return addCompiledFlag([BigInt(this.toHexString()).toString()]);
   }
 
+  /**
+   * The value as a number.
+   * @returns {bigint} the number this i16 holds, negative included
+   * @example
+   * ```typescript
+   * const result = new CairoInt16(-300).toBigInt();
+   * // result = -300n
+   * ```
+   */
   toBigInt() {
     return this.data;
   }
 
+  /**
+   * Read the value back as the UTF-8 text its bytes spell.
+   *
+   * Only a value that was text to begin with comes back as readable text. Any other number is
+   * decoded all the same, and what it gives is whatever its bytes happen to mean — a
+   * negative value is first wrapped to its two's complement, which rarely spells valid UTF-8 and
+   * so comes back as replacement characters.
+   * @returns {string} the bytes decoded as UTF-8
+   * @example
+   * ```typescript
+   * const result = new CairoInt16('ab').decodeUtf8();
+   * // result = "ab"
+   * ```
+   */
   decodeUtf8() {
     return new TextDecoder().decode(
       bigIntToUint8Array(this.data >= 0n ? this.data : 65536n + this.data)
@@ -43,8 +144,18 @@ export class CairoInt16 {
   }
 
   /**
-   * For negative values field element representation as positive hex string.
-   * @returns cairo field arithmetic hex string
+   * The value in hexadecimal, without padding.
+   *
+   * A negative value has no hexadecimal form of its own here : it is written as its field element,
+   * `PRIME + value`, the positive number Cairo actually carries.
+   * @returns {string} the number as a 0x-prefixed hex string
+   * @example
+   * ```typescript
+   * const result = new CairoInt16(300).toHexString();
+   * // result = "0x12c"
+   * const result2 = new CairoInt16(-300).toHexString();
+   * // result2 = "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffed5"
+   * ```
    */
   toHexString() {
     const value = this.toBigInt();
@@ -56,6 +167,21 @@ export class CairoInt16 {
     return addHexPrefix(value.toString(16));
   }
 
+  /**
+   * Throw unless the value can be carried by an i16.
+   *
+   * Four things are refused, each with its own message : a null or undefined value, an object or
+   * an array, a number with a decimal part, and a value outside [-32768, 32767]. A text string reaches
+   * that last check as the number its bytes spell, so `'abc'` is refused for being out of range.
+   * @param {BigNumberish | boolean} data the value to check
+   * @throws {Error} when the value is null, undefined, an object, a decimal number, or out of range
+   * @example
+   * ```typescript
+   * CairoInt16.validate(300); // passes
+   * CairoInt16.validate(32768);
+   * // throws Error("Value is out of i16 range [-32768, 32767]")
+   * ```
+   */
   static validate(data: BigNumberish | boolean | unknown): void {
     assert(data !== null && data !== undefined, 'Invalid input: null or undefined');
     assert(!isObject(data) && !Array.isArray(data), 'Invalid input: objects are not supported');
@@ -71,6 +197,21 @@ export class CairoInt16 {
     );
   }
 
+  /**
+   * Can this value be carried by an i16?
+   *
+   * The non-throwing form of {@link CairoInt16.validate}, so it answers false for every input that
+   * one refuses, whatever the reason.
+   * @param {BigNumberish | boolean} data the value to test
+   * @returns {boolean} true when the value fits in an i16
+   * @example
+   * ```typescript
+   * const result = CairoInt16.is('ab');
+   * // result = true     (24930, the UTF-8 bytes of the text)
+   * const result2 = CairoInt16.is('abc');
+   * // result2 = false   (6382179, past the i16 range)
+   * ```
+   */
   static is(data: BigNumberish | boolean | unknown): boolean {
     try {
       CairoInt16.validate(data);
@@ -81,12 +222,36 @@ export class CairoInt16 {
   }
 
   /**
-   * Check if provided abi type is this data type
+   * Is this abi type the one this class serializes?
+   * @param {string} abiType the abi type to test
+   * @returns {boolean} true for `core::integer::i16`
+   * @example
+   * ```typescript
+   * const result = CairoInt16.isAbiType('core::integer::i16');
+   * // result = true
+   * const result2 = CairoInt16.isAbiType('core::felt252');
+   * // result2 = false
+   * ```
    */
   static isAbiType(abiType: string): boolean {
     return abiType === CairoInt16.abiSelector;
   }
 
+  /**
+   * Read one i16 off a contract response, advancing the iterator past it.
+   *
+   * The felts a node returns are hex strings, and one is consumed per call, so successive calls
+   * read successive return values. A felt past half the prime is a negative number
+   * written as its field element, and is brought back below zero here.
+   * @param {Iterator<string>} responseIterator the response felts, positioned on this i16
+   * @returns {CairoInt16} the i16 that was read
+   * @example
+   * ```typescript
+   * const response = ['0x12c'];
+   * const result = CairoInt16.factoryFromApiResponse(response.values()).toBigInt();
+   * // result = 300n
+   * ```
+   */
   static factoryFromApiResponse(responseIterator: Iterator<string>): CairoInt16 {
     const response = getNext(responseIterator);
     const value = BigInt(response);

--- a/src/utils/cairoDataTypes/int32.ts
+++ b/src/utils/cairoDataTypes/int32.ts
@@ -8,16 +8,80 @@ import assert from '../assert';
 import { RANGE_I32, PRIME } from '../../global/constants';
 import { addCompiledFlag } from '../helpers';
 
+/**
+ * A Cairo `core::integer::i32` : a whole number in [-2147483648, 2147483647], carried in one felt252.
+ *
+ * The value is kept as a bigint, so the shape of the input does not survive — `1633837924`,
+ * `'1633837924'` and `'0x61626364'` give the same i32. A string that reads as text rather than as a
+ * number is taken for its UTF-8 bytes, which is why `'abcd'` is 1633837924 and not a rejected input.
+ *
+ * An already built instance is **not** an accepted input : handed back to the constructor it is
+ * seen as an object and refused. Inside the library it is `unwrapCairoScalar` that reduces an
+ * instance to its number before an abi slot receives it.
+ * @example
+ * ```typescript
+ * // the same value, reached four ways
+ * new CairoInt32(1633837924).toBigInt(); //     1633837924n
+ * new CairoInt32('1633837924').toBigInt(); //   1633837924n
+ * new CairoInt32('0x61626364').toBigInt(); // 1633837924n
+ * new CairoInt32('abcd').toBigInt(); //    1633837924n     the UTF-8 bytes of the text
+ * ```
+ */
 export class CairoInt32 {
+  /**
+   * The value, always as a bigint.
+   * @example
+   * ```typescript
+   * const result = new CairoInt32('0x61626364').data;
+   * // result = 1633837924n
+   * ```
+   */
   data: bigint;
 
+  /**
+   * The abi type this class serializes.
+   * @example
+   * ```typescript
+   * const result = CairoInt32.abiSelector;
+   * // result = "core::integer::i32"
+   * ```
+   */
   static abiSelector = 'core::integer::i32';
 
+  /**
+   * Build from a number, a string or a boolean, refusing anything out of the i32 range.
+   *
+   * A string is read as a number when it spells one — decimal or hexadecimal — and as UTF-8 text
+   * otherwise. Text therefore only fits here up to 4 ASCII characters : one more already
+   * makes a number past 2147483647.
+   * @param {BigNumberish | boolean} data the value to carry, within [-2147483648, 2147483647]
+   * @throws {Error} when the value is null, undefined, an object, a decimal number, or out of range
+   * @example
+   * ```typescript
+   * const result = new CairoInt32('abcd').toApiRequest();
+   * // result = ["1633837924"]
+   * ```
+   */
   constructor(data: BigNumberish | boolean | unknown) {
     CairoInt32.validate(data);
     this.data = CairoInt32.__processData(data);
   }
 
+  /**
+   * Turn an accepted input into its number, before the range is checked.
+   *
+   * Nothing here refuses a value : `validate` is what reads this number and decides. So an input
+   * far outside the i32 range comes back untouched rather than raising.
+   * @param {BigNumberish | boolean} data the value to convert
+   * @returns {bigint} the number the input spells, of whatever size
+   * @example
+   * ```typescript
+   * const result = CairoInt32.__processData('abcd');
+   * // result = 1633837924n
+   * const result2 = CairoInt32.__processData('abcde');
+   * // result2 = 418262508645n     (past the i32 range, and returned all the same)
+   * ```
+   */
   static __processData(data: BigNumberish | boolean | unknown): bigint {
     if (isString(data) && isText(data)) {
       // Only allow text strings that represent valid UTF-8 byte sequences for specific use cases
@@ -28,14 +92,51 @@ export class CairoInt32 {
     return BigInt(data as BigNumberish);
   }
 
+  /**
+   * Serialize to the single felt a contract call carries.
+   *
+   * A negative value goes out as its field element, `PRIME + value`, which is what Cairo reads
+   * back as the negative number.
+   * @returns {string[]} one decimal-string felt, flagged as compiled
+   * @example
+   * ```typescript
+   * const result = new CairoInt32(70000).toApiRequest();
+   * // result = ["70000"]
+   * const result2 = new CairoInt32(-70000).toApiRequest();
+   * // result2 = ["3618502788666131213697322783095070105623107215331596699973092056135871950481"]
+   * ```
+   */
   toApiRequest(): string[] {
     return addCompiledFlag([BigInt(this.toHexString()).toString()]);
   }
 
+  /**
+   * The value as a number.
+   * @returns {bigint} the number this i32 holds, negative included
+   * @example
+   * ```typescript
+   * const result = new CairoInt32(-70000).toBigInt();
+   * // result = -70000n
+   * ```
+   */
   toBigInt() {
     return this.data;
   }
 
+  /**
+   * Read the value back as the UTF-8 text its bytes spell.
+   *
+   * Only a value that was text to begin with comes back as readable text. Any other number is
+   * decoded all the same, and what it gives is whatever its bytes happen to mean — a
+   * negative value is first wrapped to its two's complement, which rarely spells valid UTF-8 and
+   * so comes back as replacement characters.
+   * @returns {string} the bytes decoded as UTF-8
+   * @example
+   * ```typescript
+   * const result = new CairoInt32('abcd').decodeUtf8();
+   * // result = "abcd"
+   * ```
+   */
   decodeUtf8() {
     return new TextDecoder().decode(
       bigIntToUint8Array(this.data >= 0n ? this.data : 4294967296n + this.data)
@@ -43,8 +144,18 @@ export class CairoInt32 {
   }
 
   /**
-   * For negative values field element representation as positive hex string.
-   * @returns cairo field arithmetic hex string
+   * The value in hexadecimal, without padding.
+   *
+   * A negative value has no hexadecimal form of its own here : it is written as its field element,
+   * `PRIME + value`, the positive number Cairo actually carries.
+   * @returns {string} the number as a 0x-prefixed hex string
+   * @example
+   * ```typescript
+   * const result = new CairoInt32(70000).toHexString();
+   * // result = "0x11170"
+   * const result2 = new CairoInt32(-70000).toHexString();
+   * // result2 = "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffeee91"
+   * ```
    */
   toHexString() {
     const value = this.toBigInt();
@@ -56,6 +167,21 @@ export class CairoInt32 {
     return addHexPrefix(value.toString(16));
   }
 
+  /**
+   * Throw unless the value can be carried by an i32.
+   *
+   * Four things are refused, each with its own message : a null or undefined value, an object or
+   * an array, a number with a decimal part, and a value outside [-2147483648, 2147483647]. A text string reaches
+   * that last check as the number its bytes spell, so `'abcde'` is refused for being out of range.
+   * @param {BigNumberish | boolean} data the value to check
+   * @throws {Error} when the value is null, undefined, an object, a decimal number, or out of range
+   * @example
+   * ```typescript
+   * CairoInt32.validate(70000); // passes
+   * CairoInt32.validate(2147483648);
+   * // throws Error("Value is out of i32 range [-2147483648, 2147483647]")
+   * ```
+   */
   static validate(data: BigNumberish | boolean | unknown): void {
     assert(data !== null && data !== undefined, 'Invalid input: null or undefined');
     assert(!isObject(data) && !Array.isArray(data), 'Invalid input: objects are not supported');
@@ -71,6 +197,21 @@ export class CairoInt32 {
     );
   }
 
+  /**
+   * Can this value be carried by an i32?
+   *
+   * The non-throwing form of {@link CairoInt32.validate}, so it answers false for every input that
+   * one refuses, whatever the reason.
+   * @param {BigNumberish | boolean} data the value to test
+   * @returns {boolean} true when the value fits in an i32
+   * @example
+   * ```typescript
+   * const result = CairoInt32.is('abcd');
+   * // result = true     (1633837924, the UTF-8 bytes of the text)
+   * const result2 = CairoInt32.is('abcde');
+   * // result2 = false   (418262508645, past the i32 range)
+   * ```
+   */
   static is(data: BigNumberish | boolean | unknown): boolean {
     try {
       CairoInt32.validate(data);
@@ -81,12 +222,36 @@ export class CairoInt32 {
   }
 
   /**
-   * Check if provided abi type is this data type
+   * Is this abi type the one this class serializes?
+   * @param {string} abiType the abi type to test
+   * @returns {boolean} true for `core::integer::i32`
+   * @example
+   * ```typescript
+   * const result = CairoInt32.isAbiType('core::integer::i32');
+   * // result = true
+   * const result2 = CairoInt32.isAbiType('core::felt252');
+   * // result2 = false
+   * ```
    */
   static isAbiType(abiType: string): boolean {
     return abiType === CairoInt32.abiSelector;
   }
 
+  /**
+   * Read one i32 off a contract response, advancing the iterator past it.
+   *
+   * The felts a node returns are hex strings, and one is consumed per call, so successive calls
+   * read successive return values. A felt past half the prime is a negative number
+   * written as its field element, and is brought back below zero here.
+   * @param {Iterator<string>} responseIterator the response felts, positioned on this i32
+   * @returns {CairoInt32} the i32 that was read
+   * @example
+   * ```typescript
+   * const response = ['0x11170'];
+   * const result = CairoInt32.factoryFromApiResponse(response.values()).toBigInt();
+   * // result = 70000n
+   * ```
+   */
   static factoryFromApiResponse(responseIterator: Iterator<string>): CairoInt32 {
     const response = getNext(responseIterator);
     const value = BigInt(response);

--- a/src/utils/cairoDataTypes/int64.ts
+++ b/src/utils/cairoDataTypes/int64.ts
@@ -8,16 +8,80 @@ import assert from '../assert';
 import { RANGE_I64, PRIME } from '../../global/constants';
 import { addCompiledFlag } from '../helpers';
 
+/**
+ * A Cairo `core::integer::i64` : a whole number in [-9223372036854775808, 9223372036854775807], carried in one felt252.
+ *
+ * The value is kept as a bigint, so the shape of the input does not survive — `7017280452245743464`,
+ * `'7017280452245743464'` and `'0x6162636465666768'` give the same i64. A string that reads as text rather than as a
+ * number is taken for its UTF-8 bytes, which is why `'abcdefgh'` is 7017280452245743464 and not a rejected input.
+ *
+ * An already built instance is **not** an accepted input : handed back to the constructor it is
+ * seen as an object and refused. Inside the library it is `unwrapCairoScalar` that reduces an
+ * instance to its number before an abi slot receives it.
+ * @example
+ * ```typescript
+ * // the same value, reached four ways
+ * new CairoInt64(7017280452245743464).toBigInt(); //     7017280452245743464n
+ * new CairoInt64('7017280452245743464').toBigInt(); //   7017280452245743464n
+ * new CairoInt64('0x6162636465666768').toBigInt(); // 7017280452245743464n
+ * new CairoInt64('abcdefgh').toBigInt(); //    7017280452245743464n     the UTF-8 bytes of the text
+ * ```
+ */
 export class CairoInt64 {
+  /**
+   * The value, always as a bigint.
+   * @example
+   * ```typescript
+   * const result = new CairoInt64('0x6162636465666768').data;
+   * // result = 7017280452245743464n
+   * ```
+   */
   data: bigint;
 
+  /**
+   * The abi type this class serializes.
+   * @example
+   * ```typescript
+   * const result = CairoInt64.abiSelector;
+   * // result = "core::integer::i64"
+   * ```
+   */
   static abiSelector = 'core::integer::i64';
 
+  /**
+   * Build from a number, a string or a boolean, refusing anything out of the i64 range.
+   *
+   * A string is read as a number when it spells one — decimal or hexadecimal — and as UTF-8 text
+   * otherwise. Text therefore only fits here up to 8 ASCII characters : one more already
+   * makes a number past 9223372036854775807.
+   * @param {BigNumberish | boolean} data the value to carry, within [-9223372036854775808, 9223372036854775807]
+   * @throws {Error} when the value is null, undefined, an object, a decimal number, or out of range
+   * @example
+   * ```typescript
+   * const result = new CairoInt64('abcdefgh').toApiRequest();
+   * // result = ["7017280452245743464"]
+   * ```
+   */
   constructor(data: BigNumberish | boolean | unknown) {
     CairoInt64.validate(data);
     this.data = CairoInt64.__processData(data);
   }
 
+  /**
+   * Turn an accepted input into its number, before the range is checked.
+   *
+   * Nothing here refuses a value : `validate` is what reads this number and decides. So an input
+   * far outside the i64 range comes back untouched rather than raising.
+   * @param {BigNumberish | boolean} data the value to convert
+   * @returns {bigint} the number the input spells, of whatever size
+   * @example
+   * ```typescript
+   * const result = CairoInt64.__processData('abcdefgh');
+   * // result = 7017280452245743464n
+   * const result2 = CairoInt64.__processData('abcdefghi');
+   * // result2 = 1796423795774910326889n     (past the i64 range, and returned all the same)
+   * ```
+   */
   static __processData(data: BigNumberish | boolean | unknown): bigint {
     if (isString(data) && isText(data)) {
       // Only allow text strings that represent valid UTF-8 byte sequences for specific use cases
@@ -28,14 +92,51 @@ export class CairoInt64 {
     return BigInt(data as BigNumberish);
   }
 
+  /**
+   * Serialize to the single felt a contract call carries.
+   *
+   * A negative value goes out as its field element, `PRIME + value`, which is what Cairo reads
+   * back as the negative number.
+   * @returns {string[]} one decimal-string felt, flagged as compiled
+   * @example
+   * ```typescript
+   * const result = new CairoInt64(5000000000).toApiRequest();
+   * // result = ["5000000000"]
+   * const result2 = new CairoInt64(-5000000000).toApiRequest();
+   * // result2 = ["3618502788666131213697322783095070105623107215331596699973092056130872020481"]
+   * ```
+   */
   toApiRequest(): string[] {
     return addCompiledFlag([BigInt(this.toHexString()).toString()]);
   }
 
+  /**
+   * The value as a number.
+   * @returns {bigint} the number this i64 holds, negative included
+   * @example
+   * ```typescript
+   * const result = new CairoInt64(-5000000000).toBigInt();
+   * // result = -5000000000n
+   * ```
+   */
   toBigInt() {
     return this.data;
   }
 
+  /**
+   * Read the value back as the UTF-8 text its bytes spell.
+   *
+   * Only a value that was text to begin with comes back as readable text. Any other number is
+   * decoded all the same, and what it gives is whatever its bytes happen to mean — a
+   * negative value is first wrapped to its two's complement, which rarely spells valid UTF-8 and
+   * so comes back as replacement characters.
+   * @returns {string} the bytes decoded as UTF-8
+   * @example
+   * ```typescript
+   * const result = new CairoInt64('abcdefgh').decodeUtf8();
+   * // result = "abcdefgh"
+   * ```
+   */
   decodeUtf8() {
     return new TextDecoder().decode(
       bigIntToUint8Array(this.data >= 0n ? this.data : 2n ** 64n + this.data)
@@ -43,8 +144,18 @@ export class CairoInt64 {
   }
 
   /**
-   * For negative values field element representation as positive hex string.
-   * @returns cairo field arithmetic hex string
+   * The value in hexadecimal, without padding.
+   *
+   * A negative value has no hexadecimal form of its own here : it is written as its field element,
+   * `PRIME + value`, the positive number Cairo actually carries.
+   * @returns {string} the number as a 0x-prefixed hex string
+   * @example
+   * ```typescript
+   * const result = new CairoInt64(5000000000).toHexString();
+   * // result = "0x12a05f200"
+   * const result2 = new CairoInt64(-5000000000).toHexString();
+   * // result2 = "0x800000000000010fffffffffffffffffffffffffffffffffffffffed5fa0e01"
+   * ```
    */
   toHexString() {
     const value = this.toBigInt();
@@ -56,6 +167,21 @@ export class CairoInt64 {
     return addHexPrefix(value.toString(16));
   }
 
+  /**
+   * Throw unless the value can be carried by an i64.
+   *
+   * Four things are refused, each with its own message : a null or undefined value, an object or
+   * an array, a number with a decimal part, and a value outside [-9223372036854775808, 9223372036854775807]. A text string reaches
+   * that last check as the number its bytes spell, so `'abcdefghi'` is refused for being out of range.
+   * @param {BigNumberish | boolean} data the value to check
+   * @throws {Error} when the value is null, undefined, an object, a decimal number, or out of range
+   * @example
+   * ```typescript
+   * CairoInt64.validate(5000000000); // passes
+   * CairoInt64.validate(9223372036854775808);
+   * // throws Error("Value is out of i64 range [-9223372036854775808, 9223372036854775807]")
+   * ```
+   */
   static validate(data: BigNumberish | boolean | unknown): void {
     assert(data !== null && data !== undefined, 'Invalid input: null or undefined');
     assert(!isObject(data) && !Array.isArray(data), 'Invalid input: objects are not supported');
@@ -71,6 +197,21 @@ export class CairoInt64 {
     );
   }
 
+  /**
+   * Can this value be carried by an i64?
+   *
+   * The non-throwing form of {@link CairoInt64.validate}, so it answers false for every input that
+   * one refuses, whatever the reason.
+   * @param {BigNumberish | boolean} data the value to test
+   * @returns {boolean} true when the value fits in an i64
+   * @example
+   * ```typescript
+   * const result = CairoInt64.is('abcdefgh');
+   * // result = true     (7017280452245743464, the UTF-8 bytes of the text)
+   * const result2 = CairoInt64.is('abcdefghi');
+   * // result2 = false   (1796423795774910326889, past the i64 range)
+   * ```
+   */
   static is(data: BigNumberish | boolean | unknown): boolean {
     try {
       CairoInt64.validate(data);
@@ -81,12 +222,36 @@ export class CairoInt64 {
   }
 
   /**
-   * Check if provided abi type is this data type
+   * Is this abi type the one this class serializes?
+   * @param {string} abiType the abi type to test
+   * @returns {boolean} true for `core::integer::i64`
+   * @example
+   * ```typescript
+   * const result = CairoInt64.isAbiType('core::integer::i64');
+   * // result = true
+   * const result2 = CairoInt64.isAbiType('core::felt252');
+   * // result2 = false
+   * ```
    */
   static isAbiType(abiType: string): boolean {
     return abiType === CairoInt64.abiSelector;
   }
 
+  /**
+   * Read one i64 off a contract response, advancing the iterator past it.
+   *
+   * The felts a node returns are hex strings, and one is consumed per call, so successive calls
+   * read successive return values. A felt past half the prime is a negative number
+   * written as its field element, and is brought back below zero here.
+   * @param {Iterator<string>} responseIterator the response felts, positioned on this i64
+   * @returns {CairoInt64} the i64 that was read
+   * @example
+   * ```typescript
+   * const response = ['0x12a05f200'];
+   * const result = CairoInt64.factoryFromApiResponse(response.values()).toBigInt();
+   * // result = 5000000000n
+   * ```
+   */
   static factoryFromApiResponse(responseIterator: Iterator<string>): CairoInt64 {
     const response = getNext(responseIterator);
     const value = BigInt(response);

--- a/src/utils/cairoDataTypes/int8.ts
+++ b/src/utils/cairoDataTypes/int8.ts
@@ -8,16 +8,80 @@ import assert from '../assert';
 import { RANGE_I8, PRIME } from '../../global/constants';
 import { addCompiledFlag } from '../helpers';
 
+/**
+ * A Cairo `core::integer::i8` : a whole number in [-128, 127], carried in one felt252.
+ *
+ * The value is kept as a bigint, so the shape of the input does not survive — `97`,
+ * `'97'` and `'0x61'` give the same i8. A string that reads as text rather than as a
+ * number is taken for its UTF-8 bytes, which is why `'a'` is 97 and not a rejected input.
+ *
+ * An already built instance is **not** an accepted input : handed back to the constructor it is
+ * seen as an object and refused. Inside the library it is `unwrapCairoScalar` that reduces an
+ * instance to its number before an abi slot receives it.
+ * @example
+ * ```typescript
+ * // the same value, reached four ways
+ * new CairoInt8(97).toBigInt(); //     97n
+ * new CairoInt8('97').toBigInt(); //   97n
+ * new CairoInt8('0x61').toBigInt(); // 97n
+ * new CairoInt8('a').toBigInt(); //    97n     the UTF-8 bytes of the text
+ * ```
+ */
 export class CairoInt8 {
+  /**
+   * The value, always as a bigint.
+   * @example
+   * ```typescript
+   * const result = new CairoInt8('0x61').data;
+   * // result = 97n
+   * ```
+   */
   data: bigint;
 
+  /**
+   * The abi type this class serializes.
+   * @example
+   * ```typescript
+   * const result = CairoInt8.abiSelector;
+   * // result = "core::integer::i8"
+   * ```
+   */
   static abiSelector = 'core::integer::i8';
 
+  /**
+   * Build from a number, a string or a boolean, refusing anything out of the i8 range.
+   *
+   * A string is read as a number when it spells one — decimal or hexadecimal — and as UTF-8 text
+   * otherwise. Text therefore only fits here up to a single ASCII character : one more already
+   * makes a number past 127.
+   * @param {BigNumberish | boolean} data the value to carry, within [-128, 127]
+   * @throws {Error} when the value is null, undefined, an object, a decimal number, or out of range
+   * @example
+   * ```typescript
+   * const result = new CairoInt8('a').toApiRequest();
+   * // result = ["97"]
+   * ```
+   */
   constructor(data: BigNumberish | boolean | unknown) {
     CairoInt8.validate(data);
     this.data = CairoInt8.__processData(data);
   }
 
+  /**
+   * Turn an accepted input into its number, before the range is checked.
+   *
+   * Nothing here refuses a value : `validate` is what reads this number and decides. So an input
+   * far outside the i8 range comes back untouched rather than raising.
+   * @param {BigNumberish | boolean} data the value to convert
+   * @returns {bigint} the number the input spells, of whatever size
+   * @example
+   * ```typescript
+   * const result = CairoInt8.__processData('a');
+   * // result = 97n
+   * const result2 = CairoInt8.__processData('ab');
+   * // result2 = 24930n     (past the i8 range, and returned all the same)
+   * ```
+   */
   static __processData(data: BigNumberish | boolean | unknown): bigint {
     if (isString(data) && isText(data)) {
       // Only allow text strings that represent valid UTF-8 byte sequences for specific use cases
@@ -28,14 +92,51 @@ export class CairoInt8 {
     return BigInt(data as BigNumberish);
   }
 
+  /**
+   * Serialize to the single felt a contract call carries.
+   *
+   * A negative value goes out as its field element, `PRIME + value`, which is what Cairo reads
+   * back as the negative number.
+   * @returns {string[]} one decimal-string felt, flagged as compiled
+   * @example
+   * ```typescript
+   * const result = new CairoInt8(5).toApiRequest();
+   * // result = ["5"]
+   * const result2 = new CairoInt8(-5).toApiRequest();
+   * // result2 = ["3618502788666131213697322783095070105623107215331596699973092056135872020476"]
+   * ```
+   */
   toApiRequest(): string[] {
     return addCompiledFlag([BigInt(this.toHexString()).toString()]);
   }
 
+  /**
+   * The value as a number.
+   * @returns {bigint} the number this i8 holds, negative included
+   * @example
+   * ```typescript
+   * const result = new CairoInt8(-5).toBigInt();
+   * // result = -5n
+   * ```
+   */
   toBigInt() {
     return this.data;
   }
 
+  /**
+   * Read the value back as the UTF-8 text its bytes spell.
+   *
+   * Only a value that was text to begin with comes back as readable text. Any other number is
+   * decoded all the same, and what it gives is whatever its bytes happen to mean — a
+   * negative value is first wrapped to its two's complement, which rarely spells valid UTF-8 and
+   * so comes back as replacement characters.
+   * @returns {string} the bytes decoded as UTF-8
+   * @example
+   * ```typescript
+   * const result = new CairoInt8('a').decodeUtf8();
+   * // result = "a"
+   * ```
+   */
   decodeUtf8() {
     return new TextDecoder().decode(
       bigIntToUint8Array(this.data >= 0n ? this.data : 256n + this.data)
@@ -43,8 +144,18 @@ export class CairoInt8 {
   }
 
   /**
-   * For negative values field element representation as positive hex string.
-   * @returns cairo field arithmetic hex string
+   * The value in hexadecimal, without padding.
+   *
+   * A negative value has no hexadecimal form of its own here : it is written as its field element,
+   * `PRIME + value`, the positive number Cairo actually carries.
+   * @returns {string} the number as a 0x-prefixed hex string
+   * @example
+   * ```typescript
+   * const result = new CairoInt8(5).toHexString();
+   * // result = "0x5"
+   * const result2 = new CairoInt8(-5).toHexString();
+   * // result2 = "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffffc"
+   * ```
    */
   toHexString() {
     const value = this.toBigInt();
@@ -56,6 +167,21 @@ export class CairoInt8 {
     return addHexPrefix(value.toString(16));
   }
 
+  /**
+   * Throw unless the value can be carried by an i8.
+   *
+   * Four things are refused, each with its own message : a null or undefined value, an object or
+   * an array, a number with a decimal part, and a value outside [-128, 127]. A text string reaches
+   * that last check as the number its bytes spell, so `'ab'` is refused for being out of range.
+   * @param {BigNumberish | boolean} data the value to check
+   * @throws {Error} when the value is null, undefined, an object, a decimal number, or out of range
+   * @example
+   * ```typescript
+   * CairoInt8.validate(5); // passes
+   * CairoInt8.validate(128);
+   * // throws Error("Value is out of i8 range [-128, 127]")
+   * ```
+   */
   static validate(data: BigNumberish | boolean | unknown): void {
     assert(data !== null && data !== undefined, 'Invalid input: null or undefined');
     assert(!isObject(data) && !Array.isArray(data), 'Invalid input: objects are not supported');
@@ -71,6 +197,21 @@ export class CairoInt8 {
     );
   }
 
+  /**
+   * Can this value be carried by an i8?
+   *
+   * The non-throwing form of {@link CairoInt8.validate}, so it answers false for every input that
+   * one refuses, whatever the reason.
+   * @param {BigNumberish | boolean} data the value to test
+   * @returns {boolean} true when the value fits in an i8
+   * @example
+   * ```typescript
+   * const result = CairoInt8.is('a');
+   * // result = true     (97, the UTF-8 bytes of the text)
+   * const result2 = CairoInt8.is('ab');
+   * // result2 = false   (24930, past the i8 range)
+   * ```
+   */
   static is(data: BigNumberish | boolean | unknown): boolean {
     try {
       CairoInt8.validate(data);
@@ -81,12 +222,36 @@ export class CairoInt8 {
   }
 
   /**
-   * Check if provided abi type is this data type
+   * Is this abi type the one this class serializes?
+   * @param {string} abiType the abi type to test
+   * @returns {boolean} true for `core::integer::i8`
+   * @example
+   * ```typescript
+   * const result = CairoInt8.isAbiType('core::integer::i8');
+   * // result = true
+   * const result2 = CairoInt8.isAbiType('core::felt252');
+   * // result2 = false
+   * ```
    */
   static isAbiType(abiType: string): boolean {
     return abiType === CairoInt8.abiSelector;
   }
 
+  /**
+   * Read one i8 off a contract response, advancing the iterator past it.
+   *
+   * The felts a node returns are hex strings, and one is consumed per call, so successive calls
+   * read successive return values. A felt past half the prime is a negative number
+   * written as its field element, and is brought back below zero here.
+   * @param {Iterator<string>} responseIterator the response felts, positioned on this i8
+   * @returns {CairoInt8} the i8 that was read
+   * @example
+   * ```typescript
+   * const response = ['0x5'];
+   * const result = CairoInt8.factoryFromApiResponse(response.values()).toBigInt();
+   * // result = 5n
+   * ```
+   */
   static factoryFromApiResponse(responseIterator: Iterator<string>): CairoInt8 {
     const response = getNext(responseIterator);
     const value = BigInt(response);

--- a/src/utils/cairoDataTypes/uint128.ts
+++ b/src/utils/cairoDataTypes/uint128.ts
@@ -8,16 +8,80 @@ import assert from '../assert';
 import { RANGE_U128 } from '../../global/constants';
 import { addCompiledFlag } from '../helpers';
 
+/**
+ * A Cairo `core::integer::u128` : a whole number in [0, 340282366920938463463374607431768211455], carried in one felt252.
+ *
+ * The value is kept as a bigint, so the shape of the input does not survive — `129445976596022050476432668810952994672`,
+ * `'129445976596022050476432668810952994672'` and `'0x6162636465666768696a6b6c6d6e6f70'` give the same u128. A string that reads as text rather than as a
+ * number is taken for its UTF-8 bytes, which is why `'abcdefghijklmnop'` is 129445976596022050476432668810952994672 and not a rejected input.
+ *
+ * An already built instance is **not** an accepted input : handed back to the constructor it is
+ * seen as an object and refused. Inside the library it is `unwrapCairoScalar` that reduces an
+ * instance to its number before an abi slot receives it.
+ * @example
+ * ```typescript
+ * // the same value, reached four ways
+ * new CairoUint128(129445976596022050476432668810952994672).toBigInt(); //     129445976596022050476432668810952994672n
+ * new CairoUint128('129445976596022050476432668810952994672').toBigInt(); //   129445976596022050476432668810952994672n
+ * new CairoUint128('0x6162636465666768696a6b6c6d6e6f70').toBigInt(); // 129445976596022050476432668810952994672n
+ * new CairoUint128('abcdefghijklmnop').toBigInt(); //    129445976596022050476432668810952994672n     the UTF-8 bytes of the text
+ * ```
+ */
 export class CairoUint128 {
+  /**
+   * The value, always as a bigint.
+   * @example
+   * ```typescript
+   * const result = new CairoUint128('0x6162636465666768696a6b6c6d6e6f70').data;
+   * // result = 129445976596022050476432668810952994672n
+   * ```
+   */
   data: bigint;
 
+  /**
+   * The abi type this class serializes.
+   * @example
+   * ```typescript
+   * const result = CairoUint128.abiSelector;
+   * // result = "core::integer::u128"
+   * ```
+   */
   static abiSelector = 'core::integer::u128';
 
+  /**
+   * Build from a number, a string or a boolean, refusing anything out of the u128 range.
+   *
+   * A string is read as a number when it spells one — decimal or hexadecimal — and as UTF-8 text
+   * otherwise. Text therefore only fits here up to 16 ASCII characters : one more already
+   * makes a number past 340282366920938463463374607431768211455.
+   * @param {BigNumberish | boolean} data the value to carry, within [0, 340282366920938463463374607431768211455]
+   * @throws {Error} when the value is null, undefined, an object, a decimal number, or out of range
+   * @example
+   * ```typescript
+   * const result = new CairoUint128('abcdefghijklmnop').toApiRequest();
+   * // result = ["129445976596022050476432668810952994672"]
+   * ```
+   */
   constructor(data: BigNumberish | boolean | unknown) {
     CairoUint128.validate(data);
     this.data = CairoUint128.__processData(data);
   }
 
+  /**
+   * Turn an accepted input into its number, before the range is checked.
+   *
+   * Nothing here refuses a value : `validate` is what reads this number and decides. So an input
+   * far outside the u128 range comes back untouched rather than raising.
+   * @param {BigNumberish | boolean} data the value to convert
+   * @returns {bigint} the number the input spells, of whatever size
+   * @example
+   * ```typescript
+   * const result = CairoUint128.__processData('abcdefghijklmnop');
+   * // result = 129445976596022050476432668810952994672n
+   * const result2 = CairoUint128.__processData('abcdefghijklmnopq');
+   * // result2 = 33138170008581644921966763215603966636145n     (past the u128 range, and returned all the same)
+   * ```
+   */
   static __processData(data: BigNumberish | boolean | unknown): bigint {
     if (isString(data) && isText(data)) {
       // Only allow text strings that represent valid UTF-8 byte sequences for specific use cases
@@ -28,22 +92,78 @@ export class CairoUint128 {
     return BigInt(data as BigNumberish);
   }
 
+  /**
+   * Serialize to the single felt a contract call carries.
+   * @returns {string[]} one decimal-string felt, flagged as compiled
+   * @example
+   * ```typescript
+   * const result = new CairoUint128(5000000000).toApiRequest();
+   * // result = ["5000000000"]
+   * ```
+   */
   toApiRequest(): string[] {
     return addCompiledFlag([BigInt(this.toHexString()).toString()]);
   }
 
+  /**
+   * The value as a number.
+   * @returns {bigint} the number this u128 holds
+   * @example
+   * ```typescript
+   * const result = new CairoUint128(340282366920938463463374607431768211455).toBigInt();
+   * // result = 340282366920938463463374607431768211455n
+   * ```
+   */
   toBigInt() {
     return this.data;
   }
 
+  /**
+   * Read the value back as the UTF-8 text its bytes spell.
+   *
+   * Only a value that was text to begin with comes back as readable text. Any other number is
+   * decoded all the same, and what it gives is whatever its bytes happen to mean.
+   * @returns {string} the bytes decoded as UTF-8
+   * @example
+   * ```typescript
+   * const result = new CairoUint128('abcdefghijklmnop').decodeUtf8();
+   * // result = "abcdefghijklmnop"
+   * ```
+   */
   decodeUtf8() {
     return new TextDecoder().decode(bigIntToUint8Array(this.data));
   }
 
+  /**
+   * The value in hexadecimal, without padding.
+   * @returns {string} the number as a 0x-prefixed hex string
+   * @example
+   * ```typescript
+   * const result = new CairoUint128(5000000000).toHexString();
+   * // result = "0x12a05f200"
+   * const result2 = new CairoUint128(0).toHexString();
+   * // result2 = "0x0"     (one digit, not "0x00")
+   * ```
+   */
   toHexString() {
     return addHexPrefix(this.toBigInt().toString(16));
   }
 
+  /**
+   * Throw unless the value can be carried by a u128.
+   *
+   * Four things are refused, each with its own message : a null or undefined value, an object or
+   * an array, a number with a decimal part, and a value outside [0, 340282366920938463463374607431768211455]. A text string reaches
+   * that last check as the number its bytes spell, so `'abcdefghijklmnopq'` is refused for being out of range.
+   * @param {BigNumberish | boolean} data the value to check
+   * @throws {Error} when the value is null, undefined, an object, a decimal number, or out of range
+   * @example
+   * ```typescript
+   * CairoUint128.validate(5000000000); // passes
+   * CairoUint128.validate(340282366920938463463374607431768211456);
+   * // throws Error("Value is out of u128 range [0, 340282366920938463463374607431768211455]")
+   * ```
+   */
   static validate(data: BigNumberish | boolean | unknown): void {
     assert(data !== null && data !== undefined, 'Invalid input: null or undefined');
     assert(!isObject(data) && !Array.isArray(data), 'Invalid input: objects are not supported');
@@ -59,6 +179,21 @@ export class CairoUint128 {
     );
   }
 
+  /**
+   * Can this value be carried by a u128?
+   *
+   * The non-throwing form of {@link CairoUint128.validate}, so it answers false for every input that
+   * one refuses, whatever the reason.
+   * @param {BigNumberish | boolean} data the value to test
+   * @returns {boolean} true when the value fits in a u128
+   * @example
+   * ```typescript
+   * const result = CairoUint128.is('abcdefghijklmnop');
+   * // result = true     (129445976596022050476432668810952994672, the UTF-8 bytes of the text)
+   * const result2 = CairoUint128.is('abcdefghijklmnopq');
+   * // result2 = false   (33138170008581644921966763215603966636145, past the u128 range)
+   * ```
+   */
   static is(data: BigNumberish | boolean | unknown): boolean {
     try {
       CairoUint128.validate(data);
@@ -69,12 +204,35 @@ export class CairoUint128 {
   }
 
   /**
-   * Check if provided abi type is this data type
+   * Is this abi type the one this class serializes?
+   * @param {string} abiType the abi type to test
+   * @returns {boolean} true for `core::integer::u128`
+   * @example
+   * ```typescript
+   * const result = CairoUint128.isAbiType('core::integer::u128');
+   * // result = true
+   * const result2 = CairoUint128.isAbiType('core::felt252');
+   * // result2 = false
+   * ```
    */
   static isAbiType(abiType: string): boolean {
     return abiType === CairoUint128.abiSelector;
   }
 
+  /**
+   * Read one u128 off a contract response, advancing the iterator past it.
+   *
+   * The felts a node returns are hex strings, and one is consumed per call, so successive calls
+   * read successive return values.
+   * @param {Iterator<string>} responseIterator the response felts, positioned on this u128
+   * @returns {CairoUint128} the u128 that was read
+   * @example
+   * ```typescript
+   * const response = ['0x12a05f200'];
+   * const result = CairoUint128.factoryFromApiResponse(response.values()).toBigInt();
+   * // result = 5000000000n
+   * ```
+   */
   static factoryFromApiResponse(responseIterator: Iterator<string>): CairoUint128 {
     return new CairoUint128(getNext(responseIterator));
   }

--- a/src/utils/cairoDataTypes/uint16.ts
+++ b/src/utils/cairoDataTypes/uint16.ts
@@ -8,16 +8,80 @@ import assert from '../assert';
 import { RANGE_U16 } from '../../global/constants';
 import { addCompiledFlag } from '../helpers';
 
+/**
+ * A Cairo `core::integer::u16` : a whole number in [0, 65535], carried in one felt252.
+ *
+ * The value is kept as a bigint, so the shape of the input does not survive — `24930`,
+ * `'24930'` and `'0x6162'` give the same u16. A string that reads as text rather than as a
+ * number is taken for its UTF-8 bytes, which is why `'ab'` is 24930 and not a rejected input.
+ *
+ * An already built instance is **not** an accepted input : handed back to the constructor it is
+ * seen as an object and refused. Inside the library it is `unwrapCairoScalar` that reduces an
+ * instance to its number before an abi slot receives it.
+ * @example
+ * ```typescript
+ * // the same value, reached four ways
+ * new CairoUint16(24930).toBigInt(); //     24930n
+ * new CairoUint16('24930').toBigInt(); //   24930n
+ * new CairoUint16('0x6162').toBigInt(); // 24930n
+ * new CairoUint16('ab').toBigInt(); //    24930n     the UTF-8 bytes of the text
+ * ```
+ */
 export class CairoUint16 {
+  /**
+   * The value, always as a bigint.
+   * @example
+   * ```typescript
+   * const result = new CairoUint16('0x6162').data;
+   * // result = 24930n
+   * ```
+   */
   data: bigint;
 
+  /**
+   * The abi type this class serializes.
+   * @example
+   * ```typescript
+   * const result = CairoUint16.abiSelector;
+   * // result = "core::integer::u16"
+   * ```
+   */
   static abiSelector = 'core::integer::u16';
 
+  /**
+   * Build from a number, a string or a boolean, refusing anything out of the u16 range.
+   *
+   * A string is read as a number when it spells one — decimal or hexadecimal — and as UTF-8 text
+   * otherwise. Text therefore only fits here up to 2 ASCII characters : one more already
+   * makes a number past 65535.
+   * @param {BigNumberish | boolean} data the value to carry, within [0, 65535]
+   * @throws {Error} when the value is null, undefined, an object, a decimal number, or out of range
+   * @example
+   * ```typescript
+   * const result = new CairoUint16('ab').toApiRequest();
+   * // result = ["24930"]
+   * ```
+   */
   constructor(data: BigNumberish | boolean | unknown) {
     CairoUint16.validate(data);
     this.data = CairoUint16.__processData(data);
   }
 
+  /**
+   * Turn an accepted input into its number, before the range is checked.
+   *
+   * Nothing here refuses a value : `validate` is what reads this number and decides. So an input
+   * far outside the u16 range comes back untouched rather than raising.
+   * @param {BigNumberish | boolean} data the value to convert
+   * @returns {bigint} the number the input spells, of whatever size
+   * @example
+   * ```typescript
+   * const result = CairoUint16.__processData('ab');
+   * // result = 24930n
+   * const result2 = CairoUint16.__processData('abc');
+   * // result2 = 6382179n     (past the u16 range, and returned all the same)
+   * ```
+   */
   static __processData(data: BigNumberish | boolean | unknown): bigint {
     if (isString(data) && isText(data)) {
       // Only allow text strings that represent valid UTF-8 byte sequences for specific use cases
@@ -28,22 +92,78 @@ export class CairoUint16 {
     return BigInt(data as BigNumberish);
   }
 
+  /**
+   * Serialize to the single felt a contract call carries.
+   * @returns {string[]} one decimal-string felt, flagged as compiled
+   * @example
+   * ```typescript
+   * const result = new CairoUint16(300).toApiRequest();
+   * // result = ["300"]
+   * ```
+   */
   toApiRequest(): string[] {
     return addCompiledFlag([BigInt(this.toHexString()).toString()]);
   }
 
+  /**
+   * The value as a number.
+   * @returns {bigint} the number this u16 holds
+   * @example
+   * ```typescript
+   * const result = new CairoUint16(65535).toBigInt();
+   * // result = 65535n
+   * ```
+   */
   toBigInt() {
     return this.data;
   }
 
+  /**
+   * Read the value back as the UTF-8 text its bytes spell.
+   *
+   * Only a value that was text to begin with comes back as readable text. Any other number is
+   * decoded all the same, and what it gives is whatever its bytes happen to mean.
+   * @returns {string} the bytes decoded as UTF-8
+   * @example
+   * ```typescript
+   * const result = new CairoUint16('ab').decodeUtf8();
+   * // result = "ab"
+   * ```
+   */
   decodeUtf8() {
     return new TextDecoder().decode(bigIntToUint8Array(this.data));
   }
 
+  /**
+   * The value in hexadecimal, without padding.
+   * @returns {string} the number as a 0x-prefixed hex string
+   * @example
+   * ```typescript
+   * const result = new CairoUint16(300).toHexString();
+   * // result = "0x12c"
+   * const result2 = new CairoUint16(0).toHexString();
+   * // result2 = "0x0"     (one digit, not "0x00")
+   * ```
+   */
   toHexString() {
     return addHexPrefix(this.toBigInt().toString(16));
   }
 
+  /**
+   * Throw unless the value can be carried by a u16.
+   *
+   * Four things are refused, each with its own message : a null or undefined value, an object or
+   * an array, a number with a decimal part, and a value outside [0, 65535]. A text string reaches
+   * that last check as the number its bytes spell, so `'abc'` is refused for being out of range.
+   * @param {BigNumberish | boolean} data the value to check
+   * @throws {Error} when the value is null, undefined, an object, a decimal number, or out of range
+   * @example
+   * ```typescript
+   * CairoUint16.validate(300); // passes
+   * CairoUint16.validate(65536);
+   * // throws Error("Value is out of u16 range [0, 65535]")
+   * ```
+   */
   static validate(data: BigNumberish | boolean | unknown): void {
     assert(data !== null && data !== undefined, 'Invalid input: null or undefined');
     assert(!isObject(data) && !Array.isArray(data), 'Invalid input: objects are not supported');
@@ -59,6 +179,21 @@ export class CairoUint16 {
     );
   }
 
+  /**
+   * Can this value be carried by a u16?
+   *
+   * The non-throwing form of {@link CairoUint16.validate}, so it answers false for every input that
+   * one refuses, whatever the reason.
+   * @param {BigNumberish | boolean} data the value to test
+   * @returns {boolean} true when the value fits in a u16
+   * @example
+   * ```typescript
+   * const result = CairoUint16.is('ab');
+   * // result = true     (24930, the UTF-8 bytes of the text)
+   * const result2 = CairoUint16.is('abc');
+   * // result2 = false   (6382179, past the u16 range)
+   * ```
+   */
   static is(data: BigNumberish | boolean | unknown): boolean {
     try {
       CairoUint16.validate(data);
@@ -69,12 +204,35 @@ export class CairoUint16 {
   }
 
   /**
-   * Check if provided abi type is this data type
+   * Is this abi type the one this class serializes?
+   * @param {string} abiType the abi type to test
+   * @returns {boolean} true for `core::integer::u16`
+   * @example
+   * ```typescript
+   * const result = CairoUint16.isAbiType('core::integer::u16');
+   * // result = true
+   * const result2 = CairoUint16.isAbiType('core::felt252');
+   * // result2 = false
+   * ```
    */
   static isAbiType(abiType: string): boolean {
     return abiType === CairoUint16.abiSelector;
   }
 
+  /**
+   * Read one u16 off a contract response, advancing the iterator past it.
+   *
+   * The felts a node returns are hex strings, and one is consumed per call, so successive calls
+   * read successive return values.
+   * @param {Iterator<string>} responseIterator the response felts, positioned on this u16
+   * @returns {CairoUint16} the u16 that was read
+   * @example
+   * ```typescript
+   * const response = ['0x12c'];
+   * const result = CairoUint16.factoryFromApiResponse(response.values()).toBigInt();
+   * // result = 300n
+   * ```
+   */
   static factoryFromApiResponse(responseIterator: Iterator<string>): CairoUint16 {
     return new CairoUint16(getNext(responseIterator));
   }

--- a/src/utils/cairoDataTypes/uint256.ts
+++ b/src/utils/cairoDataTypes/uint256.ts
@@ -1,7 +1,4 @@
 /* eslint-disable no-bitwise */
-/**
- * Singular class handling cairo u256 data type
- */
 
 import { BigNumberish, Uint256 } from '../../types';
 import { addHexPrefix } from '../encode';
@@ -9,27 +6,145 @@ import { isObject } from '../typed';
 import { getNext, isBigNumberish } from '../num';
 import assert from '../assert';
 
+/**
+ * The largest u128, and the mask that cuts a u256 in two.
+ * @example
+ * ```typescript
+ * const result = UINT_128_MAX;
+ * // result = 340282366920938463463374607431768211455n
+ * ```
+ */
 export const UINT_128_MAX = (1n << 128n) - 1n;
+
+/**
+ * The largest u256, 2^256 - 1.
+ * @example
+ * ```typescript
+ * const result = UINT_256_MAX;
+ * // result = 115792089237316195423570985008687907853269984665640564039457584007913129639935n
+ * ```
+ */
 export const UINT_256_MAX = (1n << 256n) - 1n;
+
+/**
+ * The smallest u256, zero : a u256 is never negative.
+ * @example
+ * ```typescript
+ * const result = UINT_256_MIN;
+ * // result = 0n
+ * ```
+ */
 export const UINT_256_MIN = 0n;
+
+/**
+ * The largest `low` half, which is the largest u128.
+ * @example
+ * ```typescript
+ * const result = UINT_256_LOW_MAX === UINT_128_MAX;
+ * // result = true
+ * ```
+ */
 export const UINT_256_LOW_MAX = 340282366920938463463374607431768211455n;
+
+/**
+ * The largest `high` half, the same u128 bound as {@link UINT_256_LOW_MAX}.
+ * @example
+ * ```typescript
+ * const result = UINT_256_HIGH_MAX === UINT_256_LOW_MAX;
+ * // result = true
+ * ```
+ */
 export const UINT_256_HIGH_MAX = 340282366920938463463374607431768211455n;
+
+/**
+ * The smallest `low` half, zero.
+ * @example
+ * ```typescript
+ * const result = UINT_256_LOW_MIN;
+ * // result = 0n
+ * ```
+ */
 export const UINT_256_LOW_MIN = 0n;
+
+/**
+ * The smallest `high` half, zero.
+ * @example
+ * ```typescript
+ * const result = UINT_256_HIGH_MIN;
+ * // result = 0n
+ * ```
+ */
 export const UINT_256_HIGH_MIN = 0n;
 
+/**
+ * A Cairo `core::integer::u256` : a whole number from 0 to 2^256 - 1, carried in two felts.
+ *
+ * A felt252 is too narrow to hold a u256, so the number is cut into two u128 halves — `low` for the
+ * bottom 128 bits, `high` for the top — and a contract call carries both, low first. Either half
+ * can be given directly, which is how a response from a node is read back.
+ * @example
+ * ```typescript
+ * const small = new CairoUint256(255);
+ * // small.low = 255n, small.high = 0n
+ * const big = new CairoUint256(2n ** 130n + 5n);
+ * // big.low = 5n, big.high = 4n
+ * ```
+ */
 export class CairoUint256 {
+  /**
+   * The bottom 128 bits of the value.
+   * @example
+   * ```typescript
+   * const result = new CairoUint256(2n ** 130n + 5n).low;
+   * // result = 5n
+   * ```
+   */
   public low: bigint; // TODO should be u128
 
+  /**
+   * The top 128 bits of the value.
+   * @example
+   * ```typescript
+   * const result = new CairoUint256(2n ** 130n + 5n).high;
+   * // result = 4n
+   * ```
+   */
   public high: bigint; // TODO should be u128
 
+  /**
+   * The abi type this class serializes.
+   * @example
+   * ```typescript
+   * const result = CairoUint256.abiSelector;
+   * // result = "core::integer::u256"
+   * ```
+   */
   static abiSelector = 'core::integer::u256' as const;
 
   /**
-   * Default constructor (Lib usage)
+   * Build from one number, cutting it into its two halves (Lib usage).
+   *
+   * A `Uint256` object is accepted here too : it already carries `low` and `high`, and both are
+   * checked as u128 rather than the whole being cut again.
+   * @param {BigNumberish | Uint256} data the value to carry, within [0, 2^256 - 1]
+   * @throws {Error} when the value is null, undefined, of an unread type, or out of range
+   * @example
+   * ```typescript
+   * const result = new CairoUint256(2n ** 130n + 5n).toApiRequest();
+   * // result = ["5", "4"]
+   * ```
    */
   public constructor(data: BigNumberish | Uint256 | unknown);
   /**
-   * Direct props initialization (Api response)
+   * Build from the two halves as they arrive, already cut (Api response).
+   * @param {BigNumberish} low the bottom 128 bits
+   * @param {BigNumberish} high the top 128 bits
+   * @throws {Error} when either half is out of the u128 range
+   * @example
+   * ```typescript
+   * const result = new CairoUint256(5, 4).toBigInt();
+   * // result = 1361129467683753853853498429727072845829n
+   * ```
    */
   public constructor(low: BigNumberish, high: BigNumberish);
   public constructor(...arr: any[]) {
@@ -54,7 +169,20 @@ export class CairoUint256 {
   }
 
   /**
-   * Validate if BigNumberish can be represented as Unit256
+   * Throw unless a whole value can be represented as a u256, and give back its number.
+   *
+   * A string is only accepted while it spells a number : one that does not is refused for its
+   * type, whatever the message says about strings.
+   * @param {BigNumberish} bigNumberish the value to check
+   * @returns {bigint} the value as a number, once accepted
+   * @throws {Error} when the value is null, undefined, of an unread type, or out of range
+   * @example
+   * ```typescript
+   * const result = CairoUint256.validate(255);
+   * // result = 255n
+   * CairoUint256.validate(-1);
+   * // throws Error("bigNumberish is smaller than UINT_256_MIN")
+   * ```
    */
   static validate(bigNumberish: BigNumberish | unknown) {
     assert(bigNumberish !== null, 'null value is not allowed for u256');
@@ -71,7 +199,21 @@ export class CairoUint256 {
   }
 
   /**
-   * Validate if low and high can be represented as Unit256
+   * Throw unless both halves are u128, and give them back as numbers.
+   *
+   * This is the check for a value that arrives already cut. Each half is bounded on its own : it
+   * is the pair that makes a u256, so neither can overflow into the other.
+   * @param {BigNumberish} low the bottom 128 bits
+   * @param {BigNumberish} high the top 128 bits
+   * @returns {{low: bigint, high: bigint}} the two halves as numbers
+   * @throws {Error} when either half is outside the u128 range
+   * @example
+   * ```typescript
+   * const result = CairoUint256.validateProps(5, 4);
+   * // result = { low: 5n, high: 4n }
+   * CairoUint256.validateProps(-1, 4);
+   * // throws Error("low is out of range UINT_256_LOW_MIN - UINT_256_LOW_MAX")
+   * ```
    */
   static validateProps(low: BigNumberish, high: BigNumberish) {
     const bigIntLow = BigInt(low);
@@ -88,7 +230,19 @@ export class CairoUint256 {
   }
 
   /**
-   * Check if BigNumberish can be represented as Unit256
+   * Can this value be represented as a u256?
+   *
+   * The non-throwing form of {@link CairoUint256.validate}, so it answers false for every input
+   * that one refuses, whatever the reason.
+   * @param {BigNumberish} bigNumberish the value to test
+   * @returns {boolean} true when the value fits in a u256
+   * @example
+   * ```typescript
+   * const result = CairoUint256.is(255);
+   * // result = true
+   * const result2 = CairoUint256.is(-1);
+   * // result2 = false
+   * ```
    */
   static is(bigNumberish: BigNumberish | unknown) {
     try {
@@ -100,12 +254,34 @@ export class CairoUint256 {
   }
 
   /**
-   * Check if provided abi type is this data type
+   * Is this abi type the one this class serializes?
+   * @param {string} abiType the abi type to test
+   * @returns {boolean} true for `core::integer::u256`
+   * @example
+   * ```typescript
+   * const result = CairoUint256.isAbiType('core::integer::u256');
+   * // result = true
+   * const result2 = CairoUint256.isAbiType('core::integer::u512');
+   * // result2 = false
+   * ```
    */
   static isAbiType(abiType: string) {
     return abiType === CairoUint256.abiSelector;
   }
 
+  /**
+   * Read one u256 off a contract response, advancing the iterator past it.
+   *
+   * **Two** felts are consumed, low first, since that is how a u256 travels.
+   * @param {Iterator<string>} responseIterator the response felts, positioned on this u256
+   * @returns {CairoUint256} the u256 that was read
+   * @example
+   * ```typescript
+   * const response = ['0x5', '0x4'];
+   * const result = CairoUint256.factoryFromApiResponse(response.values()).toBigInt();
+   * // result = 1361129467683753853853498429727072845829n
+   * ```
+   */
   static factoryFromApiResponse(responseIterator: Iterator<string>) {
     const low = getNext(responseIterator);
     const high = getNext(responseIterator);
@@ -113,15 +289,26 @@ export class CairoUint256 {
   }
 
   /**
-   * Return bigint representation
+   * The two halves put back together as one number.
+   * @returns {bigint} the value this u256 holds
+   * @example
+   * ```typescript
+   * const result = new CairoUint256(5, 4).toBigInt();
+   * // result = 1361129467683753853853498429727072845829n
+   * ```
    */
   toBigInt() {
     return (this.high << 128n) + this.low;
   }
 
   /**
-   * Return Uint256 structure with HexString props
-   * {low: HexString, high: HexString}
+   * The two halves as a `Uint256` of hexadecimal strings.
+   * @returns {{low: string, high: string}} both halves, 0x-prefixed and unpadded
+   * @example
+   * ```typescript
+   * const result = new CairoUint256(255).toUint256HexString();
+   * // result = { low: "0xff", high: "0x0" }
+   * ```
    */
   toUint256HexString() {
     return {
@@ -131,8 +318,13 @@ export class CairoUint256 {
   }
 
   /**
-   * Return Uint256 structure with DecimalString props
-   * {low: DecString, high: DecString}
+   * The two halves as a `Uint256` of decimal strings.
+   * @returns {{low: string, high: string}} both halves, in base 10
+   * @example
+   * ```typescript
+   * const result = new CairoUint256(255).toUint256DecimalString();
+   * // result = { low: "255", high: "0" }
+   * ```
    */
   toUint256DecimalString() {
     return {
@@ -142,7 +334,13 @@ export class CairoUint256 {
   }
 
   /**
-   * Return api requests representation witch is felt array
+   * Serialize to the two felts a contract call carries.
+   * @returns {string[]} the two halves as decimal strings, low first
+   * @example
+   * ```typescript
+   * const result = new CairoUint256(255).toApiRequest();
+   * // result = ["255", "0"]
+   * ```
    */
   toApiRequest() {
     return [this.low.toString(), this.high.toString()];

--- a/src/utils/cairoDataTypes/uint32.ts
+++ b/src/utils/cairoDataTypes/uint32.ts
@@ -8,16 +8,80 @@ import assert from '../assert';
 import { addCompiledFlag } from '../helpers';
 import { RANGE_U32 } from '../../global/constants';
 
+/**
+ * A Cairo `core::integer::u32` : a whole number in [0, 4294967295], carried in one felt252.
+ *
+ * The value is kept as a bigint, so the shape of the input does not survive — `1633837924`,
+ * `'1633837924'` and `'0x61626364'` give the same u32. A string that reads as text rather than as a
+ * number is taken for its UTF-8 bytes, which is why `'abcd'` is 1633837924 and not a rejected input.
+ *
+ * An already built instance is **not** an accepted input : handed back to the constructor it is
+ * seen as an object and refused. Inside the library it is `unwrapCairoScalar` that reduces an
+ * instance to its number before an abi slot receives it.
+ * @example
+ * ```typescript
+ * // the same value, reached four ways
+ * new CairoUint32(1633837924).toBigInt(); //     1633837924n
+ * new CairoUint32('1633837924').toBigInt(); //   1633837924n
+ * new CairoUint32('0x61626364').toBigInt(); // 1633837924n
+ * new CairoUint32('abcd').toBigInt(); //    1633837924n     the UTF-8 bytes of the text
+ * ```
+ */
 export class CairoUint32 {
+  /**
+   * The value, always as a bigint.
+   * @example
+   * ```typescript
+   * const result = new CairoUint32('0x61626364').data;
+   * // result = 1633837924n
+   * ```
+   */
   data: bigint;
 
+  /**
+   * The abi type this class serializes.
+   * @example
+   * ```typescript
+   * const result = CairoUint32.abiSelector;
+   * // result = "core::integer::u32"
+   * ```
+   */
   static abiSelector = 'core::integer::u32';
 
+  /**
+   * Build from a number, a string or a boolean, refusing anything out of the u32 range.
+   *
+   * A string is read as a number when it spells one — decimal or hexadecimal — and as UTF-8 text
+   * otherwise. Text therefore only fits here up to 4 ASCII characters : one more already
+   * makes a number past 4294967295.
+   * @param {BigNumberish | boolean} data the value to carry, within [0, 4294967295]
+   * @throws {Error} when the value is null, undefined, an object, a decimal number, or out of range
+   * @example
+   * ```typescript
+   * const result = new CairoUint32('abcd').toApiRequest();
+   * // result = ["1633837924"]
+   * ```
+   */
   constructor(data: BigNumberish | boolean | unknown) {
     CairoUint32.validate(data);
     this.data = CairoUint32.__processData(data);
   }
 
+  /**
+   * Turn an accepted input into its number, before the range is checked.
+   *
+   * Nothing here refuses a value : `validate` is what reads this number and decides. So an input
+   * far outside the u32 range comes back untouched rather than raising.
+   * @param {BigNumberish | boolean} data the value to convert
+   * @returns {bigint} the number the input spells, of whatever size
+   * @example
+   * ```typescript
+   * const result = CairoUint32.__processData('abcd');
+   * // result = 1633837924n
+   * const result2 = CairoUint32.__processData('abcde');
+   * // result2 = 418262508645n     (past the u32 range, and returned all the same)
+   * ```
+   */
   static __processData(data: BigNumberish | boolean | unknown): bigint {
     if (isString(data) && isText(data)) {
       // Only allow text strings that represent valid UTF-8 byte sequences for specific use cases
@@ -28,22 +92,78 @@ export class CairoUint32 {
     return BigInt(data as BigNumberish);
   }
 
+  /**
+   * Serialize to the single felt a contract call carries.
+   * @returns {string[]} one decimal-string felt, flagged as compiled
+   * @example
+   * ```typescript
+   * const result = new CairoUint32(70000).toApiRequest();
+   * // result = ["70000"]
+   * ```
+   */
   toApiRequest(): string[] {
     return addCompiledFlag([BigInt(this.toHexString()).toString()]);
   }
 
+  /**
+   * The value as a number.
+   * @returns {bigint} the number this u32 holds
+   * @example
+   * ```typescript
+   * const result = new CairoUint32(4294967295).toBigInt();
+   * // result = 4294967295n
+   * ```
+   */
   toBigInt() {
     return this.data;
   }
 
+  /**
+   * Read the value back as the UTF-8 text its bytes spell.
+   *
+   * Only a value that was text to begin with comes back as readable text. Any other number is
+   * decoded all the same, and what it gives is whatever its bytes happen to mean.
+   * @returns {string} the bytes decoded as UTF-8
+   * @example
+   * ```typescript
+   * const result = new CairoUint32('abcd').decodeUtf8();
+   * // result = "abcd"
+   * ```
+   */
   decodeUtf8() {
     return new TextDecoder().decode(bigIntToUint8Array(this.data));
   }
 
+  /**
+   * The value in hexadecimal, without padding.
+   * @returns {string} the number as a 0x-prefixed hex string
+   * @example
+   * ```typescript
+   * const result = new CairoUint32(70000).toHexString();
+   * // result = "0x11170"
+   * const result2 = new CairoUint32(0).toHexString();
+   * // result2 = "0x0"     (one digit, not "0x00")
+   * ```
+   */
   toHexString() {
     return addHexPrefix(this.toBigInt().toString(16));
   }
 
+  /**
+   * Throw unless the value can be carried by a u32.
+   *
+   * Four things are refused, each with its own message : a null or undefined value, an object or
+   * an array, a number with a decimal part, and a value outside [0, 4294967295]. A text string reaches
+   * that last check as the number its bytes spell, so `'abcde'` is refused for being out of range.
+   * @param {BigNumberish | boolean} data the value to check
+   * @throws {Error} when the value is null, undefined, an object, a decimal number, or out of range
+   * @example
+   * ```typescript
+   * CairoUint32.validate(70000); // passes
+   * CairoUint32.validate(4294967296);
+   * // throws Error("Value is out of u32 range [0, 2^32)")
+   * ```
+   */
   static validate(data: BigNumberish | boolean | unknown): void {
     assert(data !== null && data !== undefined, 'Invalid input: null or undefined');
     assert(!isObject(data) && !Array.isArray(data), 'Invalid input: objects are not supported');
@@ -56,6 +176,21 @@ export class CairoUint32 {
     assert(value >= RANGE_U32.min && value <= RANGE_U32.max, 'Value is out of u32 range [0, 2^32)');
   }
 
+  /**
+   * Can this value be carried by a u32?
+   *
+   * The non-throwing form of {@link CairoUint32.validate}, so it answers false for every input that
+   * one refuses, whatever the reason.
+   * @param {BigNumberish | boolean} data the value to test
+   * @returns {boolean} true when the value fits in a u32
+   * @example
+   * ```typescript
+   * const result = CairoUint32.is('abcd');
+   * // result = true     (1633837924, the UTF-8 bytes of the text)
+   * const result2 = CairoUint32.is('abcde');
+   * // result2 = false   (418262508645, past the u32 range)
+   * ```
+   */
   static is(data: BigNumberish | boolean | unknown): boolean {
     try {
       CairoUint32.validate(data);
@@ -66,12 +201,35 @@ export class CairoUint32 {
   }
 
   /**
-   * Check if provided abi type is this data type
+   * Is this abi type the one this class serializes?
+   * @param {string} abiType the abi type to test
+   * @returns {boolean} true for `core::integer::u32`
+   * @example
+   * ```typescript
+   * const result = CairoUint32.isAbiType('core::integer::u32');
+   * // result = true
+   * const result2 = CairoUint32.isAbiType('core::felt252');
+   * // result2 = false
+   * ```
    */
   static isAbiType(abiType: string): boolean {
     return abiType === CairoUint32.abiSelector;
   }
 
+  /**
+   * Read one u32 off a contract response, advancing the iterator past it.
+   *
+   * The felts a node returns are hex strings, and one is consumed per call, so successive calls
+   * read successive return values.
+   * @param {Iterator<string>} responseIterator the response felts, positioned on this u32
+   * @returns {CairoUint32} the u32 that was read
+   * @example
+   * ```typescript
+   * const response = ['0x11170'];
+   * const result = CairoUint32.factoryFromApiResponse(response.values()).toBigInt();
+   * // result = 70000n
+   * ```
+   */
   static factoryFromApiResponse(responseIterator: Iterator<string>): CairoUint32 {
     return new CairoUint32(getNext(responseIterator));
   }

--- a/src/utils/cairoDataTypes/uint512.ts
+++ b/src/utils/cairoDataTypes/uint512.ts
@@ -1,7 +1,4 @@
 /* eslint-disable no-bitwise */
-/**
- * Singular class handling cairo u512 data type
- */
 
 import { BigNumberish, type Uint512 } from '../../types';
 import { addHexPrefix } from '../encode';
@@ -10,27 +7,127 @@ import { isObject } from '../typed';
 import { getNext, isBigNumberish } from '../num';
 import assert from '../assert';
 
+/**
+ * The largest u512, 2^512 - 1.
+ * @example
+ * ```typescript
+ * const result = UINT_512_MAX === 2n ** 512n - 1n;
+ * // result = true
+ * ```
+ */
 export const UINT_512_MAX = (1n << 512n) - 1n;
+
+/**
+ * The smallest u512, zero : a u512 is never negative.
+ * @example
+ * ```typescript
+ * const result = UINT_512_MIN;
+ * // result = 0n
+ * ```
+ */
 export const UINT_512_MIN = 0n;
+
+/**
+ * The smallest value a limb can hold, zero.
+ * @example
+ * ```typescript
+ * const result = UINT_128_MIN;
+ * // result = 0n
+ * ```
+ */
 export const UINT_128_MIN = 0n;
 
+/**
+ * A Cairo `core::integer::u512` : a whole number from 0 to 2^512 - 1, carried in four felts.
+ *
+ * The number is cut into four u128 limbs, `limb0` holding the bottom 128 bits and `limb3` the top,
+ * and a contract call carries all four, lowest limb first. The limbs can be given directly, which
+ * is how a response from a node is read back.
+ * @example
+ * ```typescript
+ * const small = new CairoUint512(255);
+ * // small.limb0 = 255n, and limb1, limb2, limb3 are 0n
+ * const big = new CairoUint512(2n ** 390n + 7n);
+ * // big.limb0 = 7n, big.limb3 = 64n
+ * ```
+ */
 export class CairoUint512 {
+  /**
+   * Bits 0 to 127 of the value.
+   * @example
+   * ```typescript
+   * const result = new CairoUint512(2n ** 390n + 7n).limb0;
+   * // result = 7n
+   * ```
+   */
   public limb0: bigint; // TODO should be u128
 
+  /**
+   * Bits 128 to 255 of the value.
+   * @example
+   * ```typescript
+   * const result = new CairoUint512(2n ** 390n + 7n).limb1;
+   * // result = 0n
+   * ```
+   */
   public limb1: bigint; // TODO should be u128
 
+  /**
+   * Bits 256 to 383 of the value.
+   * @example
+   * ```typescript
+   * const result = new CairoUint512(2n ** 390n + 7n).limb2;
+   * // result = 0n
+   * ```
+   */
   public limb2: bigint; // TODO should be u128
 
+  /**
+   * Bits 384 to 511 of the value.
+   * @example
+   * ```typescript
+   * const result = new CairoUint512(2n ** 390n + 7n).limb3;
+   * // result = 64n
+   * ```
+   */
   public limb3: bigint; // TODO should be u128
 
+  /**
+   * The abi type this class serializes.
+   * @example
+   * ```typescript
+   * const result = CairoUint512.abiSelector;
+   * // result = "core::integer::u512"
+   * ```
+   */
   static abiSelector = 'core::integer::u512';
 
   /**
-   * Default constructor (Lib usage)
+   * Build from one number, cutting it into its four limbs (Lib usage).
+   *
+   * A `Uint512` object is accepted here too : it already carries the four limbs, and each is
+   * checked as a u128 rather than the whole being cut again.
+   * @param {BigNumberish | Uint512} bigNumberish the value to carry, within [0, 2^512 - 1]
+   * @throws {Error} when the value is null, undefined, of an unread type, or out of range
+   * @example
+   * ```typescript
+   * const result = new CairoUint512(255).toApiRequest();
+   * // result = ["255", "0", "0", "0"]
+   * ```
    */
   public constructor(bigNumberish: BigNumberish | Uint512 | unknown);
   /**
-   * Direct props initialization (Api response)
+   * Build from the four limbs as they arrive, already cut (Api response).
+   * @param {BigNumberish} limb0 bits 0 to 127
+   * @param {BigNumberish} limb1 bits 128 to 255
+   * @param {BigNumberish} limb2 bits 256 to 383
+   * @param {BigNumberish} limb3 bits 384 to 511
+   * @throws {Error} when any limb is out of the u128 range
+   * @example
+   * ```typescript
+   * const result = new CairoUint512(7, 0, 0, 64).toBigInt() === 2n ** 390n + 7n;
+   * // result = true
+   * ```
    */
   public constructor(
     limb0: BigNumberish,
@@ -75,7 +172,20 @@ export class CairoUint512 {
   }
 
   /**
-   * Validate if BigNumberish can be represented as Uint512
+   * Throw unless a whole value can be represented as a u512, and give back its number.
+   *
+   * A string is only accepted while it spells a number : one that does not is refused for its
+   * type, whatever the message says about strings.
+   * @param {BigNumberish} bigNumberish the value to check
+   * @returns {bigint} the value as a number, once accepted
+   * @throws {Error} when the value is null, undefined, of an unread type, or out of range
+   * @example
+   * ```typescript
+   * const result = CairoUint512.validate(255);
+   * // result = 255n
+   * CairoUint512.validate(-1);
+   * // throws Error("bigNumberish is smaller than UINT_512_MIN.")
+   * ```
    */
   static validate(bigNumberish: BigNumberish | unknown): bigint {
     assert(bigNumberish !== null, 'null value is not allowed for u512');
@@ -92,7 +202,23 @@ export class CairoUint512 {
   }
 
   /**
-   * Validate if limbs can be represented as Uint512
+   * Throw unless all four limbs are u128, and give them back as numbers.
+   *
+   * This is the check for a value that arrives already cut. Each limb is bounded on its own, and
+   * the message names the one at fault by its index.
+   * @param {BigNumberish} limb0 bits 0 to 127
+   * @param {BigNumberish} limb1 bits 128 to 255
+   * @param {BigNumberish} limb2 bits 256 to 383
+   * @param {BigNumberish} limb3 bits 384 to 511
+   * @returns {{limb0: bigint, limb1: bigint, limb2: bigint, limb3: bigint}} the four limbs as numbers
+   * @throws {Error} when any limb is outside the u128 range
+   * @example
+   * ```typescript
+   * const result = CairoUint512.validateProps(7, 0, 0, 64);
+   * // result = { limb0: 7n, limb1: 0n, limb2: 0n, limb3: 64n }
+   * CairoUint512.validateProps(-1, 0, 0, 0);
+   * // throws Error("limb0 is not in the range of a u128 number")
+   * ```
    */
   static validateProps(
     limb0: BigNumberish,
@@ -114,7 +240,19 @@ export class CairoUint512 {
   }
 
   /**
-   * Check if BigNumberish can be represented as Uint512
+   * Can this value be represented as a u512?
+   *
+   * The non-throwing form of {@link CairoUint512.validate}, so it answers false for every input
+   * that one refuses, whatever the reason.
+   * @param {BigNumberish} bigNumberish the value to test
+   * @returns {boolean} true when the value fits in a u512
+   * @example
+   * ```typescript
+   * const result = CairoUint512.is(255);
+   * // result = true
+   * const result2 = CairoUint512.is(-1);
+   * // result2 = false
+   * ```
    */
   static is(bigNumberish: BigNumberish | unknown): boolean {
     try {
@@ -126,12 +264,34 @@ export class CairoUint512 {
   }
 
   /**
-   * Check if provided abi type is this data type
+   * Is this abi type the one this class serializes?
+   * @param {string} abiType the abi type to test
+   * @returns {boolean} true for `core::integer::u512`
+   * @example
+   * ```typescript
+   * const result = CairoUint512.isAbiType('core::integer::u512');
+   * // result = true
+   * const result2 = CairoUint512.isAbiType('core::integer::u256');
+   * // result2 = false
+   * ```
    */
   static isAbiType(abiType: string): boolean {
     return abiType === CairoUint512.abiSelector;
   }
 
+  /**
+   * Read one u512 off a contract response, advancing the iterator past it.
+   *
+   * **Four** felts are consumed, lowest limb first, since that is how a u512 travels.
+   * @param {Iterator<string>} responseIterator the response felts, positioned on this u512
+   * @returns {CairoUint512} the u512 that was read
+   * @example
+   * ```typescript
+   * const response = ['0xff', '0x0', '0x0', '0x0'];
+   * const result = CairoUint512.factoryFromApiResponse(response.values()).toBigInt();
+   * // result = 255n
+   * ```
+   */
   static factoryFromApiResponse(responseIterator: Iterator<string>) {
     const limb0 = getNext(responseIterator);
     const limb1 = getNext(responseIterator);
@@ -141,15 +301,26 @@ export class CairoUint512 {
   }
 
   /**
-   * Return bigint representation
+   * The four limbs put back together as one number.
+   * @returns {bigint} the value this u512 holds
+   * @example
+   * ```typescript
+   * const result = new CairoUint512(255).toBigInt();
+   * // result = 255n
+   * ```
    */
   toBigInt(): bigint {
     return (this.limb3 << 384n) + (this.limb2 << 256n) + (this.limb1 << 128n) + this.limb0;
   }
 
   /**
-   * Return Uint512 structure with HexString props
-   * limbx: HexString
+   * The four limbs as a `Uint512` of hexadecimal strings.
+   * @returns {{limb0: string, limb1: string, limb2: string, limb3: string}} the limbs, 0x-prefixed and unpadded
+   * @example
+   * ```typescript
+   * const result = new CairoUint512(255).toUint512HexString();
+   * // result = { limb0: "0xff", limb1: "0x0", limb2: "0x0", limb3: "0x0" }
+   * ```
    */
   toUint512HexString() {
     return {
@@ -161,8 +332,13 @@ export class CairoUint512 {
   }
 
   /**
-   * Return Uint512 structure with DecimalString props
-   * limbx DecString
+   * The four limbs as a `Uint512` of decimal strings.
+   * @returns {{limb0: string, limb1: string, limb2: string, limb3: string}} the limbs, in base 10
+   * @example
+   * ```typescript
+   * const result = new CairoUint512(255).toUint512DecimalString();
+   * // result = { limb0: "255", limb1: "0", limb2: "0", limb3: "0" }
+   * ```
    */
   toUint512DecimalString() {
     return {
@@ -174,7 +350,13 @@ export class CairoUint512 {
   }
 
   /**
-   * Return api requests representation witch is felt array
+   * Serialize to the four felts a contract call carries.
+   * @returns {string[]} the four limbs as decimal strings, lowest first
+   * @example
+   * ```typescript
+   * const result = new CairoUint512(255).toApiRequest();
+   * // result = ["255", "0", "0", "0"]
+   * ```
    */
   toApiRequest(): string[] {
     // lower limb first : https://github.com/starkware-libs/cairo/blob/07484c52791b76abcc18fd86265756904557d0d2/corelib/src/test/integer_test.cairo#L767

--- a/src/utils/cairoDataTypes/uint64.ts
+++ b/src/utils/cairoDataTypes/uint64.ts
@@ -8,16 +8,80 @@ import assert from '../assert';
 import { RANGE_U64 } from '../../global/constants';
 import { addCompiledFlag } from '../helpers';
 
+/**
+ * A Cairo `core::integer::u64` : a whole number in [0, 18446744073709551615], carried in one felt252.
+ *
+ * The value is kept as a bigint, so the shape of the input does not survive — `7017280452245743464`,
+ * `'7017280452245743464'` and `'0x6162636465666768'` give the same u64. A string that reads as text rather than as a
+ * number is taken for its UTF-8 bytes, which is why `'abcdefgh'` is 7017280452245743464 and not a rejected input.
+ *
+ * An already built instance is **not** an accepted input : handed back to the constructor it is
+ * seen as an object and refused. Inside the library it is `unwrapCairoScalar` that reduces an
+ * instance to its number before an abi slot receives it.
+ * @example
+ * ```typescript
+ * // the same value, reached four ways
+ * new CairoUint64(7017280452245743464).toBigInt(); //     7017280452245743464n
+ * new CairoUint64('7017280452245743464').toBigInt(); //   7017280452245743464n
+ * new CairoUint64('0x6162636465666768').toBigInt(); // 7017280452245743464n
+ * new CairoUint64('abcdefgh').toBigInt(); //    7017280452245743464n     the UTF-8 bytes of the text
+ * ```
+ */
 export class CairoUint64 {
+  /**
+   * The value, always as a bigint.
+   * @example
+   * ```typescript
+   * const result = new CairoUint64('0x6162636465666768').data;
+   * // result = 7017280452245743464n
+   * ```
+   */
   data: bigint;
 
+  /**
+   * The abi type this class serializes.
+   * @example
+   * ```typescript
+   * const result = CairoUint64.abiSelector;
+   * // result = "core::integer::u64"
+   * ```
+   */
   static abiSelector = 'core::integer::u64';
 
+  /**
+   * Build from a number, a string or a boolean, refusing anything out of the u64 range.
+   *
+   * A string is read as a number when it spells one — decimal or hexadecimal — and as UTF-8 text
+   * otherwise. Text therefore only fits here up to 8 ASCII characters : one more already
+   * makes a number past 18446744073709551615.
+   * @param {BigNumberish | boolean} data the value to carry, within [0, 18446744073709551615]
+   * @throws {Error} when the value is null, undefined, an object, a decimal number, or out of range
+   * @example
+   * ```typescript
+   * const result = new CairoUint64('abcdefgh').toApiRequest();
+   * // result = ["7017280452245743464"]
+   * ```
+   */
   constructor(data: BigNumberish | boolean | unknown) {
     CairoUint64.validate(data);
     this.data = CairoUint64.__processData(data);
   }
 
+  /**
+   * Turn an accepted input into its number, before the range is checked.
+   *
+   * Nothing here refuses a value : `validate` is what reads this number and decides. So an input
+   * far outside the u64 range comes back untouched rather than raising.
+   * @param {BigNumberish | boolean} data the value to convert
+   * @returns {bigint} the number the input spells, of whatever size
+   * @example
+   * ```typescript
+   * const result = CairoUint64.__processData('abcdefgh');
+   * // result = 7017280452245743464n
+   * const result2 = CairoUint64.__processData('abcdefghi');
+   * // result2 = 1796423795774910326889n     (past the u64 range, and returned all the same)
+   * ```
+   */
   static __processData(data: BigNumberish | boolean | unknown): bigint {
     if (isString(data) && isText(data)) {
       // Only allow text strings that represent valid UTF-8 byte sequences for specific use cases
@@ -28,22 +92,78 @@ export class CairoUint64 {
     return BigInt(data as BigNumberish);
   }
 
+  /**
+   * Serialize to the single felt a contract call carries.
+   * @returns {string[]} one decimal-string felt, flagged as compiled
+   * @example
+   * ```typescript
+   * const result = new CairoUint64(5000000000).toApiRequest();
+   * // result = ["5000000000"]
+   * ```
+   */
   toApiRequest(): string[] {
     return addCompiledFlag([BigInt(this.toHexString()).toString()]);
   }
 
+  /**
+   * The value as a number.
+   * @returns {bigint} the number this u64 holds
+   * @example
+   * ```typescript
+   * const result = new CairoUint64(18446744073709551615).toBigInt();
+   * // result = 18446744073709551615n
+   * ```
+   */
   toBigInt() {
     return this.data;
   }
 
+  /**
+   * Read the value back as the UTF-8 text its bytes spell.
+   *
+   * Only a value that was text to begin with comes back as readable text. Any other number is
+   * decoded all the same, and what it gives is whatever its bytes happen to mean.
+   * @returns {string} the bytes decoded as UTF-8
+   * @example
+   * ```typescript
+   * const result = new CairoUint64('abcdefgh').decodeUtf8();
+   * // result = "abcdefgh"
+   * ```
+   */
   decodeUtf8() {
     return new TextDecoder().decode(bigIntToUint8Array(this.data));
   }
 
+  /**
+   * The value in hexadecimal, without padding.
+   * @returns {string} the number as a 0x-prefixed hex string
+   * @example
+   * ```typescript
+   * const result = new CairoUint64(5000000000).toHexString();
+   * // result = "0x12a05f200"
+   * const result2 = new CairoUint64(0).toHexString();
+   * // result2 = "0x0"     (one digit, not "0x00")
+   * ```
+   */
   toHexString() {
     return addHexPrefix(this.toBigInt().toString(16));
   }
 
+  /**
+   * Throw unless the value can be carried by a u64.
+   *
+   * Four things are refused, each with its own message : a null or undefined value, an object or
+   * an array, a number with a decimal part, and a value outside [0, 18446744073709551615]. A text string reaches
+   * that last check as the number its bytes spell, so `'abcdefghi'` is refused for being out of range.
+   * @param {BigNumberish | boolean} data the value to check
+   * @throws {Error} when the value is null, undefined, an object, a decimal number, or out of range
+   * @example
+   * ```typescript
+   * CairoUint64.validate(5000000000); // passes
+   * CairoUint64.validate(18446744073709551616);
+   * // throws Error("Value is out of u64 range [0, 18446744073709551615]")
+   * ```
+   */
   static validate(data: BigNumberish | boolean | unknown): void {
     assert(data !== null && data !== undefined, 'Invalid input: null or undefined');
     assert(!isObject(data) && !Array.isArray(data), 'Invalid input: objects are not supported');
@@ -59,6 +179,21 @@ export class CairoUint64 {
     );
   }
 
+  /**
+   * Can this value be carried by a u64?
+   *
+   * The non-throwing form of {@link CairoUint64.validate}, so it answers false for every input that
+   * one refuses, whatever the reason.
+   * @param {BigNumberish | boolean} data the value to test
+   * @returns {boolean} true when the value fits in a u64
+   * @example
+   * ```typescript
+   * const result = CairoUint64.is('abcdefgh');
+   * // result = true     (7017280452245743464, the UTF-8 bytes of the text)
+   * const result2 = CairoUint64.is('abcdefghi');
+   * // result2 = false   (1796423795774910326889, past the u64 range)
+   * ```
+   */
   static is(data: BigNumberish | boolean | unknown): boolean {
     try {
       CairoUint64.validate(data);
@@ -69,12 +204,35 @@ export class CairoUint64 {
   }
 
   /**
-   * Check if provided abi type is this data type
+   * Is this abi type the one this class serializes?
+   * @param {string} abiType the abi type to test
+   * @returns {boolean} true for `core::integer::u64`
+   * @example
+   * ```typescript
+   * const result = CairoUint64.isAbiType('core::integer::u64');
+   * // result = true
+   * const result2 = CairoUint64.isAbiType('core::felt252');
+   * // result2 = false
+   * ```
    */
   static isAbiType(abiType: string): boolean {
     return abiType === CairoUint64.abiSelector;
   }
 
+  /**
+   * Read one u64 off a contract response, advancing the iterator past it.
+   *
+   * The felts a node returns are hex strings, and one is consumed per call, so successive calls
+   * read successive return values.
+   * @param {Iterator<string>} responseIterator the response felts, positioned on this u64
+   * @returns {CairoUint64} the u64 that was read
+   * @example
+   * ```typescript
+   * const response = ['0x12a05f200'];
+   * const result = CairoUint64.factoryFromApiResponse(response.values()).toBigInt();
+   * // result = 5000000000n
+   * ```
+   */
   static factoryFromApiResponse(responseIterator: Iterator<string>): CairoUint64 {
     return new CairoUint64(getNext(responseIterator));
   }

--- a/src/utils/cairoDataTypes/uint8.ts
+++ b/src/utils/cairoDataTypes/uint8.ts
@@ -8,16 +8,80 @@ import assert from '../assert';
 import { RANGE_U8 } from '../../global/constants';
 import { addCompiledFlag } from '../helpers';
 
+/**
+ * A Cairo `core::integer::u8` : a whole number from 0 to 255, carried in one felt252.
+ *
+ * The value is kept as a bigint, so the shape of the input does not survive — `97`, `'97'` and
+ * `'0x61'` give the same u8. A string that reads as text rather than as a number is taken for its
+ * UTF-8 bytes, which is why `'a'` is 97 and not a rejected input.
+ *
+ * An already built instance is **not** an accepted input : handed back to the constructor it is
+ * seen as an object and refused. Inside the library it is `unwrapCairoScalar` that reduces an
+ * instance to its number before an abi slot receives it.
+ * @example
+ * ```typescript
+ * // the same value, reached four ways
+ * new CairoUint8(97).toBigInt(); //     97n
+ * new CairoUint8('97').toBigInt(); //   97n
+ * new CairoUint8('0x61').toBigInt(); // 97n
+ * new CairoUint8('a').toBigInt(); //    97n     the UTF-8 code of the character
+ * ```
+ */
 export class CairoUint8 {
+  /**
+   * The value, always as a bigint.
+   * @example
+   * ```typescript
+   * const result = new CairoUint8('0x61').data;
+   * // result = 97n
+   * ```
+   */
   data: bigint;
 
+  /**
+   * The abi type this class serializes.
+   * @example
+   * ```typescript
+   * const result = CairoUint8.abiSelector;
+   * // result = "core::integer::u8"
+   * ```
+   */
   static abiSelector = 'core::integer::u8';
 
+  /**
+   * Build from a number, a string or a boolean, refusing anything out of the u8 range.
+   *
+   * A string is read as a number when it spells one — decimal or hexadecimal — and as UTF-8 text
+   * otherwise. Text therefore only fits here while it is a single ASCII character : two characters
+   * already make a number past 255.
+   * @param {BigNumberish | boolean} data the value to carry, within [0, 255]
+   * @throws {Error} when the value is null, undefined, an object, a decimal number, or out of range
+   * @example
+   * ```typescript
+   * const result = new CairoUint8('a').toApiRequest();
+   * // result = ["97"]
+   * ```
+   */
   constructor(data: BigNumberish | boolean | unknown) {
     CairoUint8.validate(data);
     this.data = CairoUint8.__processData(data);
   }
 
+  /**
+   * Turn an accepted input into its number, before the range is checked.
+   *
+   * Nothing here refuses a value : `validate` is what reads this number and decides. So an input
+   * far outside the u8 range comes back untouched rather than raising.
+   * @param {BigNumberish | boolean} data the value to convert
+   * @returns {bigint} the number the input spells, of whatever size
+   * @example
+   * ```typescript
+   * const result = CairoUint8.__processData('a');
+   * // result = 97n
+   * const result2 = CairoUint8.__processData('ab');
+   * // result2 = 24930n     (past the u8 range, and returned all the same)
+   * ```
+   */
   static __processData(data: BigNumberish | boolean | unknown): bigint {
     if (isString(data) && isText(data)) {
       // Only allow text strings that represent valid UTF-8 byte sequences for specific use cases
@@ -28,22 +92,80 @@ export class CairoUint8 {
     return BigInt(data as BigNumberish);
   }
 
+  /**
+   * Serialize to the single felt a contract call carries.
+   * @returns {string[]} one decimal-string felt, flagged as compiled
+   * @example
+   * ```typescript
+   * const result = new CairoUint8(44).toApiRequest();
+   * // result = ["44"]
+   * ```
+   */
   toApiRequest(): string[] {
     return addCompiledFlag([BigInt(this.toHexString()).toString()]);
   }
 
+  /**
+   * The value as a number.
+   * @returns {bigint} the number this u8 holds
+   * @example
+   * ```typescript
+   * const result = new CairoUint8(255).toBigInt();
+   * // result = 255n
+   * ```
+   */
   toBigInt() {
     return this.data;
   }
 
+  /**
+   * Read the value back as the one UTF-8 byte it spells.
+   *
+   * Every u8 is a byte, so this always returns a character — including for values that were never
+   * meant as text, and a NUL for 0.
+   * @returns {string} the byte decoded as UTF-8
+   * @example
+   * ```typescript
+   * const result = new CairoUint8('a').decodeUtf8();
+   * // result = "a"
+   * const result2 = new CairoUint8(44).decodeUtf8();
+   * // result2 = ","     (44 is the code of a comma)
+   * ```
+   */
   decodeUtf8() {
     return new TextDecoder().decode(bigIntToUint8Array(this.data));
   }
 
+  /**
+   * The value in hexadecimal, without padding.
+   * @returns {string} the number as a 0x-prefixed hex string
+   * @example
+   * ```typescript
+   * const result = new CairoUint8(44).toHexString();
+   * // result = "0x2c"
+   * const result2 = new CairoUint8(0).toHexString();
+   * // result2 = "0x0"     (one digit, not "0x00")
+   * ```
+   */
   toHexString() {
     return addHexPrefix(this.toBigInt().toString(16));
   }
 
+  /**
+   * Throw unless the value can be carried by a u8.
+   *
+   * Four things are refused, each with its own message : a null or undefined value, an object or
+   * an array, a number with a decimal part, and a value outside [0, 255]. A text string reaches
+   * that last check as the number its bytes spell, so `'ab'` is refused for being out of range.
+   * @param {BigNumberish | boolean} data the value to check
+   * @throws {Error} when the value is null, undefined, an object, a decimal number, or out of range
+   * @example
+   * ```typescript
+   * CairoUint8.validate(44); // passes
+   * CairoUint8.validate(256);
+   * // throws Error("Value is out of u8 range [0, 255]")
+   * ```
+   */
   static validate(data: BigNumberish | boolean | unknown): void {
     assert(data !== null && data !== undefined, 'Invalid input: null or undefined');
     assert(!isObject(data) && !Array.isArray(data), 'Invalid input: objects are not supported');
@@ -59,6 +181,21 @@ export class CairoUint8 {
     );
   }
 
+  /**
+   * Can this value be carried by a u8?
+   *
+   * The non-throwing form of {@link CairoUint8.validate}, so it answers false for every input that
+   * one refuses, whatever the reason.
+   * @param {BigNumberish | boolean} data the value to test
+   * @returns {boolean} true when the value fits in a u8
+   * @example
+   * ```typescript
+   * const result = CairoUint8.is('a');
+   * // result = true     (97, the UTF-8 code of the character)
+   * const result2 = CairoUint8.is('ab');
+   * // result2 = false   (24930, past the u8 range)
+   * ```
+   */
   static is(data: BigNumberish | boolean | unknown): boolean {
     try {
       CairoUint8.validate(data);
@@ -69,12 +206,35 @@ export class CairoUint8 {
   }
 
   /**
-   * Check if provided abi type is this data type
+   * Is this abi type the one this class serializes?
+   * @param {string} abiType the abi type to test
+   * @returns {boolean} true for `core::integer::u8`
+   * @example
+   * ```typescript
+   * const result = CairoUint8.isAbiType('core::integer::u8');
+   * // result = true
+   * const result2 = CairoUint8.isAbiType('core::integer::u16');
+   * // result2 = false
+   * ```
    */
   static isAbiType(abiType: string): boolean {
     return abiType === CairoUint8.abiSelector;
   }
 
+  /**
+   * Read one u8 off a contract response, advancing the iterator past it.
+   *
+   * The felts a node returns are hex strings, and one is consumed per call, so successive calls
+   * read successive return values.
+   * @param {Iterator<string>} responseIterator the response felts, positioned on this u8
+   * @returns {CairoUint8} the u8 that was read
+   * @example
+   * ```typescript
+   * const response = ['0x2c'];
+   * const result = CairoUint8.factoryFromApiResponse(response.values()).toBigInt();
+   * // result = 44n
+   * ```
+   */
   static factoryFromApiResponse(responseIterator: Iterator<string>): CairoUint8 {
     return new CairoUint8(getNext(responseIterator));
   }

--- a/src/utils/cairoDataTypes/uint96.ts
+++ b/src/utils/cairoDataTypes/uint96.ts
@@ -8,16 +8,80 @@ import assert from '../assert';
 import { RANGE_U96 } from '../../global/constants';
 import { addCompiledFlag } from '../helpers';
 
+/**
+ * A Cairo `core::integer::u96` : a whole number in [0, 79228162514264337593543950335], carried in one felt252.
+ *
+ * The value is kept as a bigint, so the shape of the input does not survive — `30138990049255557934854335340`,
+ * `'30138990049255557934854335340'` and `'0x6162636465666768696a6b6c'` give the same u96. A string that reads as text rather than as a
+ * number is taken for its UTF-8 bytes, which is why `'abcdefghijkl'` is 30138990049255557934854335340 and not a rejected input.
+ *
+ * An already built instance is **not** an accepted input : handed back to the constructor it is
+ * seen as an object and refused. Inside the library it is `unwrapCairoScalar` that reduces an
+ * instance to its number before an abi slot receives it.
+ * @example
+ * ```typescript
+ * // the same value, reached four ways
+ * new CairoUint96(30138990049255557934854335340).toBigInt(); //     30138990049255557934854335340n
+ * new CairoUint96('30138990049255557934854335340').toBigInt(); //   30138990049255557934854335340n
+ * new CairoUint96('0x6162636465666768696a6b6c').toBigInt(); // 30138990049255557934854335340n
+ * new CairoUint96('abcdefghijkl').toBigInt(); //    30138990049255557934854335340n     the UTF-8 bytes of the text
+ * ```
+ */
 export class CairoUint96 {
+  /**
+   * The value, always as a bigint.
+   * @example
+   * ```typescript
+   * const result = new CairoUint96('0x6162636465666768696a6b6c').data;
+   * // result = 30138990049255557934854335340n
+   * ```
+   */
   data: bigint;
 
+  /**
+   * The abi type this class serializes.
+   * @example
+   * ```typescript
+   * const result = CairoUint96.abiSelector;
+   * // result = "core::integer::u96"
+   * ```
+   */
   static abiSelector = 'core::integer::u96';
 
+  /**
+   * Build from a number, a string or a boolean, refusing anything out of the u96 range.
+   *
+   * A string is read as a number when it spells one — decimal or hexadecimal — and as UTF-8 text
+   * otherwise. Text therefore only fits here up to 12 ASCII characters : one more already
+   * makes a number past 79228162514264337593543950335.
+   * @param {BigNumberish | boolean} data the value to carry, within [0, 79228162514264337593543950335]
+   * @throws {Error} when the value is null, undefined, an object, a decimal number, or out of range
+   * @example
+   * ```typescript
+   * const result = new CairoUint96('abcdefghijkl').toApiRequest();
+   * // result = ["30138990049255557934854335340"]
+   * ```
+   */
   constructor(data: BigNumberish | boolean | unknown) {
     CairoUint96.validate(data);
     this.data = CairoUint96.__processData(data);
   }
 
+  /**
+   * Turn an accepted input into its number, before the range is checked.
+   *
+   * Nothing here refuses a value : `validate` is what reads this number and decides. So an input
+   * far outside the u96 range comes back untouched rather than raising.
+   * @param {BigNumberish | boolean} data the value to convert
+   * @returns {bigint} the number the input spells, of whatever size
+   * @example
+   * ```typescript
+   * const result = CairoUint96.__processData('abcdefghijkl');
+   * // result = 30138990049255557934854335340n
+   * const result2 = CairoUint96.__processData('abcdefghijklm');
+   * // result2 = 7715581452609422831322709847149n     (past the u96 range, and returned all the same)
+   * ```
+   */
   static __processData(data: BigNumberish | boolean | unknown): bigint {
     if (isString(data) && isText(data)) {
       // Only allow text strings that represent valid UTF-8 byte sequences for specific use cases
@@ -28,22 +92,78 @@ export class CairoUint96 {
     return BigInt(data as BigNumberish);
   }
 
+  /**
+   * Serialize to the single felt a contract call carries.
+   * @returns {string[]} one decimal-string felt, flagged as compiled
+   * @example
+   * ```typescript
+   * const result = new CairoUint96(5000000000).toApiRequest();
+   * // result = ["5000000000"]
+   * ```
+   */
   toApiRequest(): string[] {
     return addCompiledFlag([BigInt(this.toHexString()).toString()]);
   }
 
+  /**
+   * The value as a number.
+   * @returns {bigint} the number this u96 holds
+   * @example
+   * ```typescript
+   * const result = new CairoUint96(79228162514264337593543950335).toBigInt();
+   * // result = 79228162514264337593543950335n
+   * ```
+   */
   toBigInt() {
     return this.data;
   }
 
+  /**
+   * Read the value back as the UTF-8 text its bytes spell.
+   *
+   * Only a value that was text to begin with comes back as readable text. Any other number is
+   * decoded all the same, and what it gives is whatever its bytes happen to mean.
+   * @returns {string} the bytes decoded as UTF-8
+   * @example
+   * ```typescript
+   * const result = new CairoUint96('abcdefghijkl').decodeUtf8();
+   * // result = "abcdefghijkl"
+   * ```
+   */
   decodeUtf8() {
     return new TextDecoder().decode(bigIntToUint8Array(this.data));
   }
 
+  /**
+   * The value in hexadecimal, without padding.
+   * @returns {string} the number as a 0x-prefixed hex string
+   * @example
+   * ```typescript
+   * const result = new CairoUint96(5000000000).toHexString();
+   * // result = "0x12a05f200"
+   * const result2 = new CairoUint96(0).toHexString();
+   * // result2 = "0x0"     (one digit, not "0x00")
+   * ```
+   */
   toHexString() {
     return addHexPrefix(this.toBigInt().toString(16));
   }
 
+  /**
+   * Throw unless the value can be carried by a u96.
+   *
+   * Four things are refused, each with its own message : a null or undefined value, an object or
+   * an array, a number with a decimal part, and a value outside [0, 79228162514264337593543950335]. A text string reaches
+   * that last check as the number its bytes spell, so `'abcdefghijklm'` is refused for being out of range.
+   * @param {BigNumberish | boolean} data the value to check
+   * @throws {Error} when the value is null, undefined, an object, a decimal number, or out of range
+   * @example
+   * ```typescript
+   * CairoUint96.validate(5000000000); // passes
+   * CairoUint96.validate(79228162514264337593543950336);
+   * // throws Error("Value is out of u96 range [0, 79228162514264337593543950335]")
+   * ```
+   */
   static validate(data: BigNumberish | boolean | unknown): void {
     assert(data !== null && data !== undefined, 'Invalid input: null or undefined');
     assert(!isObject(data) && !Array.isArray(data), 'Invalid input: objects are not supported');
@@ -59,6 +179,21 @@ export class CairoUint96 {
     );
   }
 
+  /**
+   * Can this value be carried by a u96?
+   *
+   * The non-throwing form of {@link CairoUint96.validate}, so it answers false for every input that
+   * one refuses, whatever the reason.
+   * @param {BigNumberish | boolean} data the value to test
+   * @returns {boolean} true when the value fits in a u96
+   * @example
+   * ```typescript
+   * const result = CairoUint96.is('abcdefghijkl');
+   * // result = true     (30138990049255557934854335340, the UTF-8 bytes of the text)
+   * const result2 = CairoUint96.is('abcdefghijklm');
+   * // result2 = false   (7715581452609422831322709847149, past the u96 range)
+   * ```
+   */
   static is(data: BigNumberish | boolean | unknown): boolean {
     try {
       CairoUint96.validate(data);
@@ -69,12 +204,35 @@ export class CairoUint96 {
   }
 
   /**
-   * Check if provided abi type is this data type
+   * Is this abi type the one this class serializes?
+   * @param {string} abiType the abi type to test
+   * @returns {boolean} true for `core::integer::u96`
+   * @example
+   * ```typescript
+   * const result = CairoUint96.isAbiType('core::integer::u96');
+   * // result = true
+   * const result2 = CairoUint96.isAbiType('core::felt252');
+   * // result2 = false
+   * ```
    */
   static isAbiType(abiType: string): boolean {
     return abiType === CairoUint96.abiSelector;
   }
 
+  /**
+   * Read one u96 off a contract response, advancing the iterator past it.
+   *
+   * The felts a node returns are hex strings, and one is consumed per call, so successive calls
+   * read successive return values.
+   * @param {Iterator<string>} responseIterator the response felts, positioned on this u96
+   * @returns {CairoUint96} the u96 that was read
+   * @example
+   * ```typescript
+   * const response = ['0x12a05f200'];
+   * const result = CairoUint96.factoryFromApiResponse(response.values()).toBigInt();
+   * // result = 5000000000n
+   * ```
+   */
   static factoryFromApiResponse(responseIterator: Iterator<string>): CairoUint96 {
     return new CairoUint96(getNext(responseIterator));
   }


### PR DESCRIPTION
## Motivation and Resolution

`src/utils/cairoDataTypes/` was the least documented corner of the library.

This PR documents the whole directory. 
Every `@example` value was obtained by executing the code, never estimated.

### RPC version (if applicable)

Not applicable.

## Usage related changes

- No behavior change. Stripping the JSDoc blocks from every file in the directory yields
  a result identical to the base branch, checked file by file.
- Generated API docs now describe every public class, method, field and exported constant
  of the Cairo data types, with a runnable example for each.

## Development related changes

## Checklist:

- [x] Performed a self-review of the code
- [x] Documented the changes in code (API docs will be generated automatically)
- [x] All tests are passing
