### PR TITLE
fix(cairoDataTypes): correct u256 and u512 toApiRequest and validate

### DIFF
--- a/__tests__/utils/cairoDataTypes/CairoFixedArray.test.ts
+++ b/__tests__/utils/cairoDataTypes/CairoFixedArray.test.ts
@@ -9,6 +9,33 @@ describe('CairoFixedArray class test', () => {
     expect(() => new CairoFixedArray([2, 4, 6], '[; 3]')).toThrow();
   });
 
+  test('the constructor refuses in exactly two ways', () => {
+    // whatever a type is malformed by — not bracketed, no item type, no length, a length that is
+    // not digits — the first assert catches it, and its message is the only one a bad type gives.
+    // The item count is the other, checked once the type is known to be a well formed one.
+    const malformed = [
+      'core::integer::u32',
+      'core::integer::u32; 3',
+      '[core::integer::u32]',
+      '[core::integer::u32;3]',
+      '[core::integer::u32; ]',
+      '[core::integer::u32; zorg]',
+      '[; 3]',
+      '[; ]',
+      '[]',
+      '',
+    ];
+    malformed.forEach((arrayType) => {
+      expect(() => new CairoFixedArray([2, 4, 6], arrayType)).toThrow(
+        `The type ${arrayType} is not a Cairo fixed array. Needs [type; length].`
+      );
+    });
+
+    expect(() => new CairoFixedArray([2, 4], '[core::integer::u32; 3]')).toThrow(
+      'The ABI type [core::integer::u32; 3] is expecting 3 items. 2 items provided.'
+    );
+  });
+
   test('use dynamic class methods', () => {
     const myFixedArray = new CairoFixedArray([1, 2, 3], '[core::integer::u32; 3]');
     expect(myFixedArray.getFixedArraySize()).toBe(3);

--- a/__tests__/utils/cairoDataTypes/CairoUint256.test.ts
+++ b/__tests__/utils/cairoDataTypes/CairoUint256.test.ts
@@ -8,6 +8,7 @@ import {
   UINT_256_LOW_MIN,
   UINT_256_MAX,
   UINT_256_MIN,
+  transaction,
 } from '../../../src';
 
 describe('CairoUint256 class test', () => {
@@ -118,19 +119,19 @@ describe('CairoUint256 class test', () => {
     expect(() => {
       CairoUint256.validate(Symbol('test') as any);
     }).toThrow(
-      "Unsupported data type 'symbol' for u256. Expected string, number, bigint, or Uint256 object"
+      "Unsupported data type 'symbol' for u256. Expected a numeric string (decimal or hexadecimal), number, bigint, or Uint256 object"
     );
 
     expect(() => {
       CairoUint256.validate((() => {}) as any);
     }).toThrow(
-      "Unsupported data type 'function' for u256. Expected string, number, bigint, or Uint256 object"
+      "Unsupported data type 'function' for u256. Expected a numeric string (decimal or hexadecimal), number, bigint, or Uint256 object"
     );
 
     expect(() => {
       CairoUint256.validate(true as any);
     }).toThrow(
-      "Unsupported data type 'boolean' for u256. Expected string, number, bigint, or Uint256 object"
+      "Unsupported data type 'boolean' for u256. Expected a numeric string (decimal or hexadecimal), number, bigint, or Uint256 object"
     );
   });
 
@@ -230,5 +231,21 @@ describe('CairoUint256 class test', () => {
       '340282366920938463463374607431768211455',
       '340282366920938463463374607431768211455',
     ]);
+  });
+
+  describe('toApiRequest is flagged as compiled', () => {
+    test('should carry the __compiled__ flag', () => {
+      const result = new CairoUint256(255).toApiRequest();
+      expect(result).toEqual(['255', '0']);
+      expect(result).toHaveProperty('__compiled__', true);
+    });
+
+    test('should be taken as calldata by a call that skips request parsing', () => {
+      // the shape `Contract.invoke` builds under `withOptions({ parseRequest: false })` : `args` is
+      // the argument list, its only item is already serialized, and the callback hands `args` back
+      // untouched. Only the flag tells the two apart, and without it the calldata stays nested.
+      const args = [new CairoUint256(255).toApiRequest()];
+      expect(transaction.getCompiledCalldata(args, () => args)).toEqual(['255', '0']);
+    });
   });
 });

--- a/__tests__/utils/cairoDataTypes/CairoUint32.test.ts
+++ b/__tests__/utils/cairoDataTypes/CairoUint32.test.ts
@@ -50,14 +50,18 @@ describe('CairoUint32 class Unit Tests', () => {
     });
 
     test('should reject negative values', () => {
-      expect(() => new CairoUint32(-1)).toThrow('Value is out of u32 range [0, 2^32)');
-      expect(() => new CairoUint32(-100n)).toThrow('Value is out of u32 range [0, 2^32)');
+      expect(() => new CairoUint32(-1)).toThrow('Value is out of u32 range [0, 4294967295]');
+      expect(() => new CairoUint32(-100n)).toThrow('Value is out of u32 range [0, 4294967295]');
     });
 
     test('should reject values greater than 2^32 - 1', () => {
       const overflowValue = 2n ** 32n; // 4294967296
-      expect(() => new CairoUint32(overflowValue)).toThrow('Value is out of u32 range [0, 2^32)');
-      expect(() => new CairoUint32(4294967296)).toThrow('Value is out of u32 range [0, 2^32)');
+      expect(() => new CairoUint32(overflowValue)).toThrow(
+        'Value is out of u32 range [0, 4294967295]'
+      );
+      expect(() => new CairoUint32(4294967296)).toThrow(
+        'Value is out of u32 range [0, 4294967295]'
+      );
     });
 
     test('should handle valid string inputs correctly', () => {
@@ -95,10 +99,14 @@ describe('CairoUint32 class Unit Tests', () => {
     });
 
     test('should validate string inputs with out-of-range values', () => {
-      expect(() => new CairoUint32('4294967296')).toThrow('Value is out of u32 range [0, 2^32)');
+      expect(() => new CairoUint32('4294967296')).toThrow(
+        'Value is out of u32 range [0, 4294967295]'
+      );
       // Note: '-1' is treated as text and converted via UTF-8, not as a number string
       // because it fails isStringWholeNumber (which only matches positive digits)
-      expect(() => new CairoUint32('0x100000000')).toThrow('Value is out of u32 range [0, 2^32)');
+      expect(() => new CairoUint32('0x100000000')).toThrow(
+        'Value is out of u32 range [0, 4294967295]'
+      );
     });
   });
 
@@ -241,13 +249,19 @@ describe('CairoUint32 class Unit Tests', () => {
     });
 
     test('should reject negative values', () => {
-      expect(() => CairoUint32.validate(-1)).toThrow('Value is out of u32 range [0, 2^32)');
-      expect(() => CairoUint32.validate(-100n)).toThrow('Value is out of u32 range [0, 2^32)');
+      expect(() => CairoUint32.validate(-1)).toThrow('Value is out of u32 range [0, 4294967295]');
+      expect(() => CairoUint32.validate(-100n)).toThrow(
+        'Value is out of u32 range [0, 4294967295]'
+      );
     });
 
     test('should reject values exceeding u32 range', () => {
-      expect(() => CairoUint32.validate(2n ** 32n)).toThrow('Value is out of u32 range [0, 2^32)');
-      expect(() => CairoUint32.validate(4294967296)).toThrow('Value is out of u32 range [0, 2^32)');
+      expect(() => CairoUint32.validate(2n ** 32n)).toThrow(
+        'Value is out of u32 range [0, 4294967295]'
+      );
+      expect(() => CairoUint32.validate(4294967296)).toThrow(
+        'Value is out of u32 range [0, 4294967295]'
+      );
     });
 
     test('should reject decimal numbers', () => {
@@ -448,12 +462,12 @@ describe('CairoUint32 class Unit Tests', () => {
       });
 
       test('should reject out-of-range values', () => {
-        expect(() => CairoUint32.validate(-1)).toThrow('Value is out of u32 range [0, 2^32)');
+        expect(() => CairoUint32.validate(-1)).toThrow('Value is out of u32 range [0, 4294967295]');
         expect(() => CairoUint32.validate(4294967296)).toThrow(
-          'Value is out of u32 range [0, 2^32)'
+          'Value is out of u32 range [0, 4294967295]'
         );
         expect(() => CairoUint32.validate(2n ** 32n)).toThrow(
-          'Value is out of u32 range [0, 2^32)'
+          'Value is out of u32 range [0, 4294967295]'
         );
       });
     });

--- a/__tests__/utils/cairoDataTypes/CairoUint512.test.ts
+++ b/__tests__/utils/cairoDataTypes/CairoUint512.test.ts
@@ -7,6 +7,7 @@ import {
   UINT_128_MIN,
   UINT_512_MAX,
   UINT_512_MIN,
+  transaction,
 } from '../../../src';
 
 describe('CairoUint512 class test', () => {
@@ -180,19 +181,19 @@ describe('CairoUint512 class test', () => {
     expect(() => {
       CairoUint512.validate(Symbol('test') as any);
     }).toThrow(
-      "Unsupported data type 'symbol' for u512. Expected string, number, bigint, or Uint512 object"
+      "Unsupported data type 'symbol' for u512. Expected a numeric string (decimal or hexadecimal), number, bigint, or Uint512 object"
     );
 
     expect(() => {
       CairoUint512.validate((() => {}) as any);
     }).toThrow(
-      "Unsupported data type 'function' for u512. Expected string, number, bigint, or Uint512 object"
+      "Unsupported data type 'function' for u512. Expected a numeric string (decimal or hexadecimal), number, bigint, or Uint512 object"
     );
 
     expect(() => {
       CairoUint512.validate(true as any);
     }).toThrow(
-      "Unsupported data type 'boolean' for u512. Expected string, number, bigint, or Uint512 object"
+      "Unsupported data type 'boolean' for u512. Expected a numeric string (decimal or hexadecimal), number, bigint, or Uint512 object"
     );
   });
 
@@ -288,6 +289,22 @@ describe('CairoUint512 class test', () => {
       limb1: '0x11111111111111111111111111111111',
       limb2: '0x22222222222222222222222222222222',
       limb3: '0x33333333333333333333333333333333',
+    });
+  });
+
+  describe('toApiRequest is flagged as compiled', () => {
+    test('should carry the __compiled__ flag', () => {
+      const result = new CairoUint512(255).toApiRequest();
+      expect(result).toEqual(['255', '0', '0', '0']);
+      expect(result).toHaveProperty('__compiled__', true);
+    });
+
+    test('should be taken as calldata by a call that skips request parsing', () => {
+      // the shape `Contract.invoke` builds under `withOptions({ parseRequest: false })` : `args` is
+      // the argument list, its only item is already serialized, and the callback hands `args` back
+      // untouched. Only the flag tells the two apart, and without it the calldata stays nested.
+      const args = [new CairoUint512(255).toApiRequest()];
+      expect(transaction.getCompiledCalldata(args, () => args)).toEqual(['255', '0', '0', '0']);
     });
   });
 });

--- a/__tests__/utils/calldata/requestParser.test.ts
+++ b/__tests__/utils/calldata/requestParser.test.ts
@@ -341,7 +341,7 @@ describe('requestParser', () => {
         })
       ).toThrow(
         new Error(
-          "Unsupported data type 'string' for u256. Expected string, number, bigint, or Uint256 object"
+          "Unsupported data type 'string' for u256. Expected a numeric string (decimal or hexadecimal), number, bigint, or Uint256 object"
         )
       );
     });

--- a/src/utils/cairoDataTypes/fixedArray.ts
+++ b/src/utils/cairoDataTypes/fixedArray.ts
@@ -97,25 +97,9 @@ export class CairoFixedArray {
       `The type ${arrayType} is not a Cairo fixed array. Needs [type; length].`
     );
 
-    // Validate that the type includes content type
-    try {
-      CairoFixedArray.getFixedArrayType(arrayType);
-    } catch {
-      throw new Error(
-        `The type ${arrayType} do not includes any content type. Needs [type; length].`
-      );
-    }
-
-    // Validate that the type includes array size
-    let arraySize: number;
-    try {
-      arraySize = CairoFixedArray.getFixedArraySize(arrayType);
-    } catch {
-      throw new Error(
-        `The type ${arrayType} type do not includes any length. Needs [type; length].`
-      );
-    }
-
+    // the assert above already had `parseFixedArrayType` read the type, and this reads it again on
+    // the same string : both halves are there, so this cannot raise.
+    const arraySize = CairoFixedArray.getFixedArraySize(arrayType);
     assert(
       arraySize === content.length,
       `The ABI type ${arrayType} is expecting ${arraySize} items. ${content.length} items provided.`

--- a/src/utils/cairoDataTypes/uint256.ts
+++ b/src/utils/cairoDataTypes/uint256.ts
@@ -5,6 +5,7 @@ import { addHexPrefix } from '../encode';
 import { isObject } from '../typed';
 import { getNext, isBigNumberish } from '../num';
 import assert from '../assert';
+import { addCompiledFlag } from '../helpers';
 
 /**
  * The largest u128, and the mask that cuts a u256 in two.
@@ -171,8 +172,8 @@ export class CairoUint256 {
   /**
    * Throw unless a whole value can be represented as a u256, and give back its number.
    *
-   * A string is only accepted while it spells a number : one that does not is refused for its
-   * type, whatever the message says about strings.
+   * A string is only accepted while it spells a number, in base 10 or 16 : one that does not is
+   * refused for its type.
    * @param {BigNumberish} bigNumberish the value to check
    * @returns {bigint} the value as a number, once accepted
    * @throws {Error} when the value is null, undefined, of an unread type, or out of range
@@ -189,7 +190,7 @@ export class CairoUint256 {
     assert(bigNumberish !== undefined, 'undefined value is not allowed for u256');
     assert(
       isBigNumberish(bigNumberish) || isObject(bigNumberish),
-      `Unsupported data type '${typeof bigNumberish}' for u256. Expected string, number, bigint, or Uint256 object`
+      `Unsupported data type '${typeof bigNumberish}' for u256. Expected a numeric string (decimal or hexadecimal), number, bigint, or Uint256 object`
     );
 
     const bigInt = BigInt(bigNumberish as BigNumberish);
@@ -335,7 +336,7 @@ export class CairoUint256 {
 
   /**
    * Serialize to the two felts a contract call carries.
-   * @returns {string[]} the two halves as decimal strings, low first
+   * @returns {string[]} the two halves as decimal strings, low first, flagged as compiled
    * @example
    * ```typescript
    * const result = new CairoUint256(255).toApiRequest();
@@ -343,6 +344,6 @@ export class CairoUint256 {
    * ```
    */
   toApiRequest() {
-    return [this.low.toString(), this.high.toString()];
+    return addCompiledFlag([this.low.toString(), this.high.toString()]);
   }
 }

--- a/src/utils/cairoDataTypes/uint32.ts
+++ b/src/utils/cairoDataTypes/uint32.ts
@@ -161,7 +161,7 @@ export class CairoUint32 {
    * ```typescript
    * CairoUint32.validate(70000); // passes
    * CairoUint32.validate(4294967296);
-   * // throws Error("Value is out of u32 range [0, 2^32)")
+   * // throws Error("Value is out of u32 range [0, 4294967295]")
    * ```
    */
   static validate(data: BigNumberish | boolean | unknown): void {
@@ -173,7 +173,10 @@ export class CairoUint32 {
     );
 
     const value = CairoUint32.__processData(data);
-    assert(value >= RANGE_U32.min && value <= RANGE_U32.max, 'Value is out of u32 range [0, 2^32)');
+    assert(
+      value >= RANGE_U32.min && value <= RANGE_U32.max,
+      `Value is out of u32 range [${RANGE_U32.min}, ${RANGE_U32.max}]`
+    );
   }
 
   /**

--- a/src/utils/cairoDataTypes/uint512.ts
+++ b/src/utils/cairoDataTypes/uint512.ts
@@ -6,6 +6,7 @@ import { UINT_128_MAX } from './uint256';
 import { isObject } from '../typed';
 import { getNext, isBigNumberish } from '../num';
 import assert from '../assert';
+import { addCompiledFlag } from '../helpers';
 
 /**
  * The largest u512, 2^512 - 1.
@@ -174,8 +175,8 @@ export class CairoUint512 {
   /**
    * Throw unless a whole value can be represented as a u512, and give back its number.
    *
-   * A string is only accepted while it spells a number : one that does not is refused for its
-   * type, whatever the message says about strings.
+   * A string is only accepted while it spells a number, in base 10 or 16 : one that does not is
+   * refused for its type.
    * @param {BigNumberish} bigNumberish the value to check
    * @returns {bigint} the value as a number, once accepted
    * @throws {Error} when the value is null, undefined, of an unread type, or out of range
@@ -192,7 +193,7 @@ export class CairoUint512 {
     assert(bigNumberish !== undefined, 'undefined value is not allowed for u512');
     assert(
       isBigNumberish(bigNumberish) || isObject(bigNumberish),
-      `Unsupported data type '${typeof bigNumberish}' for u512. Expected string, number, bigint, or Uint512 object`
+      `Unsupported data type '${typeof bigNumberish}' for u512. Expected a numeric string (decimal or hexadecimal), number, bigint, or Uint512 object`
     );
 
     const bigInt = BigInt(bigNumberish as BigNumberish);
@@ -351,7 +352,7 @@ export class CairoUint512 {
 
   /**
    * Serialize to the four felts a contract call carries.
-   * @returns {string[]} the four limbs as decimal strings, lowest first
+   * @returns {string[]} the four limbs as decimal strings, lowest first, flagged as compiled
    * @example
    * ```typescript
    * const result = new CairoUint512(255).toApiRequest();
@@ -360,11 +361,11 @@ export class CairoUint512 {
    */
   toApiRequest(): string[] {
     // lower limb first : https://github.com/starkware-libs/cairo/blob/07484c52791b76abcc18fd86265756904557d0d2/corelib/src/test/integer_test.cairo#L767
-    return [
+    return addCompiledFlag([
       this.limb0.toString(),
       this.limb1.toString(),
       this.limb2.toString(),
       this.limb3.toString(),
-    ];
+    ]);
   }
 }


### PR DESCRIPTION
## Motivation and Resolution

Four behaviour anomalies in `src/utils/cairoDataTypes/`, found while re-reading the directory
after its JSDoc pass. None of them is urgent, hence `beta` as the target branch.

**1. `toApiRequest()` did not flag its result on `u256` and `u512`.** The 14 other classes of the
directory pass theirs through `addCompiledFlag`. The `__compiled__` flag is read in only two
places, both on a whole calldata array, and `Array.prototype.concat` drops it — so it plays no
part in normal calldata assembly. It is load-bearing in exactly one place: `getCompiledCalldata`
is what flattens `args` when request parsing is skipped. Without the flag:

```typescript
// before
await contract
  .withOptions({ parseRequest: false })
  .store_u256(new CairoUint256(255).toApiRequest());
// calldata sent: [["255", "0"]]   nested, plus a "possible malfunction request" warning
```

That same pattern is already exercised for u8 / u128 / i64 and `ByteArray` in
`__tests__/integerTypesContract.test.ts` and `__tests__/cairoByteArrayContract.test.ts`, which is
why the fix aligns `u256`/`u512` on the other classes rather than the other way round.

**2. `CairoUint32` hardcoded its range message.** It was the only one of the six unsigned classes
not to interpolate `RANGE_U32`, and it announced an open bound `[0, 2^32)` instead of the closed
bound actually asserted. Now built like its five siblings.

**3. Two unreachable branches in the `CairoFixedArray` constructor.** The `assert` above them
requires `isTypeFixedArray(arrayType)`, which is `parseFixedArrayType(type) !== undefined`, and
both `getFixedArrayType` and `getFixedArraySize` throw only when that same call returns
`undefined` — so past the assert neither can raise. Confirmed by feeding the constructor every
word of length 1 to 8 over the alphabet `[ ] ; ␣ 0 a` plus 22 realistic types: 8 062 240 calls,
two distinct messages, neither of them the two suspects. Removing the branches leaves the same
two messages at the same counts.

**4. Misleading `validate()` message on `u256` and `u512`.** `CairoUint256.validate('abc')` threw
`Unsupported data type 'string' ... Expected string, number, bigint, or Uint256 object` — claiming
to accept strings while refusing that one. Only a string that spells a number passes
`isBigNumberish`: `'255'` and `'0xff'` are accepted, `'abc'`, `'-1'` and `'1e3'` are not. Behaviour
is unchanged, only the message is corrected.

### RPC version (if applicable)

Not applicable.

## Usage related changes

- `CairoUint256.toApiRequest()` and `CairoUint512.toApiRequest()` now return an array flagged as
  compiled calldata. Passing one as the sole argument of a call made with `parseRequest: false`
  now yields flat calldata instead of a nested array.
- `CairoUint32` out-of-range errors now read `Value is out of u32 range [0, 4294967295]` instead
  of `Value is out of u32 range [0, 2^32)`.
- `CairoUint256.validate()` and `CairoUint512.validate()` refuse exactly the same values as
  before, but the message now names what is accepted:
  `Expected a numeric string (decimal or hexadecimal), number, bigint, or Uint256 object`.
- Two `CairoFixedArray` constructor messages are gone (`do not includes any content type`,
  `do not includes any length`). No input ever produced them, so nothing stops being reported.

## Development related changes

- 5 unit tests added: the compiled flag and its effect through `getCompiledCalldata`, for `u256`
  and for `u512`; and a characterisation test pinning the two — and only two — ways the
  `CairoFixedArray` constructor refuses, which is what makes the branch removal safe to review.
- Test assertions realigned on the two corrected messages, in `CairoUint32.test.ts`,
  `CairoUint256.test.ts`, `CairoUint512.test.ts` and `utils/calldata/requestParser.test.ts`.
- `__tests__/utils/cairoDataTypes`: 822 → 827 tests.
- Ran locally: the whole `unit` project (78 suites, 1689 tests, 1 skipped), `ts:check`, ESLint and
  Prettier on the touched files. The devnet-backed suites were not run locally and are left to CI.

## Checklist:

- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Documented the changes in code (API docs will be generated automatically)
- [x] Updated the tests
- [x] All tests are passing
