### PR TITLE
feat!: add CairoBool, CairoEthAddress and CairoSecp256k1Point

### DIFF
--- a/__tests__/utils/cairoDataTypes/CairoBool.test.ts
+++ b/__tests__/utils/cairoDataTypes/CairoBool.test.ts
@@ -1,0 +1,196 @@
+import { CairoBool } from '../../../src';
+
+describe('CairoBool class Unit Tests', () => {
+  describe('constructor with different input types', () => {
+    test('should handle boolean input', () => {
+      expect(new CairoBool(true).data).toBe(true);
+      expect(new CairoBool(false).data).toBe(false);
+    });
+
+    test('should handle the two numbers a bool occupies', () => {
+      expect(new CairoBool(1).data).toBe(true);
+      expect(new CairoBool(0).data).toBe(false);
+    });
+
+    test('should handle bigint input', () => {
+      expect(new CairoBool(1n).data).toBe(true);
+      expect(new CairoBool(0n).data).toBe(false);
+    });
+
+    test('should handle decimal string input', () => {
+      expect(new CairoBool('1').data).toBe(true);
+      expect(new CairoBool('0').data).toBe(false);
+    });
+
+    test('should handle hexadecimal string input, as a response felt arrives', () => {
+      expect(new CairoBool('0x1').data).toBe(true);
+      expect(new CairoBool('0x0').data).toBe(false);
+    });
+
+    test('should always store a boolean', () => {
+      expect(typeof new CairoBool(1).data).toBe('boolean');
+      expect(typeof new CairoBool('0x0').data).toBe('boolean');
+    });
+  });
+
+  describe('a bool is exactly two values', () => {
+    test('should reject any other number, naming the value received', () => {
+      expect(() => new CairoBool(2)).toThrow(
+        'Only values 0 or 1 are possible in a core::bool, received 2'
+      );
+      expect(() => new CairoBool(255)).toThrow(
+        'Only values 0 or 1 are possible in a core::bool, received 255'
+      );
+      expect(() => new CairoBool('0x2')).toThrow(
+        'Only values 0 or 1 are possible in a core::bool, received 2'
+      );
+    });
+
+    test('should reject a negative value', () => {
+      // the message comes from the encoding layer rather than from this class
+      expect(() => new CairoBool(-1)).toThrow('Cannot convert negative bigint');
+    });
+  });
+
+  describe('text is not a bool', () => {
+    test('should reject free-form text', () => {
+      expect(() => new CairoBool('abc')).toThrow(
+        'Invalid input: a core::bool cannot be built from text'
+      );
+      expect(() => new CairoBool('true')).toThrow(
+        'Invalid input: a core::bool cannot be built from text'
+      );
+      expect(() => new CairoBool('')).toThrow(
+        'Invalid input: a core::bool cannot be built from text'
+      );
+    });
+  });
+
+  describe('inputs a felt252 does not read', () => {
+    test('should reject null and undefined', () => {
+      expect(() => new CairoBool(null)).toThrow('null value is not allowed for felt252');
+      expect(() => new CairoBool(undefined)).toThrow('undefined value is not allowed for felt252');
+    });
+
+    test('should reject objects and arrays', () => {
+      expect(() => new CairoBool({})).toThrow("Unsupported data type 'object' for felt252");
+      expect(() => new CairoBool([])).toThrow("Unsupported data type 'object' for felt252");
+    });
+
+    test('should reject a decimal number', () => {
+      expect(() => new CairoBool(1.5)).toThrow("1.5 can't be computed by felt()");
+    });
+  });
+
+  describe('toBoolean method', () => {
+    test('should return the stored boolean', () => {
+      expect(new CairoBool(true).toBoolean()).toBe(true);
+      expect(new CairoBool(0).toBoolean()).toBe(false);
+      expect(new CairoBool('0x1').toBoolean()).toBe(true);
+    });
+  });
+
+  describe('toHexString method', () => {
+    test('should return the felt a bool occupies', () => {
+      expect(new CairoBool(true).toHexString()).toBe('0x1');
+      expect(new CairoBool(false).toHexString()).toBe('0x0');
+    });
+  });
+
+  describe('toApiRequest method', () => {
+    test('should return one decimal-string felt', () => {
+      expect([...new CairoBool(true).toApiRequest()]).toEqual(['1']);
+      expect([...new CairoBool(false).toApiRequest()]).toEqual(['0']);
+    });
+
+    test('should flag the result as compiled', () => {
+      const request = new CairoBool(true).toApiRequest();
+      expect(request).toHaveProperty('__compiled__', true);
+      // the flag is not enumerable, so it does not show up as an element
+      expect(Object.keys(request)).toEqual(['0']);
+    });
+  });
+
+  describe('validate static method', () => {
+    test('should pass for the accepted inputs', () => {
+      expect(() => CairoBool.validate(true)).not.toThrow();
+      expect(() => CairoBool.validate(false)).not.toThrow();
+      expect(() => CairoBool.validate(1)).not.toThrow();
+      expect(() => CairoBool.validate(0n)).not.toThrow();
+      expect(() => CairoBool.validate('0x1')).not.toThrow();
+    });
+
+    test('should throw for a number that is neither 0 nor 1', () => {
+      expect(() => CairoBool.validate(2)).toThrow(
+        'Only values 0 or 1 are possible in a core::bool, received 2'
+      );
+    });
+
+    test('should throw for text', () => {
+      expect(() => CairoBool.validate('abc')).toThrow(
+        'Invalid input: a core::bool cannot be built from text'
+      );
+    });
+  });
+
+  describe('is static method', () => {
+    test('should return true for a valid bool', () => {
+      expect(CairoBool.is(true)).toBe(true);
+      expect(CairoBool.is(false)).toBe(true);
+      expect(CairoBool.is(1)).toBe(true);
+      expect(CairoBool.is(0)).toBe(true);
+      expect(CairoBool.is('0x1')).toBe(true);
+    });
+
+    test('should return false for anything this class refuses', () => {
+      expect(CairoBool.is(2)).toBe(false);
+      expect(CairoBool.is(-1)).toBe(false);
+      expect(CairoBool.is(1.5)).toBe(false);
+      expect(CairoBool.is('abc')).toBe(false);
+      expect(CairoBool.is(null)).toBe(false);
+      expect(CairoBool.is(undefined)).toBe(false);
+      expect(CairoBool.is({})).toBe(false);
+      expect(CairoBool.is([])).toBe(false);
+    });
+  });
+
+  describe('isAbiType static method', () => {
+    test('should recognise its own abi type', () => {
+      expect(CairoBool.abiSelector).toBe('core::bool');
+      expect(CairoBool.isAbiType('core::bool')).toBe(true);
+    });
+
+    test('should reject any other abi type', () => {
+      expect(CairoBool.isAbiType('core::felt252')).toBe(false);
+      expect(CairoBool.isAbiType('core::integer::u8')).toBe(false);
+    });
+  });
+
+  describe('factoryFromApiResponse static method', () => {
+    test('should read one bool off a response', () => {
+      expect(CairoBool.factoryFromApiResponse(['0x1'].values()).toBoolean()).toBe(true);
+      expect(CairoBool.factoryFromApiResponse(['0x0'].values()).toBoolean()).toBe(false);
+    });
+
+    test('should consume exactly one felt per call', () => {
+      const iterator = ['0x1', '0x0'].values();
+      expect(CairoBool.factoryFromApiResponse(iterator).toBoolean()).toBe(true);
+      expect(CairoBool.factoryFromApiResponse(iterator).toBoolean()).toBe(false);
+    });
+
+    test('should refuse a felt that is neither 0 nor 1', () => {
+      expect(() => CairoBool.factoryFromApiResponse(['0x2'].values())).toThrow(
+        'Only values 0 or 1 are possible in a core::bool, received 2'
+      );
+    });
+  });
+
+  describe('round-trip consistency', () => {
+    test('should survive a serialize then read back cycle', () => {
+      [true, false].forEach((value) => {
+        const felts = [...new CairoBool(value).toApiRequest()];
+        expect(CairoBool.factoryFromApiResponse(felts.values()).toBoolean()).toBe(value);
+      });
+    });
+  });
+});

--- a/__tests__/utils/cairoDataTypes/CairoEthAddress.test.ts
+++ b/__tests__/utils/cairoDataTypes/CairoEthAddress.test.ts
@@ -1,0 +1,250 @@
+import { CairoEthAddress, ETH_ADDRESS } from '../../../src';
+import { RANGE_ETH_ADDRESS } from '../../../src/global/constants';
+
+// vitalik.eth, the canonical 40-hex-digit address
+const REAL_ADDRESS = '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045';
+
+describe('CairoEthAddress class Unit Tests', () => {
+  describe('constructor with different input types', () => {
+    test('should handle number input', () => {
+      expect(new CairoEthAddress(4660).data).toBe(4660n);
+      expect(new CairoEthAddress(0).data).toBe(0n);
+    });
+
+    test('should handle bigint input', () => {
+      expect(new CairoEthAddress(4660n).data).toBe(4660n);
+      expect(new CairoEthAddress(0n).data).toBe(0n);
+    });
+
+    test('should handle hexadecimal string input', () => {
+      expect(new CairoEthAddress('0x1234').data).toBe(4660n);
+      expect(new CairoEthAddress('0x0').data).toBe(0n);
+    });
+
+    test('should handle decimal string input', () => {
+      expect(new CairoEthAddress('4660').data).toBe(4660n);
+    });
+
+    test('should handle boolean input', () => {
+      expect(new CairoEthAddress(true).data).toBe(1n);
+      expect(new CairoEthAddress(false).data).toBe(0n);
+    });
+
+    test('should read the same address whatever the input shape', () => {
+      const fromHex = new CairoEthAddress('0x1234').toBigInt();
+      const fromDecimalString = new CairoEthAddress('4660').toBigInt();
+      const fromNumber = new CairoEthAddress(4660).toBigInt();
+      const fromBigint = new CairoEthAddress(4660n).toBigInt();
+
+      expect(fromHex).toBe(4660n);
+      expect(fromDecimalString).toBe(4660n);
+      expect(fromNumber).toBe(4660n);
+      expect(fromBigint).toBe(4660n);
+    });
+
+    test('should always store a bigint', () => {
+      expect(typeof new CairoEthAddress(200).data).toBe('bigint');
+    });
+
+    test('should carry a real Ethereum address unchanged', () => {
+      const address = new CairoEthAddress(REAL_ADDRESS);
+      expect(address.toHexString()).toBe(REAL_ADDRESS.toLowerCase());
+    });
+  });
+
+  describe('range', () => {
+    test('should accept the whole 160-bit range', () => {
+      expect(() => new CairoEthAddress(RANGE_ETH_ADDRESS.min)).not.toThrow();
+      expect(() => new CairoEthAddress(RANGE_ETH_ADDRESS.max)).not.toThrow();
+      expect(new CairoEthAddress(RANGE_ETH_ADDRESS.max).toBigInt()).toBe(RANGE_ETH_ADDRESS.max);
+    });
+
+    test('should reject a value one bit too wide', () => {
+      expect(() => new CairoEthAddress(RANGE_ETH_ADDRESS.max + 1n)).toThrow(
+        `Value is out of EthAddress range [${RANGE_ETH_ADDRESS.min}, ${RANGE_ETH_ADDRESS.max}]`
+      );
+      expect(() => new CairoEthAddress(2n ** 161n)).toThrow('Value is out of EthAddress range');
+    });
+
+    test('should reject an out-of-range decimal string', () => {
+      expect(() => new CairoEthAddress((2n ** 162n).toString(10))).toThrow(
+        'Value is out of EthAddress range'
+      );
+    });
+
+    test('should reject a negative value', () => {
+      // the message comes from the encoding layer rather than from this class
+      expect(() => new CairoEthAddress(-1)).toThrow('Cannot convert negative bigint');
+      expect(() => new CairoEthAddress(-1n)).toThrow('Cannot convert negative bigint');
+    });
+  });
+
+  describe('text is not an address', () => {
+    test('should reject free-form text', () => {
+      expect(() => new CairoEthAddress('abc')).toThrow(
+        'Invalid input: an EthAddress cannot be built from text'
+      );
+      expect(() => new CairoEthAddress('a')).toThrow(
+        'Invalid input: an EthAddress cannot be built from text'
+      );
+      expect(() => new CairoEthAddress('')).toThrow(
+        'Invalid input: an EthAddress cannot be built from text'
+      );
+    });
+
+    test('should reject a malformed hexadecimal string, which reads as text', () => {
+      expect(() => new CairoEthAddress('0xZZ')).toThrow(
+        'Invalid input: an EthAddress cannot be built from text'
+      );
+    });
+
+    test('should reject a signed numeric string, which also reads as text', () => {
+      // '-1' is neither hexadecimal nor a whole number, so it is text as far as isText is concerned
+      expect(() => new CairoEthAddress('-1')).toThrow(
+        'Invalid input: an EthAddress cannot be built from text'
+      );
+    });
+  });
+
+  describe('inputs a felt252 does not read', () => {
+    test('should reject null and undefined', () => {
+      expect(() => new CairoEthAddress(null)).toThrow('null value is not allowed for felt252');
+      expect(() => new CairoEthAddress(undefined)).toThrow(
+        'undefined value is not allowed for felt252'
+      );
+    });
+
+    test('should reject objects and arrays', () => {
+      expect(() => new CairoEthAddress({})).toThrow("Unsupported data type 'object' for felt252");
+      expect(() => new CairoEthAddress([])).toThrow("Unsupported data type 'object' for felt252");
+    });
+
+    test('should reject a symbol', () => {
+      expect(() => new CairoEthAddress(Symbol('address'))).toThrow(
+        "Unsupported data type 'symbol' for felt252"
+      );
+    });
+
+    test('should reject a decimal number', () => {
+      expect(() => new CairoEthAddress(42.5)).toThrow("42.5 can't be computed by felt()");
+    });
+  });
+
+  describe('toBigInt method', () => {
+    test('should return the stored value', () => {
+      [0, 1, 4660, 255].forEach((val) => {
+        expect(new CairoEthAddress(val).toBigInt()).toBe(BigInt(val));
+      });
+    });
+
+    test('should return the maximum address', () => {
+      expect(new CairoEthAddress(RANGE_ETH_ADDRESS.max).toBigInt()).toBe(RANGE_ETH_ADDRESS.max);
+    });
+  });
+
+  describe('toHexString method', () => {
+    test('should return an unpadded hexadecimal string', () => {
+      expect(new CairoEthAddress(4660).toHexString()).toBe('0x1234');
+      expect(new CairoEthAddress(0).toHexString()).toBe('0x0');
+    });
+
+    test('should drop leading zeros', () => {
+      expect(new CairoEthAddress('0x0034').toHexString()).toBe('0x34');
+    });
+  });
+
+  describe('toApiRequest method', () => {
+    test('should return one decimal-string felt', () => {
+      expect([...new CairoEthAddress('0x1234').toApiRequest()]).toEqual(['4660']);
+      expect([...new CairoEthAddress(0).toApiRequest()]).toEqual(['0']);
+    });
+
+    test('should flag the result as compiled', () => {
+      const request = new CairoEthAddress('0x1234').toApiRequest();
+      expect(request).toHaveProperty('__compiled__', true);
+      // the flag is not enumerable, so it does not show up as an element
+      expect(Object.keys(request)).toEqual(['0']);
+    });
+  });
+
+  describe('validate static method', () => {
+    test('should pass for a value in range', () => {
+      expect(() => CairoEthAddress.validate('0x1234')).not.toThrow();
+      expect(() => CairoEthAddress.validate(RANGE_ETH_ADDRESS.max)).not.toThrow();
+    });
+
+    test('should throw for a value out of range', () => {
+      expect(() => CairoEthAddress.validate(RANGE_ETH_ADDRESS.max + 1n)).toThrow(
+        'Value is out of EthAddress range'
+      );
+    });
+
+    test('should throw for text', () => {
+      expect(() => CairoEthAddress.validate('abc')).toThrow(
+        'Invalid input: an EthAddress cannot be built from text'
+      );
+    });
+  });
+
+  describe('is static method', () => {
+    test('should return true for a valid address', () => {
+      expect(CairoEthAddress.is('0x1234')).toBe(true);
+      expect(CairoEthAddress.is(0)).toBe(true);
+      expect(CairoEthAddress.is(RANGE_ETH_ADDRESS.max)).toBe(true);
+      expect(CairoEthAddress.is(REAL_ADDRESS)).toBe(true);
+    });
+
+    test('should return false for anything this class refuses', () => {
+      expect(CairoEthAddress.is('abc')).toBe(false);
+      expect(CairoEthAddress.is(RANGE_ETH_ADDRESS.max + 1n)).toBe(false);
+      expect(CairoEthAddress.is(-1)).toBe(false);
+      expect(CairoEthAddress.is(42.5)).toBe(false);
+      expect(CairoEthAddress.is(null)).toBe(false);
+      expect(CairoEthAddress.is(undefined)).toBe(false);
+      expect(CairoEthAddress.is({})).toBe(false);
+      expect(CairoEthAddress.is([])).toBe(false);
+    });
+  });
+
+  describe('isAbiType static method', () => {
+    test('should recognise its own abi type', () => {
+      expect(CairoEthAddress.abiSelector).toBe(ETH_ADDRESS);
+      expect(CairoEthAddress.isAbiType(ETH_ADDRESS)).toBe(true);
+      expect(CairoEthAddress.isAbiType('core::starknet::eth_address::EthAddress')).toBe(true);
+    });
+
+    test('should reject any other abi type', () => {
+      expect(CairoEthAddress.isAbiType('core::felt252')).toBe(false);
+      expect(CairoEthAddress.isAbiType('core::integer::u8')).toBe(false);
+    });
+  });
+
+  describe('factoryFromApiResponse static method', () => {
+    test('should read one address off a response', () => {
+      const response = ['0x1234'];
+      expect(CairoEthAddress.factoryFromApiResponse(response.values()).toBigInt()).toBe(4660n);
+    });
+
+    test('should consume exactly one felt per call', () => {
+      const iterator = ['0x1', '0x2'].values();
+      expect(CairoEthAddress.factoryFromApiResponse(iterator).toBigInt()).toBe(1n);
+      expect(CairoEthAddress.factoryFromApiResponse(iterator).toBigInt()).toBe(2n);
+    });
+
+    test('should read a real address back', () => {
+      const response = [REAL_ADDRESS];
+      expect(CairoEthAddress.factoryFromApiResponse(response.values()).toHexString()).toBe(
+        REAL_ADDRESS.toLowerCase()
+      );
+    });
+  });
+
+  describe('round-trip consistency', () => {
+    test('should survive a serialize then read back cycle', () => {
+      [0n, 1n, 4660n, RANGE_ETH_ADDRESS.max].forEach((value) => {
+        const felts = [...new CairoEthAddress(value).toApiRequest()];
+        expect(CairoEthAddress.factoryFromApiResponse(felts.values()).toBigInt()).toBe(value);
+      });
+    });
+  });
+});

--- a/__tests__/utils/cairoDataTypes/CairoSecp256k1Point.test.ts
+++ b/__tests__/utils/cairoDataTypes/CairoSecp256k1Point.test.ts
@@ -1,0 +1,294 @@
+import {
+  CairoSecp256k1Point,
+  SECP256K1_POINT_MAX,
+  SECP256K1_POINT_MIN,
+  Literal,
+} from '../../../src';
+
+// a full-width 512-bit value, x || y, as an uncompressed public key reads once its 04 prefix is gone
+const PUB_KEY = BigInt(`0x${'1a'.repeat(64)}`);
+
+/** Recompose the 512-bit value the four limbs stand for, x in the upper 256 bits. */
+const limbsToValue = (xLow: bigint, xHigh: bigint, yLow: bigint, yHigh: bigint) =>
+  (xHigh * 2n ** 128n + xLow) * 2n ** 256n + yHigh * 2n ** 128n + yLow;
+
+describe('CairoSecp256k1Point class Unit Tests', () => {
+  describe('constructor from a single 512-bit value', () => {
+    test('should split x into the upper 256 bits and y into the lower ones', () => {
+      const point = new CairoSecp256k1Point(1n);
+      expect(point.xLow).toBe(0n);
+      expect(point.xHigh).toBe(0n);
+      expect(point.yLow).toBe(1n);
+      expect(point.yHigh).toBe(0n);
+    });
+
+    test('should split each coordinate into its two limbs', () => {
+      const value = limbsToValue(1n, 2n, 3n, 4n);
+      const point = new CairoSecp256k1Point(value);
+      expect(point.xLow).toBe(1n);
+      expect(point.xHigh).toBe(2n);
+      expect(point.yLow).toBe(3n);
+      expect(point.yHigh).toBe(4n);
+    });
+
+    test('should accept a hexadecimal or decimal string', () => {
+      expect(new CairoSecp256k1Point('0x1234').toBigInt()).toBe(4660n);
+      expect(new CairoSecp256k1Point('4660').toBigInt()).toBe(4660n);
+    });
+
+    test('should carry a full-width key unchanged', () => {
+      expect(new CairoSecp256k1Point(PUB_KEY).toBigInt()).toBe(PUB_KEY);
+    });
+  });
+
+  describe('constructor from the four limbs', () => {
+    test('should keep the limbs in the order a call carries them', () => {
+      const point = new CairoSecp256k1Point(1, 2, 3, 4);
+      expect(point.xLow).toBe(1n);
+      expect(point.xHigh).toBe(2n);
+      expect(point.yLow).toBe(3n);
+      expect(point.yHigh).toBe(4n);
+    });
+
+    test('should agree with the single-value form', () => {
+      expect(new CairoSecp256k1Point(0, 0, 1, 0).toBigInt()).toBe(1n);
+      expect(new CairoSecp256k1Point(0, 0, 3, 0).toBigInt()).toBe(3n);
+    });
+  });
+
+  describe('constructor from a Secp256k1PointStruct', () => {
+    test('should read the four named limbs', () => {
+      const point = new CairoSecp256k1Point({ xLow: 1, xHigh: 2, yLow: 3, yHigh: 4 });
+      expect(point.xLow).toBe(1n);
+      expect(point.xHigh).toBe(2n);
+      expect(point.yLow).toBe(3n);
+      expect(point.yHigh).toBe(4n);
+    });
+
+    test('should accept hexadecimal limbs', () => {
+      const point = new CairoSecp256k1Point({
+        xLow: '0x1',
+        xHigh: '0x2',
+        yLow: '0x3',
+        yHigh: '0x4',
+      });
+      expect(point.toBigInt()).toBe(limbsToValue(1n, 2n, 3n, 4n));
+    });
+
+    test('should refuse an object that is not one, reading it as a value instead', () => {
+      expect(() => new CairoSecp256k1Point({ xLow: 1 } as any)).toThrow(
+        'Unsupported input for Secp256k1Point'
+      );
+      expect(() => new CairoSecp256k1Point({})).toThrow('Unsupported input for Secp256k1Point');
+    });
+  });
+
+  describe('range', () => {
+    test('should accept the whole 512-bit range', () => {
+      expect(() => new CairoSecp256k1Point(SECP256K1_POINT_MIN)).not.toThrow();
+      expect(new CairoSecp256k1Point(SECP256K1_POINT_MAX).toBigInt()).toBe(SECP256K1_POINT_MAX);
+    });
+
+    test('should reject a value one bit too wide', () => {
+      expect(() => new CairoSecp256k1Point(SECP256K1_POINT_MAX + 1n)).toThrow(
+        'input is bigger than SECP256K1_POINT_MAX'
+      );
+    });
+
+    test('should reject a negative value', () => {
+      expect(() => new CairoSecp256k1Point(-1)).toThrow(
+        'input is smaller than SECP256K1_POINT_MIN'
+      );
+    });
+
+    test('should expose the two bounds', () => {
+      expect(SECP256K1_POINT_MAX).toBe(2n ** 512n - 1n);
+      expect(SECP256K1_POINT_MIN).toBe(0n);
+    });
+  });
+
+  describe('inputs this class does not read', () => {
+    test('should reject null and undefined', () => {
+      expect(() => new CairoSecp256k1Point(null)).toThrow(
+        'null value is not allowed for Secp256k1Point'
+      );
+      expect(() => new CairoSecp256k1Point(undefined)).toThrow(
+        'undefined value is not allowed for Secp256k1Point'
+      );
+    });
+
+    test('should reject text and arrays', () => {
+      expect(() => new CairoSecp256k1Point('abc')).toThrow(
+        "Unsupported input for Secp256k1Point. Expected a number, a bigint, or a string spelling one, received 'string'"
+      );
+      expect(() => new CairoSecp256k1Point([])).toThrow('Unsupported input for Secp256k1Point');
+    });
+
+    test('should reject a decimal number', () => {
+      // the message comes from BigInt itself: isBigNumberish lets a non-integer number through
+      expect(() => new CairoSecp256k1Point(1.5)).toThrow('cannot be converted to a BigInt');
+    });
+
+    test('should reject any argument count other than 1 or 4', () => {
+      expect(() => new (CairoSecp256k1Point as any)()).toThrow(
+        'Incorrect Secp256k1Point constructor parameters'
+      );
+      expect(() => new (CairoSecp256k1Point as any)(1, 2)).toThrow(
+        'Incorrect Secp256k1Point constructor parameters'
+      );
+      expect(() => new (CairoSecp256k1Point as any)(1, 2, 3)).toThrow(
+        'Incorrect Secp256k1Point constructor parameters'
+      );
+    });
+  });
+
+  describe('validateProps static method', () => {
+    test('should return the four limbs as bigints', () => {
+      expect(CairoSecp256k1Point.validateProps(1, 2, 3, 4)).toEqual({
+        xLow: 1n,
+        xHigh: 2n,
+        yLow: 3n,
+        yHigh: 4n,
+      });
+    });
+
+    test('should name the limb that is too wide', () => {
+      expect(() => CairoSecp256k1Point.validateProps(2n ** 128n, 2, 3, 4)).toThrow(
+        'xLow must fit in 128 bits'
+      );
+      expect(() => CairoSecp256k1Point.validateProps(1, 2, 3, 2n ** 128n)).toThrow(
+        'yHigh must fit in 128 bits'
+      );
+    });
+
+    test('should name the limb that is negative or missing', () => {
+      expect(() => CairoSecp256k1Point.validateProps(-1, 2, 3, 4)).toThrow(
+        'xLow must be non-negative'
+      );
+      expect(() => CairoSecp256k1Point.validateProps(null as any, 2, 3, 4)).toThrow(
+        'xLow cannot be null'
+      );
+    });
+  });
+
+  describe('validate static method', () => {
+    test('should return the checked value', () => {
+      expect(CairoSecp256k1Point.validate('0x1234')).toBe(4660n);
+      expect(CairoSecp256k1Point.validate(SECP256K1_POINT_MAX)).toBe(SECP256K1_POINT_MAX);
+    });
+
+    test('should throw outside the range', () => {
+      expect(() => CairoSecp256k1Point.validate(SECP256K1_POINT_MAX + 1n)).toThrow(
+        'input is bigger than SECP256K1_POINT_MAX'
+      );
+    });
+  });
+
+  describe('is static method', () => {
+    test('should return true for a value that fits in 512 bits', () => {
+      expect(CairoSecp256k1Point.is(0)).toBe(true);
+      expect(CairoSecp256k1Point.is(PUB_KEY)).toBe(true);
+      expect(CairoSecp256k1Point.is(SECP256K1_POINT_MAX)).toBe(true);
+    });
+
+    test('should return false for anything this class refuses', () => {
+      expect(CairoSecp256k1Point.is(SECP256K1_POINT_MAX + 1n)).toBe(false);
+      expect(CairoSecp256k1Point.is(-1)).toBe(false);
+      expect(CairoSecp256k1Point.is('abc')).toBe(false);
+      expect(CairoSecp256k1Point.is(null)).toBe(false);
+      expect(CairoSecp256k1Point.is({})).toBe(false);
+    });
+  });
+
+  describe('isAbiType static method', () => {
+    test('should recognise its own abi type', () => {
+      expect(CairoSecp256k1Point.abiSelector).toBe(Literal.Secp256k1Point);
+      expect(CairoSecp256k1Point.isAbiType('core::starknet::secp256k1::Secp256k1Point')).toBe(true);
+    });
+
+    test('should reject any other abi type', () => {
+      expect(CairoSecp256k1Point.isAbiType('core::felt252')).toBe(false);
+    });
+  });
+
+  describe('toApiRequest method', () => {
+    test('should return the four limbs as decimal strings', () => {
+      expect([
+        ...new CairoSecp256k1Point({ xLow: 1, xHigh: 2, yLow: 3, yHigh: 4 }).toApiRequest(),
+      ]).toEqual(['1', '2', '3', '4']);
+      expect([...new CairoSecp256k1Point(1n).toApiRequest()]).toEqual(['0', '0', '1', '0']);
+    });
+
+    test('should flag the result as compiled', () => {
+      const request = new CairoSecp256k1Point(1n).toApiRequest();
+      expect(request).toHaveProperty('__compiled__', true);
+      expect(Object.keys(request)).toEqual(['0', '1', '2', '3']);
+    });
+  });
+
+  describe('toStruct and toHexString methods', () => {
+    test('should return the limbs as unpadded hexadecimal strings', () => {
+      expect(new CairoSecp256k1Point({ xLow: 1, xHigh: 2, yLow: 3, yHigh: 4 }).toStruct()).toEqual({
+        xLow: '0x1',
+        xHigh: '0x2',
+        yLow: '0x3',
+        yHigh: '0x4',
+      });
+    });
+
+    test('should return the whole point as one hexadecimal string', () => {
+      expect(new CairoSecp256k1Point(4660n).toHexString()).toBe('0x1234');
+    });
+  });
+
+  describe('fromHex static method', () => {
+    test('should left-pad a short string to 128 hex digits', () => {
+      expect([...CairoSecp256k1Point.fromHex('0x1').toApiRequest()]).toEqual(['0', '0', '1', '0']);
+      expect(CairoSecp256k1Point.fromHex('0x').toBigInt()).toBe(0n);
+    });
+
+    test('should read a full-width key', () => {
+      expect(CairoSecp256k1Point.fromHex(`0x${'1a'.repeat(64)}`).toBigInt()).toBe(PUB_KEY);
+    });
+
+    test('should agree with the single-value constructor', () => {
+      expect(CairoSecp256k1Point.fromHex('0x1234').toBigInt()).toBe(
+        new CairoSecp256k1Point(4660n).toBigInt()
+      );
+    });
+
+    test('should refuse a string wider than 512 bits', () => {
+      expect(() => CairoSecp256k1Point.fromHex(`0x${'a'.repeat(129)}`)).toThrow(
+        'Hex string must represent exactly 512 bits (128 hex characters)'
+      );
+    });
+  });
+
+  describe('factoryFromApiResponse static method', () => {
+    test('should read four felts in the order a call carries them', () => {
+      const point = CairoSecp256k1Point.factoryFromApiResponse(
+        ['0x1', '0x2', '0x3', '0x4'].values()
+      );
+      expect(point.xLow).toBe(1n);
+      expect(point.xHigh).toBe(2n);
+      expect(point.yLow).toBe(3n);
+      expect(point.yHigh).toBe(4n);
+    });
+
+    test('should consume exactly four felts per call', () => {
+      const iterator = ['0x0', '0x0', '0x1', '0x0', '0x0', '0x0', '0x2', '0x0'].values();
+      expect(CairoSecp256k1Point.factoryFromApiResponse(iterator).toBigInt()).toBe(1n);
+      expect(CairoSecp256k1Point.factoryFromApiResponse(iterator).toBigInt()).toBe(2n);
+    });
+  });
+
+  describe('round-trip consistency', () => {
+    test('should survive a serialize then read back cycle', () => {
+      [0n, 1n, 4660n, PUB_KEY, SECP256K1_POINT_MAX].forEach((value) => {
+        const felts = [...new CairoSecp256k1Point(value).toApiRequest()];
+        expect(felts).toHaveLength(4);
+        expect(CairoSecp256k1Point.factoryFromApiResponse(felts.values()).toBigInt()).toBe(value);
+      });
+    });
+  });
+});

--- a/__tests__/utils/calldata/parser/parsingStrategy.test.ts
+++ b/__tests__/utils/calldata/parser/parsingStrategy.test.ts
@@ -110,3 +110,115 @@ describe('the default parsing strategy', () => {
     });
   });
 });
+
+const BOOL = 'core::bool';
+const ETH_ADDRESS_TYPE = 'core::starknet::eth_address::EthAddress';
+const SECP256K1_POINT = 'core::starknet::secp256k1::Secp256k1Point';
+
+/**
+ * The four felts a point occupies, worked out here rather than with the library's own helpers, so
+ * that the assertion is an independent oracle and not the implementation compared to itself.
+ */
+const expectedLimbs = (value: bigint): string[] => {
+  const x = value / 2n ** 256n;
+  const y = value % 2n ** 256n;
+  return [
+    (x % 2n ** 128n).toString(),
+    (x / 2n ** 128n).toString(),
+    (y % 2n ** 128n).toString(),
+    (y / 2n ** 128n).toString(),
+  ];
+};
+
+describe('the leaf types the strategy now carries', () => {
+  const PUB_KEY = BigInt(`0x${'1a'.repeat(64)}`);
+
+  describe('core::bool', () => {
+    test('serializes the two values a bool has', () => {
+      const callData = new CallData(abiV2(BOOL));
+      expect(callData.compile('fn', [true])).toEqual(['1']);
+      expect(callData.compile('fn', [false])).toEqual(['0']);
+    });
+
+    test('refuses a number that is neither 0 nor 1, where it used to be serialized', () => {
+      // the argument array form runs no field validation, so before this type had a branch of its
+      // own it fell to the felt252 default and 5 reached the calldata as the felt 5
+      expect(() => new CallData(abiV2(BOOL)).compile('fn', [5])).toThrow(
+        'Only values 0 or 1 are possible in a core::bool, received 5'
+      );
+    });
+
+    test('accepts the two numbers a bool occupies, in the array form', () => {
+      expect(new CallData(abiV2(BOOL)).compile('fn', [1])).toEqual(['1']);
+      expect(new CallData(abiV2(BOOL)).compile('fn', [0])).toEqual(['0']);
+    });
+
+    test('still asks for a real boolean in the named form, which validates fields first', () => {
+      // the two gates do not agree, and deliberately so: validateFields is stricter than the class
+      expect(new CallData(abiV2(BOOL)).compile('fn', { v: true })).toEqual(['1']);
+      expect(() => new CallData(abiV2(BOOL)).compile('fn', { v: 1 })).toThrow();
+    });
+
+    test('reads a bool back as a boolean', () => {
+      const callData = new CallData(abiV2(BOOL));
+      expect(callData.parse('fn', ['0x1'])).toBe(true);
+      expect(callData.parse('fn', ['0x0'])).toBe(false);
+    });
+
+    test('the fast strategy lets a non-bool through, as it does for the integers', () => {
+      expect(new CallData(abiV2(BOOL), fastParsingStrategy).compile('fn', [5])).toEqual(['5']);
+    });
+  });
+
+  describe('core::starknet::eth_address::EthAddress', () => {
+    test('serializes an address, whatever the input shape', () => {
+      const callData = new CallData(abiV2(ETH_ADDRESS_TYPE));
+      expect(callData.compile('fn', ['0x1234'])).toEqual(['4660']);
+      expect(callData.compile('fn', [4660])).toEqual(['4660']);
+    });
+
+    test('refuses text, where it used to be encoded as its UTF-8 bytes', () => {
+      expect(() => new CallData(abiV2(ETH_ADDRESS_TYPE)).compile('fn', ['abc'])).toThrow(
+        'Invalid input: an EthAddress cannot be built from text'
+      );
+    });
+
+    test('reads an address back as a number', () => {
+      expect(new CallData(abiV2(ETH_ADDRESS_TYPE)).parse('fn', ['0x1234'])).toBe(4660n);
+    });
+  });
+
+  describe('core::starknet::secp256k1::Secp256k1Point', () => {
+    test.each(abiVersions)('%s emits four felts, x then y', (_name, abiFor) => {
+      const callData = new CallData(abiFor(SECP256K1_POINT));
+      expect(callData.compile('fn', [PUB_KEY])).toEqual(expectedLimbs(PUB_KEY));
+      expect(callData.compile('fn', [1n])).toEqual(['0', '0', '1', '0']);
+    });
+
+    test('both strategies emit the same four felts, since this is not a check', () => {
+      const value = PUB_KEY;
+      expect(new CallData(abiV2(SECP256K1_POINT)).compile('fn', [value])).toEqual(
+        expectedLimbs(value)
+      );
+      expect(
+        new CallData(abiV2(SECP256K1_POINT), fastParsingStrategy).compile('fn', [value])
+      ).toEqual(expectedLimbs(value));
+    });
+
+    test('reads a point back as the single number it stands for', () => {
+      const felts = expectedLimbs(PUB_KEY).map((d) => `0x${BigInt(d).toString(16)}`);
+      expect(new CallData(abiV2(SECP256K1_POINT)).parse('fn', felts)).toBe(PUB_KEY);
+      expect(new CallData(abiV2(SECP256K1_POINT), fastParsingStrategy).parse('fn', felts)).toBe(
+        PUB_KEY
+      );
+    });
+
+    test('refuses a value wider than 512 bits, where the felts used to be corrupted', () => {
+      // padStart does not truncate, so an oversized value used to shift the slices and produce
+      // four felts that stood for something else entirely
+      expect(() => new CallData(abiV2(SECP256K1_POINT)).compile('fn', [2n ** 512n])).toThrow(
+        'input is bigger than SECP256K1_POINT_MAX'
+      );
+    });
+  });
+});

--- a/src/utils/cairoDataTypes/bool.ts
+++ b/src/utils/cairoDataTypes/bool.ts
@@ -1,0 +1,211 @@
+/* eslint-disable no-underscore-dangle */
+import { BigNumberish } from '../../types';
+import { addHexPrefix } from '../encode';
+import { getNext } from '../num';
+import { isText } from '../shortString';
+import { isBoolean } from '../typed';
+import assert from '../assert';
+import { addCompiledFlag } from '../helpers';
+import { CairoFelt252 } from './felt';
+
+/**
+ * A Cairo `core::bool` : true or false, carried in one felt252 as 1 or 0.
+ *
+ * A boolean is the natural input, but the two numbers a bool occupies on the wire are accepted
+ * too — `1`, `0n`, `'1'`, `'0x0'` — because that is how a bool comes back from a node, as a felt
+ * rather than as a JS value. Any other number is refused : a bool is not a felt narrowed to a
+ * range, it is exactly two values.
+ *
+ * On the request side the library is stricter still : `CallData.compile` runs `validateFields`
+ * first, which requires a real boolean. So a `1` reaching a `core::bool` argument is refused there
+ * before this class ever sees it.
+ * @example
+ * ```typescript
+ * // the same value, reached three ways
+ * new CairoBool(true).toBoolean(); //   true
+ * new CairoBool(1).toBoolean(); //      true
+ * new CairoBool('0x1').toBoolean(); //  true
+ * ```
+ */
+export class CairoBool {
+  /**
+   * The value, always as a boolean.
+   * @example
+   * ```typescript
+   * const result = new CairoBool('0x1').data;
+   * // result = true
+   * ```
+   */
+  data: boolean;
+
+  /**
+   * The abi type this class serializes.
+   * @example
+   * ```typescript
+   * const result = CairoBool.abiSelector;
+   * // result = "core::bool"
+   * ```
+   */
+  static abiSelector = 'core::bool';
+
+  /**
+   * Build from a boolean, or from the numbers 0 and 1.
+   * @param {BigNumberish | boolean} data the value to carry : a boolean, 0 or 1
+   * @throws {Error} when the value is text, is not a felt252 input, or is a number other than 0 or 1
+   * @example
+   * ```typescript
+   * const result = new CairoBool(false).toApiRequest();
+   * // result = ["0"]
+   * ```
+   */
+  constructor(data: BigNumberish | boolean | unknown) {
+    CairoBool.validate(data);
+    this.data = CairoBool.__processData(data);
+  }
+
+  /**
+   * Turn an accepted input into its boolean.
+   *
+   * Nothing here refuses a value : `validate` is what decides, and only a boolean, a 0 or a 1
+   * reaches this point.
+   * @param {BigNumberish | boolean} data the value to convert
+   * @returns {boolean} the boolean the input spells
+   * @example
+   * ```typescript
+   * const result = CairoBool.__processData('0x1');
+   * // result = true
+   * ```
+   */
+  static __processData(data: BigNumberish | boolean | unknown): boolean {
+    if (isBoolean(data)) {
+      return data;
+    }
+    return new CairoFelt252(data).toBigInt() === 1n;
+  }
+
+  /**
+   * Serialize to the single felt a contract call carries.
+   * @returns {string[]} one decimal-string felt, `"1"` or `"0"`, flagged as compiled
+   * @example
+   * ```typescript
+   * const result = new CairoBool(true).toApiRequest();
+   * // result = ["1"]
+   * const result2 = new CairoBool(false).toApiRequest();
+   * // result2 = ["0"]
+   * ```
+   */
+  toApiRequest(): string[] {
+    return addCompiledFlag([this.data ? '1' : '0']);
+  }
+
+  /**
+   * The value as a boolean.
+   * @returns {boolean} the boolean this bool holds
+   * @example
+   * ```typescript
+   * const result = new CairoBool(1).toBoolean();
+   * // result = true
+   * ```
+   */
+  toBoolean(): boolean {
+    return this.data;
+  }
+
+  /**
+   * The value in hexadecimal, as the felt a bool occupies.
+   * @returns {string} `"0x1"` for true, `"0x0"` for false
+   * @example
+   * ```typescript
+   * const result = new CairoBool(true).toHexString();
+   * // result = "0x1"
+   * const result2 = new CairoBool(false).toHexString();
+   * // result2 = "0x0"
+   * ```
+   */
+  toHexString(): string {
+    return addHexPrefix(this.data ? '1' : '0');
+  }
+
+  /**
+   * Throw unless the value can be carried by a bool.
+   *
+   * Text is refused first, then the value is read as a felt252 — which is what refuses a null, an
+   * object or an unsupported type — and finally checked to be one of the only two numbers a bool
+   * can hold.
+   * @param {BigNumberish | boolean} data the value to check
+   * @throws {Error} when the value is text, is not a felt252 input, or is a number other than 0 or 1
+   * @example
+   * ```typescript
+   * CairoBool.validate(true); // passes
+   * CairoBool.validate(2);
+   * // throws Error("Only values 0 or 1 are possible in a core::bool, received 2")
+   * ```
+   */
+  static validate(data: BigNumberish | boolean | unknown): void {
+    assert(!isText(data), 'Invalid input: a core::bool cannot be built from text');
+
+    const value = new CairoFelt252(data).toBigInt();
+    assert(
+      value === 0n || value === 1n,
+      `Only values 0 or 1 are possible in a core::bool, received ${value}`
+    );
+  }
+
+  /**
+   * Can this value be carried by a bool?
+   *
+   * The non-throwing form of {@link CairoBool.validate}, so it answers false for every input that
+   * one refuses, whatever the reason.
+   * @param {BigNumberish | boolean} data the value to test
+   * @returns {boolean} true when the value is a boolean, a 0 or a 1
+   * @example
+   * ```typescript
+   * const result = CairoBool.is(1);
+   * // result = true
+   * const result2 = CairoBool.is(2);
+   * // result2 = false     (a bool is exactly two values)
+   * ```
+   */
+  static is(data: BigNumberish | boolean | unknown): boolean {
+    try {
+      CairoBool.validate(data);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Is this abi type the one this class serializes?
+   * @param {string} abiType the abi type to test
+   * @returns {boolean} true for `core::bool`
+   * @example
+   * ```typescript
+   * const result = CairoBool.isAbiType('core::bool');
+   * // result = true
+   * const result2 = CairoBool.isAbiType('core::felt252');
+   * // result2 = false
+   * ```
+   */
+  static isAbiType(abiType: string): boolean {
+    return abiType === CairoBool.abiSelector;
+  }
+
+  /**
+   * Read one bool off a contract response, advancing the iterator past it.
+   *
+   * The felts a node returns are hex strings, and one is consumed per call, so successive calls
+   * read successive return values.
+   * @param {Iterator<string>} responseIterator the response felts, positioned on this bool
+   * @returns {CairoBool} the bool that was read
+   * @example
+   * ```typescript
+   * const response = ['0x1'];
+   * const result = CairoBool.factoryFromApiResponse(response.values()).toBoolean();
+   * // result = true
+   * ```
+   */
+  static factoryFromApiResponse(responseIterator: Iterator<string>): CairoBool {
+    return new CairoBool(getNext(responseIterator));
+  }
+}

--- a/src/utils/cairoDataTypes/ethAddress.ts
+++ b/src/utils/cairoDataTypes/ethAddress.ts
@@ -1,0 +1,196 @@
+import { BigNumberish, ETH_ADDRESS } from '../../types';
+import { RANGE_ETH_ADDRESS } from '../../global/constants';
+import { addHexPrefix } from '../encode';
+import { getNext } from '../num';
+import { isText } from '../shortString';
+import assert from '../assert';
+import { addCompiledFlag } from '../helpers';
+import { CairoFelt252 } from './felt';
+
+/**
+ * A Cairo `core::starknet::eth_address::EthAddress` : an Ethereum address, carried in one felt252
+ * but only 160 bits wide.
+ *
+ * On the wire it is a field element like any other, so what this class adds over
+ * {@link CairoFelt252} is the narrower bound : an address must fit in 160 bits, and a value past
+ * that is refused before any calldata leaves.
+ *
+ * A number, a bigint, a decimal string and a hexadecimal string are all read as the same number,
+ * so the shape of the input does not survive. Text is **not** an accepted input : unlike the other
+ * Cairo classes, which take a string that spells no number for its UTF-8 bytes, an address has no
+ * meaning as text and refuses it rather than encoding it into a number nobody meant.
+ * @example
+ * ```typescript
+ * // the same address, reached three ways
+ * new CairoEthAddress('0x1234').toBigInt(); // 4660n
+ * new CairoEthAddress(4660).toBigInt(); //    4660n
+ * new CairoEthAddress('4660').toBigInt(); //  4660n
+ * ```
+ */
+export class CairoEthAddress {
+  /**
+   * The address, always as a bigint.
+   * @example
+   * ```typescript
+   * const result = new CairoEthAddress('0x1234').data;
+   * // result = 4660n
+   * ```
+   */
+  data: bigint;
+
+  /**
+   * The abi type this class serializes.
+   * @example
+   * ```typescript
+   * const result = CairoEthAddress.abiSelector;
+   * // result = "core::starknet::eth_address::EthAddress"
+   * ```
+   */
+  static abiSelector = ETH_ADDRESS;
+
+  /**
+   * Build from a number or a numeric string, refusing text and anything wider than 160 bits.
+   * @param {BigNumberish | boolean} data the address to carry, within [0, 2^160 - 1]
+   * @throws {Error} when the value is text, is not a felt252 input, or is out of the EthAddress range
+   * @example
+   * ```typescript
+   * const result = new CairoEthAddress('0x1234').toApiRequest();
+   * // result = ["4660"]
+   * ```
+   */
+  constructor(data: BigNumberish | boolean | unknown) {
+    CairoEthAddress.validate(data);
+    this.data = new CairoFelt252(data).toBigInt();
+  }
+
+  /**
+   * Serialize to the single felt a contract call carries.
+   * @returns {string[]} one decimal-string felt, flagged as compiled
+   * @example
+   * ```typescript
+   * const result = new CairoEthAddress('0x1234').toApiRequest();
+   * // result = ["4660"]
+   * ```
+   */
+  toApiRequest(): string[] {
+    return addCompiledFlag([this.toBigInt().toString()]);
+  }
+
+  /**
+   * The address as a number.
+   * @returns {bigint} the number this address holds
+   * @example
+   * ```typescript
+   * const result = new CairoEthAddress('0x1234').toBigInt();
+   * // result = 4660n
+   * ```
+   */
+  toBigInt(): bigint {
+    return this.data;
+  }
+
+  /**
+   * The address in hexadecimal, without padding.
+   *
+   * The 40 hex digits an Ethereum address is usually written with are not restored here : leading
+   * zeros are dropped, as they are everywhere else in the library.
+   * @returns {string} the address as a 0x-prefixed hex string
+   * @example
+   * ```typescript
+   * const result = new CairoEthAddress(4660).toHexString();
+   * // result = "0x1234"
+   * const result2 = new CairoEthAddress('0x0034').toHexString();
+   * // result2 = "0x34"     (four digits in, two out)
+   * ```
+   */
+  toHexString(): string {
+    return addHexPrefix(this.toBigInt().toString(16));
+  }
+
+  /**
+   * Throw unless the value can be carried by an EthAddress.
+   *
+   * Text is refused first, since an address spelled as words is a mistake rather than a value to
+   * encode. What remains is read as a felt252 — which is what refuses a null, an object or an
+   * unsupported type — then checked against the 160 bits an Ethereum address occupies.
+   * @param {BigNumberish | boolean} data the value to check
+   * @throws {Error} when the value is text, is not a felt252 input, or is out of the EthAddress range
+   * @example
+   * ```typescript
+   * CairoEthAddress.validate('0x1234'); // passes
+   * CairoEthAddress.validate('abc');
+   * // throws Error("Invalid input: an EthAddress cannot be built from text")
+   * CairoEthAddress.validate(2n ** 160n);
+   * // throws Error("Value is out of EthAddress range [0, 1461501637330902918203684832716283019655932542975]")
+   * ```
+   */
+  static validate(data: BigNumberish | boolean | unknown): void {
+    assert(!isText(data), 'Invalid input: an EthAddress cannot be built from text');
+
+    const value = new CairoFelt252(data).toBigInt();
+    assert(
+      value >= RANGE_ETH_ADDRESS.min && value <= RANGE_ETH_ADDRESS.max,
+      `Value is out of EthAddress range [${RANGE_ETH_ADDRESS.min}, ${RANGE_ETH_ADDRESS.max}]`
+    );
+  }
+
+  /**
+   * Can this value be carried by an EthAddress?
+   *
+   * The non-throwing form of {@link CairoEthAddress.validate}, so it answers false for every input
+   * that one refuses, whatever the reason.
+   * @param {BigNumberish | boolean} data the value to test
+   * @returns {boolean} true when the value fits in an EthAddress
+   * @example
+   * ```typescript
+   * const result = CairoEthAddress.is('0x1234');
+   * // result = true
+   * const result2 = CairoEthAddress.is('abc');
+   * // result2 = false     (text, not a number)
+   * const result3 = CairoEthAddress.is(2n ** 160n);
+   * // result3 = false     (one bit too wide)
+   * ```
+   */
+  static is(data: BigNumberish | boolean | unknown): boolean {
+    try {
+      CairoEthAddress.validate(data);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Is this abi type the one this class serializes?
+   * @param {string} abiType the abi type to test
+   * @returns {boolean} true for `core::starknet::eth_address::EthAddress`
+   * @example
+   * ```typescript
+   * const result = CairoEthAddress.isAbiType('core::starknet::eth_address::EthAddress');
+   * // result = true
+   * const result2 = CairoEthAddress.isAbiType('core::felt252');
+   * // result2 = false
+   * ```
+   */
+  static isAbiType(abiType: string): boolean {
+    return abiType === CairoEthAddress.abiSelector;
+  }
+
+  /**
+   * Read one EthAddress off a contract response, advancing the iterator past it.
+   *
+   * The felts a node returns are hex strings, and one is consumed per call, so successive calls
+   * read successive return values.
+   * @param {Iterator<string>} responseIterator the response felts, positioned on this address
+   * @returns {CairoEthAddress} the address that was read
+   * @example
+   * ```typescript
+   * const response = ['0x1234'];
+   * const result = CairoEthAddress.factoryFromApiResponse(response.values()).toBigInt();
+   * // result = 4660n
+   * ```
+   */
+  static factoryFromApiResponse(responseIterator: Iterator<string>): CairoEthAddress {
+    return new CairoEthAddress(getNext(responseIterator));
+  }
+}

--- a/src/utils/cairoDataTypes/index.ts
+++ b/src/utils/cairoDataTypes/index.ts
@@ -15,3 +15,6 @@ export * from './byteArray';
 export * from './bytes31';
 export * from './felt';
 export * from './uint32';
+export * from './bool';
+export * from './ethAddress';
+export * from './secp256k1Point';

--- a/src/utils/cairoDataTypes/secp256k1Point.ts
+++ b/src/utils/cairoDataTypes/secp256k1Point.ts
@@ -1,0 +1,411 @@
+/* eslint-disable no-bitwise */
+import { BigNumberish, Literal } from '../../types';
+import { addHexPrefix, removeHexPrefix } from '../encode';
+import { getNext, isBigNumberish } from '../num';
+import { isObject } from '../typed';
+import assert from '../assert';
+import { addCompiledFlag } from '../helpers';
+import { UINT_128_MAX } from './uint256';
+
+/**
+ * The largest value a Secp256k1Point can carry : both coordinates at their maximum, 512 bits.
+ * @example
+ * ```typescript
+ * const result = SECP256K1_POINT_MAX === (1n << 512n) - 1n;
+ * // result = true
+ * ```
+ */
+export const SECP256K1_POINT_MAX = (1n << 512n) - 1n;
+
+/**
+ * The smallest value a Secp256k1Point can carry.
+ * @example
+ * ```typescript
+ * const result = SECP256K1_POINT_MIN;
+ * // result = 0n
+ * ```
+ */
+export const SECP256K1_POINT_MIN = 0n;
+
+/**
+ * The four 128-bit limbs a Secp256k1Point occupies on the wire, in the order a call carries them.
+ */
+export interface Secp256k1PointStruct {
+  xLow: BigNumberish;
+  xHigh: BigNumberish;
+  yLow: BigNumberish;
+  yHigh: BigNumberish;
+}
+
+/**
+ * A Cairo `core::starknet::secp256k1::Secp256k1Point` : a point on the secp256k1 curve, the one
+ * Ethereum signs with.
+ *
+ * A point is two 256-bit coordinates, x and y, and Cairo carries each of them as two 128-bit
+ * limbs — so four felts in all, in the order `xLow, xHigh, yLow, yHigh`. The single number this
+ * class accepts is the 512-bit concatenation `x || y`, x in the upper half : that is the shape an
+ * uncompressed public key already has once its `04` prefix is dropped.
+ *
+ * Both ways in are supported : one number, or the four limbs directly, which is how a response is
+ * read back.
+ * @example
+ * ```typescript
+ * // one number, x in the upper 256 bits
+ * const point = new CairoSecp256k1Point(1n);
+ * point.toApiRequest(); // ["0", "0", "1", "0"]     x = 0, y = 1
+ *
+ * // the four limbs, as a call carries them
+ * const same = new CairoSecp256k1Point(0, 0, 1, 0);
+ * same.toBigInt(); // 1n
+ * ```
+ */
+export class CairoSecp256k1Point {
+  /**
+   * The low 128 bits of the x coordinate.
+   * @example
+   * ```typescript
+   * const result = new CairoSecp256k1Point({ xLow: 1, xHigh: 2, yLow: 3, yHigh: 4 }).xLow;
+   * // result = 1n
+   * ```
+   */
+  public xLow: bigint;
+
+  /**
+   * The high 128 bits of the x coordinate.
+   * @example
+   * ```typescript
+   * const result = new CairoSecp256k1Point({ xLow: 1, xHigh: 2, yLow: 3, yHigh: 4 }).xHigh;
+   * // result = 2n
+   * ```
+   */
+  public xHigh: bigint;
+
+  /**
+   * The low 128 bits of the y coordinate.
+   * @example
+   * ```typescript
+   * const result = new CairoSecp256k1Point({ xLow: 1, xHigh: 2, yLow: 3, yHigh: 4 }).yLow;
+   * // result = 3n
+   * ```
+   */
+  public yLow: bigint;
+
+  /**
+   * The high 128 bits of the y coordinate.
+   * @example
+   * ```typescript
+   * const result = new CairoSecp256k1Point({ xLow: 1, xHigh: 2, yLow: 3, yHigh: 4 }).yHigh;
+   * // result = 4n
+   * ```
+   */
+  public yHigh: bigint;
+
+  /**
+   * The abi type this class serializes.
+   * @example
+   * ```typescript
+   * const result = CairoSecp256k1Point.abiSelector;
+   * // result = "core::starknet::secp256k1::Secp256k1Point"
+   * ```
+   */
+  static abiSelector = Literal.Secp256k1Point;
+
+  /**
+   * Build from the 512-bit number `x || y`, or from an object carrying the four limbs.
+   */
+  public constructor(input: BigNumberish | Secp256k1PointStruct | unknown);
+  /**
+   * Build from the four limbs, in the order a contract response returns them.
+   */
+  public constructor(
+    xLow: BigNumberish,
+    xHigh: BigNumberish,
+    yLow: BigNumberish,
+    yHigh: BigNumberish
+  );
+  /**
+   * @param {any[]} arr either one value — a 512-bit number or a {@link Secp256k1PointStruct} — or
+   * the four limbs
+   * @throws {Error} when a value is out of range, or when the argument count is neither 1 nor 4
+   * @example
+   * ```typescript
+   * const result = new CairoSecp256k1Point(1n).toApiRequest();
+   * // result = ["0", "0", "1", "0"]
+   * const result2 = new CairoSecp256k1Point({ xLow: 1, xHigh: 2, yLow: 3, yHigh: 4 }).toApiRequest();
+   * // result2 = ["1", "2", "3", "4"]
+   * ```
+   */
+  public constructor(...arr: any[]) {
+    if (
+      isObject(arr[0]) &&
+      arr.length === 1 &&
+      'xLow' in arr[0] &&
+      'xHigh' in arr[0] &&
+      'yLow' in arr[0] &&
+      'yHigh' in arr[0]
+    ) {
+      // Secp256k1PointStruct input
+      const props = CairoSecp256k1Point.validateProps(
+        arr[0].xLow as BigNumberish,
+        arr[0].xHigh as BigNumberish,
+        arr[0].yLow as BigNumberish,
+        arr[0].yHigh as BigNumberish
+      );
+      this.xLow = props.xLow;
+      this.xHigh = props.xHigh;
+      this.yLow = props.yLow;
+      this.yHigh = props.yHigh;
+    } else if (arr.length === 1) {
+      // a 512-bit value, holding the x coordinate then the y coordinate
+      const bigInt = CairoSecp256k1Point.validate(arr[0]);
+      const hexStr = bigInt.toString(16).padStart(128, '0');
+
+      // first 256 bits (64 hex chars) = x, last 256 bits = y
+      const xBigInt = BigInt(addHexPrefix(hexStr.slice(0, 64)));
+      const yBigInt = BigInt(addHexPrefix(hexStr.slice(64, 128)));
+
+      this.xLow = xBigInt & UINT_128_MAX;
+      this.xHigh = xBigInt >> 128n;
+      this.yLow = yBigInt & UINT_128_MAX;
+      this.yHigh = yBigInt >> 128n;
+    } else if (arr.length === 4) {
+      const props = CairoSecp256k1Point.validateProps(arr[0], arr[1], arr[2], arr[3]);
+      this.xLow = props.xLow;
+      this.xHigh = props.xHigh;
+      this.yLow = props.yLow;
+      this.yHigh = props.yHigh;
+    } else {
+      throw Error('Incorrect Secp256k1Point constructor parameters');
+    }
+  }
+
+  /**
+   * Throw unless the value can be carried by a Secp256k1Point, and return it as a number.
+   *
+   * Unlike the other classes here this one gives the number back rather than returning nothing :
+   * the constructor needs it, and computing it twice would mean splitting a 512-bit value twice.
+   * @param {BigNumberish} input the 512-bit value to check
+   * @returns {bigint} the value, once checked
+   * @throws {Error} when the value is null, undefined, of an unread type, or outside [0, 2^512 - 1]
+   * @example
+   * ```typescript
+   * const result = CairoSecp256k1Point.validate('0x1234');
+   * // result = 4660n
+   * CairoSecp256k1Point.validate(SECP256K1_POINT_MAX + 1n);
+   * // throws Error("input is bigger than SECP256K1_POINT_MAX")
+   * ```
+   */
+  static validate(input: BigNumberish | unknown): bigint {
+    assert(input !== null, 'null value is not allowed for Secp256k1Point');
+    assert(input !== undefined, 'undefined value is not allowed for Secp256k1Point');
+    assert(
+      isBigNumberish(input),
+      `Unsupported input for Secp256k1Point. Expected a number, a bigint, or a string spelling one, received '${typeof input}'`
+    );
+
+    const bigInt = BigInt(input as BigNumberish);
+    assert(bigInt >= SECP256K1_POINT_MIN, 'input is smaller than SECP256K1_POINT_MIN');
+    assert(bigInt <= SECP256K1_POINT_MAX, 'input is bigger than SECP256K1_POINT_MAX');
+    return bigInt;
+  }
+
+  /**
+   * Throw unless the four limbs can each be carried by 128 bits, and return them as numbers.
+   * @param {BigNumberish} xLow the low 128 bits of x
+   * @param {BigNumberish} xHigh the high 128 bits of x
+   * @param {BigNumberish} yLow the low 128 bits of y
+   * @param {BigNumberish} yHigh the high 128 bits of y
+   * @returns {{xLow: bigint, xHigh: bigint, yLow: bigint, yHigh: bigint}} the four limbs, checked
+   * @throws {Error} when a limb is null, undefined, not a number, negative, or wider than 128 bits
+   * @example
+   * ```typescript
+   * const result = CairoSecp256k1Point.validateProps(1, 2, 3, 4);
+   * // result = { xLow: 1n, xHigh: 2n, yLow: 3n, yHigh: 4n }
+   * CairoSecp256k1Point.validateProps(1, 2, 3, 2n ** 128n);
+   * // throws Error("yHigh must fit in 128 bits")
+   * ```
+   */
+  static validateProps(
+    xLow: BigNumberish,
+    xHigh: BigNumberish,
+    yLow: BigNumberish,
+    yHigh: BigNumberish
+  ): { xLow: bigint; xHigh: bigint; yLow: bigint; yHigh: bigint } {
+    const validateLimb = (limb: BigNumberish, name: string): bigint => {
+      assert(limb !== null, `${name} cannot be null`);
+      assert(limb !== undefined, `${name} cannot be undefined`);
+      assert(isBigNumberish(limb), `${name} must be a BigNumberish`);
+      const bigInt = BigInt(limb);
+      assert(bigInt >= 0n, `${name} must be non-negative`);
+      assert(bigInt <= UINT_128_MAX, `${name} must fit in 128 bits`);
+      return bigInt;
+    };
+
+    return {
+      xLow: validateLimb(xLow, 'xLow'),
+      xHigh: validateLimb(xHigh, 'xHigh'),
+      yLow: validateLimb(yLow, 'yLow'),
+      yHigh: validateLimb(yHigh, 'yHigh'),
+    };
+  }
+
+  /**
+   * Can this value be carried by a Secp256k1Point?
+   *
+   * The non-throwing form of {@link CairoSecp256k1Point.validate}, so it answers false for every
+   * input that one refuses, whatever the reason.
+   * @param {any} data the value to test
+   * @returns {boolean} true when the value fits in 512 bits
+   * @example
+   * ```typescript
+   * const result = CairoSecp256k1Point.is(SECP256K1_POINT_MAX);
+   * // result = true
+   * const result2 = CairoSecp256k1Point.is(SECP256K1_POINT_MAX + 1n);
+   * // result2 = false
+   * ```
+   */
+  static is(data: any): boolean {
+    try {
+      CairoSecp256k1Point.validate(data);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Is this abi type the one this class serializes?
+   * @param {string} abiType the abi type to test
+   * @returns {boolean} true for `core::starknet::secp256k1::Secp256k1Point`
+   * @example
+   * ```typescript
+   * const result = CairoSecp256k1Point.isAbiType('core::starknet::secp256k1::Secp256k1Point');
+   * // result = true
+   * const result2 = CairoSecp256k1Point.isAbiType('core::felt252');
+   * // result2 = false
+   * ```
+   */
+  static isAbiType(abiType: string): boolean {
+    return abiType === CairoSecp256k1Point.abiSelector;
+  }
+
+  /**
+   * Read one point off a contract response, advancing the iterator past its four felts.
+   * @param {Iterator<string>} responseIterator the response felts, positioned on this point
+   * @returns {CairoSecp256k1Point} the point that was read
+   * @example
+   * ```typescript
+   * const response = ['0x0', '0x0', '0x1', '0x0'];
+   * const result = CairoSecp256k1Point.factoryFromApiResponse(response.values()).toBigInt();
+   * // result = 1n
+   * ```
+   */
+  static factoryFromApiResponse(responseIterator: Iterator<string>): CairoSecp256k1Point {
+    const xLow = getNext(responseIterator);
+    const xHigh = getNext(responseIterator);
+    const yLow = getNext(responseIterator);
+    const yHigh = getNext(responseIterator);
+    return new CairoSecp256k1Point(xLow, xHigh, yLow, yHigh);
+  }
+
+  /**
+   * The point as the single 512-bit number `x || y`.
+   *
+   * The inverse of what the constructor does with one number, so a point built that way comes back
+   * unchanged.
+   * @returns {bigint} the two coordinates concatenated, x in the upper 256 bits
+   * @example
+   * ```typescript
+   * const result = new CairoSecp256k1Point(1n).toBigInt();
+   * // result = 1n
+   * const result2 = new CairoSecp256k1Point(0, 0, 3, 0).toBigInt();
+   * // result2 = 3n
+   * ```
+   */
+  toBigInt(): bigint {
+    const xCoordinate = (this.xHigh << 128n) + this.xLow;
+    const yCoordinate = (this.yHigh << 128n) + this.yLow;
+    return (xCoordinate << 256n) + yCoordinate;
+  }
+
+  /**
+   * The four limbs as hexadecimal strings.
+   * @returns {Secp256k1PointStruct} the limbs, each 0x-prefixed and unpadded
+   * @example
+   * ```typescript
+   * const result = new CairoSecp256k1Point({ xLow: 1, xHigh: 2, yLow: 3, yHigh: 4 }).toStruct();
+   * // result = { xLow: "0x1", xHigh: "0x2", yLow: "0x3", yHigh: "0x4" }
+   * ```
+   */
+  toStruct(): Secp256k1PointStruct {
+    return {
+      xLow: addHexPrefix(this.xLow.toString(16)),
+      xHigh: addHexPrefix(this.xHigh.toString(16)),
+      yLow: addHexPrefix(this.yLow.toString(16)),
+      yHigh: addHexPrefix(this.yHigh.toString(16)),
+    };
+  }
+
+  /**
+   * The point in hexadecimal, without padding.
+   * @returns {string} the 512-bit value as a 0x-prefixed hex string
+   * @example
+   * ```typescript
+   * const result = new CairoSecp256k1Point(4660n).toHexString();
+   * // result = "0x1234"
+   * ```
+   */
+  toHexString(): string {
+    return addHexPrefix(this.toBigInt().toString(16));
+  }
+
+  /**
+   * Serialize to the four felts a contract call carries.
+   * @returns {string[]} the limbs as decimal strings, `[xLow, xHigh, yLow, yHigh]`, flagged as compiled
+   * @example
+   * ```typescript
+   * const result = new CairoSecp256k1Point({ xLow: 1, xHigh: 2, yLow: 3, yHigh: 4 }).toApiRequest();
+   * // result = ["1", "2", "3", "4"]
+   * ```
+   */
+  toApiRequest(): string[] {
+    return addCompiledFlag([
+      this.xLow.toString(10),
+      this.xHigh.toString(10),
+      this.yLow.toString(10),
+      this.yHigh.toString(10),
+    ]);
+  }
+
+  /**
+   * Build from a hexadecimal string spelling the 512-bit value.
+   *
+   * A shorter string is left-padded to the 128 hex digits a point occupies, so a small value is
+   * read as a point whose upper limbs are zero. A longer one is refused rather than truncated.
+   * @param {string} hexString the value, 0x-prefixed or not, at most 128 hex digits
+   * @returns {CairoSecp256k1Point} the point the string spells
+   * @throws {Error} when the string holds more than 128 hex digits
+   * @example
+   * ```typescript
+   * const result = CairoSecp256k1Point.fromHex('0x1').toApiRequest();
+   * // result = ["0", "0", "1", "0"]
+   * ```
+   */
+  static fromHex(hexString: string): CairoSecp256k1Point {
+    const cleanHex = removeHexPrefix(hexString).padStart(128, '0');
+    if (cleanHex.length !== 128) {
+      throw new Error('Hex string must represent exactly 512 bits (128 hex characters)');
+    }
+
+    const xHex = cleanHex.slice(0, 64);
+    const yHex = cleanHex.slice(64, 128);
+
+    // each coordinate splits into its high 128 bits then its low 128 bits
+    const xHigh = BigInt(addHexPrefix(xHex.slice(0, 32)));
+    const xLow = BigInt(addHexPrefix(xHex.slice(32, 64)));
+    const yHigh = BigInt(addHexPrefix(yHex.slice(0, 32)));
+    const yLow = BigInt(addHexPrefix(yHex.slice(32, 64)));
+
+    return new CairoSecp256k1Point(xLow, xHigh, yLow, yHigh);
+  }
+}

--- a/src/utils/calldata/parser/parsingStrategy.ts
+++ b/src/utils/calldata/parser/parsingStrategy.ts
@@ -1,10 +1,10 @@
 import { CairoBytes31 } from '../../cairoDataTypes/bytes31';
 import { CairoByteArray } from '../../cairoDataTypes/byteArray';
 import { AbiEntryType, ETH_ADDRESS } from '../../../types';
-import { RANGE_ETH_ADDRESS } from '../../../global/constants';
-import assert from '../../assert';
-import { addCompiledFlag } from '../../helpers';
 import { CairoFelt252 } from '../../cairoDataTypes/felt';
+import { CairoBool } from '../../cairoDataTypes/bool';
+import { CairoEthAddress } from '../../cairoDataTypes/ethAddress';
+import { CairoSecp256k1Point } from '../../cairoDataTypes/secp256k1Point';
 import { CairoUint256 } from '../../cairoDataTypes/uint256';
 import { CairoUint512 } from '../../cairoDataTypes/uint512';
 import { CairoUint8 } from '../../cairoDataTypes/uint8';
@@ -56,16 +56,17 @@ export const hdParsingStrategy = {
     [CairoFelt252.abiSelector]: (val: unknown) => {
       return new CairoFelt252(val).toApiRequest();
     },
-    // The one entry whose bound is spelled out here rather than delegated: an EthAddress is a felt
-    // on the wire, narrowed to the 160 bits an Ethereum address occupies, and has no class of its
-    // own to hold that range.
     [ETH_ADDRESS]: (val: unknown) => {
-      const value = new CairoFelt252(val).toBigInt();
-      assert(
-        value >= RANGE_ETH_ADDRESS.min && value <= RANGE_ETH_ADDRESS.max,
-        `Value is out of EthAddress range [${RANGE_ETH_ADDRESS.min}, ${RANGE_ETH_ADDRESS.max}]`
-      );
-      return addCompiledFlag([value.toString()]);
+      return new CairoEthAddress(val).toApiRequest();
+    },
+    [CairoBool.abiSelector]: (val: unknown) => {
+      return new CairoBool(val).toApiRequest();
+    },
+    // Four felts, not one: a point is two 256-bit coordinates, each split into two 128-bit limbs.
+    // It has to be spelled out in both strategies rather than left to the felt252 default, which
+    // would emit a single felt and quietly corrupt the calldata.
+    [CairoSecp256k1Point.abiSelector]: (val: unknown) => {
+      return new CairoSecp256k1Point(val).toApiRequest();
     },
     [CairoUint256.abiSelector]: (val: unknown) => {
       return new CairoUint256(val).toApiRequest();
@@ -116,6 +117,17 @@ export const hdParsingStrategy = {
     },
     [CairoFelt252.abiSelector]: (responseIterator: Iterator<string>) => {
       return CairoFelt252.factoryFromApiResponse(responseIterator).toBigInt();
+    },
+    // Read as it comes, without its class, for the same reason as the unsigned integers below: a
+    // bool that is neither 0 nor 1 is a node anomaly, and refusing it here would turn something
+    // the caller cannot act on into an exception.
+    [CairoBool.abiSelector]: (responseIterator: Iterator<string>) => {
+      return Boolean(BigInt(getNext(responseIterator)));
+    },
+    // The class is what reads this one: four felts have to be recombined into the single number a
+    // point is, and that is decoding, not checking.
+    [CairoSecp256k1Point.abiSelector]: (responseIterator: Iterator<string>) => {
+      return CairoSecp256k1Point.factoryFromApiResponse(responseIterator).toBigInt();
     },
     [CairoUint256.abiSelector]: (responseIterator: Iterator<string>) => {
       return CairoUint256.factoryFromApiResponse(responseIterator).toBigInt();
@@ -190,6 +202,17 @@ export const fastParsingStrategy: ParsingStrategy = {
     [ETH_ADDRESS]: (val: unknown) => {
       return new CairoFelt252(val).toBigInt().toString();
     },
+    // No 0-or-1 check here either, for the same reason as the integers below. This is what a bool
+    // already got before it had an entry at all, by falling through to the felt252 default.
+    [CairoBool.abiSelector]: (val: unknown) => {
+      return new CairoFelt252(val).toBigInt().toString();
+    },
+    // Present here too, and doing the same work as in the strategy above: this entry is not a
+    // range check that speed could trade away, it is the only thing that turns a point into its
+    // four felts. Without it the felt252 default would emit one.
+    [CairoSecp256k1Point.abiSelector]: (val: unknown) => {
+      return new CairoSecp256k1Point(val).toApiRequest();
+    },
     [CairoUint256.abiSelector]: (val: unknown) => {
       return new CairoUint256(val).toApiRequest();
     },
@@ -242,6 +265,16 @@ export const fastParsingStrategy: ParsingStrategy = {
     },
     [CairoFelt252.abiSelector]: (responseIterator: Iterator<string>) => {
       return BigInt(getNext(responseIterator));
+    },
+    // Identical to the strategy above: reading a bool back is decoding, not checking, so there is
+    // nothing here for speed to trade away.
+    [CairoBool.abiSelector]: (responseIterator: Iterator<string>) => {
+      return Boolean(BigInt(getNext(responseIterator)));
+    },
+    // Identical too, and required: recombining four felts into one number is the only way to read
+    // a point back, whatever the strategy.
+    [CairoSecp256k1Point.abiSelector]: (responseIterator: Iterator<string>) => {
+      return CairoSecp256k1Point.factoryFromApiResponse(responseIterator).toBigInt();
     },
     [CairoUint256.abiSelector]: (responseIterator: Iterator<string>) => {
       return CairoUint256.factoryFromApiResponse(responseIterator).toBigInt();

--- a/src/utils/calldata/requestParser.ts
+++ b/src/utils/calldata/requestParser.ts
@@ -26,9 +26,10 @@ import { CairoInt16 } from '../cairoDataTypes/int16';
 import { CairoInt32 } from '../cairoDataTypes/int32';
 import { CairoInt64 } from '../cairoDataTypes/int64';
 import { CairoInt128 } from '../cairoDataTypes/int128';
+import { CairoBool } from '../cairoDataTypes/bool';
+import { CairoSecp256k1Point } from '../cairoDataTypes/secp256k1Point';
 import { unwrapCairoScalar } from '../cairoDataTypes/scalar';
-import { addHexPrefix, buf2hex, removeHexPrefix, utf8ToUint8Array } from '../encode';
-import { toHex } from '../num';
+import { addHexPrefix, buf2hex, utf8ToUint8Array } from '../encode';
 import { isText, splitLongString } from '../shortString';
 import { isUndefined } from '../typed';
 import {
@@ -41,10 +42,8 @@ import {
   isTypeNonZero,
   isTypeOption,
   isTypeResult,
-  isTypeSecp256k1Point,
   isTypeStruct,
   isTypeTuple,
-  uint256,
 } from './cairo';
 import {
   CairoCustomEnum,
@@ -158,21 +157,19 @@ function parseBaseTypes({
       return parser.getRequestParser(type)(val);
     case CairoBytes31.isAbiType(type):
       return parser.getRequestParser(type)(val);
+    // without this a bool fell to the felt252 default, which bounds the field but not the two
+    // values a bool actually has. `validateFields` is stricter still upstream, and asks for a real
+    // boolean — this catches what reaches the parser by another road.
+    case CairoBool.isAbiType(type):
+      return parser.getRequestParser(type)(val);
     // reached from parseCalldataField and from the struct branch of parseCalldataValue. Without
     // this it fell to the felt252 default, which only bounds the field, not the 160 bits
     case isTypeEthAddress(type):
       return parser.getRequestParser(type)(val);
-    case isTypeSecp256k1Point(type): {
-      const pubKeyETH = removeHexPrefix(toHex(val as BigNumberish)).padStart(128, '0');
-      const pubKeyETHy = uint256(addHexPrefix(pubKeyETH.slice(-64)));
-      const pubKeyETHx = uint256(addHexPrefix(pubKeyETH.slice(0, -64)));
-      return [
-        felt(pubKeyETHx.low),
-        felt(pubKeyETHx.high),
-        felt(pubKeyETHy.low),
-        felt(pubKeyETHy.high),
-      ];
-    }
+    // the four felts a point occupies used to be spelled out here; the class now holds that split,
+    // and both strategies carry it since the felt252 default would emit a single felt
+    case CairoSecp256k1Point.isAbiType(type):
+      return parser.getRequestParser(type)(val);
     default:
       // TODO: check but u32 should land here with rest of the simple types, at the moment handle as felt
       return parser.getRequestParser(CairoFelt252.abiSelector)(val);

--- a/src/utils/calldata/responseParser.ts
+++ b/src/utils/calldata/responseParser.ts
@@ -26,17 +26,16 @@ import { CairoInt16 } from '../cairoDataTypes/int16';
 import { CairoInt32 } from '../cairoDataTypes/int32';
 import { CairoInt64 } from '../cairoDataTypes/int64';
 import { CairoInt128 } from '../cairoDataTypes/int128';
-import { addHexPrefix, removeHexPrefix } from '../encode';
+import { CairoBool } from '../cairoDataTypes/bool';
+import { CairoSecp256k1Point } from '../cairoDataTypes/secp256k1Point';
 import {
   getArrayType,
   isCairo1Type,
   isLen,
   isTypeArray,
-  isTypeBool,
   isTypeEnum,
   isTypeEthAddress,
   isTypeNonZero,
-  isTypeSecp256k1Point,
   isTypeTuple,
 } from './cairo';
 import {
@@ -59,9 +58,8 @@ import extractTupleMemberTypes from './tuple';
 function parseBaseTypes(type: string, it: Iterator<string>, parser: AbiParserInterface) {
   let temp;
   switch (true) {
-    case isTypeBool(type):
-      temp = it.next().value;
-      return Boolean(BigInt(temp));
+    case CairoBool.isAbiType(type):
+      return parser.getResponseParser(type)(it);
     case CairoUint256.isAbiType(type):
       return parser.getResponseParser(type)(it);
     case CairoUint512.isAbiType(type):
@@ -93,13 +91,8 @@ function parseBaseTypes(type: string, it: Iterator<string>, parser: AbiParserInt
       return BigInt(temp);
     case CairoBytes31.isAbiType(type):
       return parser.getResponseParser(type)(it);
-    case isTypeSecp256k1Point(type):
-      const xLow = removeHexPrefix(it.next().value).padStart(32, '0');
-      const xHigh = removeHexPrefix(it.next().value).padStart(32, '0');
-      const yLow = removeHexPrefix(it.next().value).padStart(32, '0');
-      const yHigh = removeHexPrefix(it.next().value).padStart(32, '0');
-      const pubK = BigInt(addHexPrefix(xHigh + xLow + yHigh + yLow));
-      return pubK;
+    case CairoSecp256k1Point.isAbiType(type):
+      return parser.getResponseParser(type)(it);
     default:
       // TODO: this is for all simple types felt and rest to BN, at the moment handle as felt
       return parser.getResponseParser(CairoFelt252.abiSelector)(it);


### PR DESCRIPTION
## Motivation and Resolution

Three Cairo leaf types had no class of their own: `core::bool`, `EthAddress` and
`Secp256k1Point`. Their handling lived inline in the parsers instead:

- the 160-bit bound of an `EthAddress` was spelled out in `parsingStrategy.ts`, under a comment
  stating that the type "has no class of its own to hold that range";
- the four-limb split of a `Secp256k1Point` was written twice, once in `requestParser.ts` and
  once in `responseParser.ts`;
- `core::bool` had no branch at all and fell through to the `felt252` default, which bounds the
  field but not the two values a bool actually has.

This PR gives each of them a class in `src/utils/cairoDataTypes/`, built on the model of the
existing ones, and routes both parsers through the parsing strategy as every other leaf type
already is. The inline blocks and eight now-dead imports are removed, and the `Secp256k1Point`
logic lives in one place instead of two.

It is also groundwork: the same model is what the composite types (arrays, tuples, structs,
`Option`/`Result`/`CustomEnum`, `NonZero`) would need to move to next.

### RPC version (if applicable)

N/A

## Usage related changes

- New exported class `CairoEthAddress`, for `core::starknet::eth_address::EthAddress`.
- New exported class `CairoBool`, for `core::bool`.
- New exported class `CairoSecp256k1Point`, for `core::starknet::secp256k1::Secp256k1Point`,
  along with `SECP256K1_POINT_MIN`, `SECP256K1_POINT_MAX` and the `Secp256k1PointStruct`
  interface.
- **Breaking:** a `core::bool` argument that is neither a boolean nor 0/1 is now refused instead
  of being serialized. Only reachable through the argument-array call form, since the named form
  already required a real boolean.

      compile('fn', [5])   before: ['5']   after: throws

- **Breaking:** an `EthAddress` built from text is now refused instead of being encoded as its
  UTF-8 bytes. An address spelled as words was never a value anyone meant to send.
- **Breaking:** a `Secp256k1Point` wider than 512 bits is now refused instead of emitting four
  felts that stood for something else. `padStart` does not truncate, so an oversized value used
  to shift the slices and quietly corrupt the calldata.

The three changes go the same way: an error instead of calldata a contract cannot interpret.
No correct call is affected — every request and response path is asserted to produce exactly what
it produced before.

## Development related changes

- `requestParser.ts` loses the nine-line inline `Secp256k1Point` block and gains a `core::bool`
  branch; `responseParser.ts` loses its eight-line counterpart. Both now delegate like their
  neighbours.
- Both `hdParsingStrategy` and `fastParsingStrategy` carry the two new entries.
  `Secp256k1Point` is identical in both on purpose: it is not a range check that speed could
  trade away, it is the only thing that turns a point into its four felts, and the `felt252`
  default would emit a single one.
- 114 new tests. `CairoSecp256k1Point` is checked against an oracle that recomputes the four
  limbs in plain arithmetic rather than reusing `uint256()` and `felt()`, so the assertion is
  independent of the implementation it verifies.
- The new tests in `parsingStrategy.test.ts` name the previous behaviour in their titles, so the
  three changes above are recorded in the suite rather than only in this description.
- One pre-existing quirk is now documented by a test rather than left to surprise someone: for
  `core::bool` the two gates disagree, `compile('fn', [1])` passing where `compile('fn', {v: 1})`
  is refused by `validateFields`.
- Three unrelated error messages leak from lower layers for inputs that are correctly refused
  (`-1` on an address or a bool, `1.5` on a point). They are pre-existing, untouched here, and
  marked by a comment in the tests that assert them.

## Checklist:

- [x] Performed a self-review of the code
- [x] Documented the changes in code (API docs will be generated automatically)
- [x] Updated the tests
- [x] All tests are passing
