### PR TITLE
feat(cairoDataTypes): add the composite Cairo type classes and their …

### DIFF
--- a/__tests__/utils/cairoDataTypes/CairoArray.test.ts
+++ b/__tests__/utils/cairoDataTypes/CairoArray.test.ts
@@ -1,0 +1,320 @@
+import { CallData } from '../../../src';
+import { CairoArray } from '../../../src/utils/cairoDataTypes/array';
+import { CairoTuple } from '../../../src/utils/cairoDataTypes/tuple';
+import { CairoUint8 } from '../../../src/utils/cairoDataTypes/uint8';
+import { cairoTypeStrategy } from '../../../src/utils/calldata/parser/cairoTypeStrategy';
+
+const S = cairoTypeStrategy;
+const U8 = 'core::array::Array::<core::integer::u8>';
+const SPAN = 'core::array::Span::<core::integer::u8>';
+const NESTED = 'core::array::Array::<core::array::Array::<core::integer::u8>>';
+const FELTS = 'core::array::Array::<core::felt252>';
+const BYTES31 = 'core::array::Array::<core::bytes_31::bytes31>';
+const OF_TUPLES = 'core::array::Array::<(core::integer::u8, core::integer::u8)>';
+
+const LONG_TEXT = 'Bug is back, for ever, here and everywhere';
+/** Two chunks of 31 bytes at most, which is what a felt252 and a bytes31 each hold. */
+const LONG_TEXT_FELTS = [
+  '2',
+  '117422190885827407409664260607192623408641871979684112605616397634538401380',
+  '39164769268277364419555941',
+];
+
+/** The felts an array serializes to, as the hex strings a node would answer with. */
+const asResponse = (array: CairoArray): string[] =>
+  [...array.toApiRequest()].map((felt) => `0x${BigInt(felt).toString(16)}`);
+
+describe('CairoArray class Unit Tests', () => {
+  describe('construction from the values a caller passes', () => {
+    test('should build from an array, length first', () => {
+      expect([...new CairoArray([1, 2, 3], U8, S).toApiRequest()]).toEqual(['3', '1', '2', '3']);
+    });
+
+    test('should build from an object, read by its values', () => {
+      expect([...new CairoArray({ 0: 1, 1: 2 }, U8, S).toApiRequest()]).toEqual(['2', '1', '2']);
+    });
+
+    test('should take an element that is already built', () => {
+      expect([...new CairoArray([new CairoUint8(1), 2], U8, S).toApiRequest()]).toEqual([
+        '2',
+        '1',
+        '2',
+      ]);
+    });
+
+    test('should copy an array handed to it whole', () => {
+      const copy = new CairoArray(new CairoArray([1, 2], U8, S), U8, S);
+      expect([...copy.toApiRequest()]).toEqual(['2', '1', '2']);
+      expect(copy.arrayType).toBe(U8);
+    });
+
+    test('should hold no elements at all', () => {
+      expect([...new CairoArray([], U8, S).toApiRequest()]).toEqual(['0']);
+      expect(new CairoArray([], U8, S).decompose(S)).toEqual([]);
+    });
+
+    test('should hold as many elements as it is given', () => {
+      const size = 100;
+      const values = Array.from({ length: size }, (_, index) => index % 256);
+      const felts = [...new CairoArray(values, U8, S).toApiRequest()];
+      expect(felts).toHaveLength(size + 1);
+      expect(felts[0]).toBe(String(size));
+    });
+
+    test('should treat Array and Span the same way', () => {
+      expect([...new CairoArray([1, 2], SPAN, S).toApiRequest()]).toEqual(['2', '1', '2']);
+      expect(new CairoArray([1], SPAN, S).arrayType).toBe(SPAN);
+    });
+
+    test('should refuse an element type the strategy does not know', () => {
+      expect(() => new CairoArray([1], 'core::array::Array::<core::foo::Bar>', S)).toThrow(
+        '"core::foo::Bar" is not a valid Cairo type'
+      );
+    });
+
+    test('should refuse an unknown element type even with nothing to build', () => {
+      // the element type is looked up once, before the elements: an empty array of a type that
+      // does not exist is still an array of a type that does not exist
+      expect(() => new CairoArray([], 'core::array::Array::<core::foo::Bar>', S)).toThrow(
+        '"core::foo::Bar" is not a valid Cairo type'
+      );
+    });
+  });
+
+  describe('text becomes the chunks a felt252 or a bytes31 holds', () => {
+    test('should split a long string for an array of felt252', () => {
+      expect([...new CairoArray(LONG_TEXT, FELTS, S).toApiRequest()]).toEqual(LONG_TEXT_FELTS);
+    });
+
+    test('should split it the same way for an array of bytes31', () => {
+      expect([...new CairoArray(LONG_TEXT, BYTES31, S).toApiRequest()]).toEqual(LONG_TEXT_FELTS);
+    });
+
+    test('should split it for a Span as well as an Array', () => {
+      expect([
+        ...new CairoArray(LONG_TEXT, 'core::array::Span::<core::felt252>', S).toApiRequest(),
+      ]).toEqual(LONG_TEXT_FELTS);
+    });
+
+    test('should leave text alone where the elements do not hold text', () => {
+      // a u8 is one byte, so there is nothing sensible to split a sentence into
+      expect(() => new CairoArray(LONG_TEXT, U8, S)).toThrow(
+        'Invalid input: expected Array or Object, got string'
+      );
+    });
+
+    test('should not split a string that spells a number', () => {
+      // '123' is the number, not text; one element is written as ['123']
+      expect(() => new CairoArray('123', FELTS, S)).toThrow(
+        'Invalid input: expected Array or Object, got string'
+      );
+    });
+  });
+
+  describe('construction from a response', () => {
+    test('should read the length then that many elements', () => {
+      const array = new CairoArray(['0x2', '0x1', '0x2'].values(), U8, S);
+      expect(array.decompose(S)).toEqual([1n, 2n]);
+    });
+
+    test('should consume exactly what the length announces, leaving the rest', () => {
+      const iterator = ['0x2', '0x1', '0x2', '0x9'].values();
+      // eslint-disable-next-line no-new
+      new CairoArray(iterator, U8, S);
+      expect(iterator.next().value).toBe('0x9');
+    });
+
+    test('should read a length written in decimal as well as in hexadecimal', () => {
+      // this class writes the length in decimal and a node answers in hexadecimal; reading it in
+      // a fixed base would turn a decimal 10 into 16
+      const values = Array.from({ length: 10 }, (_, index) => index + 1);
+      const decimal = [...new CairoArray(values, U8, S).toApiRequest()];
+      const hexadecimal = decimal.map((felt) => `0x${BigInt(felt).toString(16)}`);
+      expect(new CairoArray(decimal.values(), U8, S).content).toHaveLength(10);
+      expect(new CairoArray(hexadecimal.values(), U8, S).content).toHaveLength(10);
+    });
+  });
+
+  describe('nesting', () => {
+    test('should give every level its own length prefix', () => {
+      expect([...new CairoArray([[1, 2], [3]], NESTED, S).toApiRequest()]).toEqual([
+        '2',
+        '2',
+        '1',
+        '2',
+        '1',
+        '3',
+      ]);
+    });
+
+    test('should read a nested array back off a flat response', () => {
+      const array = new CairoArray(['0x2', '0x2', '0x1', '0x2', '0x1', '0x3'].values(), NESTED, S);
+      expect(array.decompose(S)).toEqual([[1n, 2n], [3n]]);
+    });
+
+    test('should hold tuples, which have no length of their own', () => {
+      const array = new CairoArray(
+        [
+          [1, 2],
+          [3, 4],
+        ],
+        OF_TUPLES,
+        S
+      );
+      expect([...array.toApiRequest()]).toEqual(['2', '1', '2', '3', '4']);
+      expect(array.decompose(S)).toEqual([
+        { 0: 1n, 1: 2n },
+        { 0: 3n, 1: 4n },
+      ]);
+    });
+
+    test('should sit inside a tuple in turn', () => {
+      const tuple = new CairoTuple([[1, 2, 3], 9], `(${U8}, core::integer::u8)`, S);
+      expect([...tuple.toApiRequest()]).toEqual(['3', '1', '2', '3', '9']);
+    });
+  });
+
+  describe('reading an array type', () => {
+    test('should give the element type', () => {
+      expect(CairoArray.getArrayElementType('core::array::Array::<core::integer::u32>')).toBe(
+        'core::integer::u32'
+      );
+      expect(CairoArray.getArrayElementType(SPAN)).toBe('core::integer::u8');
+    });
+  });
+
+  describe('validate, is and isAbiType', () => {
+    test('should accept an array or an object for an array type', () => {
+      expect(() => CairoArray.validate([1, 2], U8)).not.toThrow();
+      expect(() => CairoArray.validate({ 0: 1 }, U8)).not.toThrow();
+    });
+
+    test('should refuse a type that is not a dynamic array', () => {
+      expect(() => CairoArray.validate([1, 2], 'core::integer::u8')).toThrow(
+        'The type core::integer::u8 is not a Cairo dynamic array. Needs core::array::Array::<T> or core::array::Span::<T>.'
+      );
+    });
+
+    test('should refuse an input that is neither an array nor an object', () => {
+      expect(() => CairoArray.validate('nope', U8)).toThrow(
+        'Invalid input: expected Array or Object, got string'
+      );
+    });
+
+    test('is should be the non-throwing form of validate', () => {
+      expect(CairoArray.is([1, 2], U8)).toBe(true);
+      expect(CairoArray.is([], U8)).toBe(true);
+      expect(CairoArray.is('nope', U8)).toBe(false);
+      expect(CairoArray.is([1, 2], 'core::integer::u8')).toBe(false);
+    });
+
+    test('isAbiType should tell a dynamic array from a fixed one', () => {
+      expect(CairoArray.isAbiType(U8)).toBe(true);
+      expect(CairoArray.isAbiType(SPAN)).toBe(true);
+      expect(CairoArray.isAbiType(NESTED)).toBe(true);
+      expect(CairoArray.isAbiType('[core::integer::u32; 8]')).toBe(false);
+      expect(CairoArray.isAbiType('core::integer::u32')).toBe(false);
+    });
+  });
+
+  describe('the dynamic selector', () => {
+    test('should name the class, on the class and on an instance', () => {
+      expect(CairoArray.dynamicSelector).toBe('CairoArray');
+      expect(new CairoArray([1], U8, S).dynamicSelector).toBe('CairoArray');
+    });
+
+    test('should be registered in the strategy, which is what makes nesting work', () => {
+      expect(S.dynamicSelectors[CairoArray.dynamicSelector](U8)).toBe(true);
+      expect(S.dynamicSelectors[CairoArray.dynamicSelector]('core::integer::u8')).toBe(false);
+      expect(typeof S.constructors[CairoArray.dynamicSelector]).toBe('function');
+      expect(typeof S.response[CairoArray.dynamicSelector]).toBe('function');
+    });
+
+    test('should refuse to build without the abi type it stands for', () => {
+      expect(() => S.constructors[CairoArray.dynamicSelector]([1, 2], S)).toThrow(
+        'A CairoArray cannot be built without the abi type it stands for'
+      );
+    });
+  });
+
+  describe('toApiRequest method', () => {
+    test('should put the count in front', () => {
+      // the whole difference with a tuple: an array declares no size in its type
+      expect([...new CairoArray([1, 2, 3], U8, S).toApiRequest()][0]).toBe('3');
+    });
+
+    test('should flag the result as compiled', () => {
+      expect(new CairoArray([1], U8, S).toApiRequest()).toHaveProperty('__compiled__', true);
+    });
+  });
+
+  describe('CallData.compile integration', () => {
+    test('should serialize an instance with its length prefix', () => {
+      expect(CallData.compile([new CairoArray([1, 2, 3], U8, S)] as any)).toEqual([
+        '3',
+        '1',
+        '2',
+        '3',
+      ]);
+    });
+
+    test('should sit alongside ordinary values', () => {
+      expect(CallData.compile([new CairoArray([1, 2], U8, S), 30] as any)).toEqual([
+        '2',
+        '1',
+        '2',
+        '30',
+      ]);
+    });
+
+    test('should flatten a nested array, prefixes and all', () => {
+      expect(CallData.compile([new CairoArray([[1, 2], [3]], NESTED, S)] as any)).toEqual([
+        '2',
+        '2',
+        '1',
+        '2',
+        '1',
+        '3',
+      ]);
+    });
+  });
+
+  describe('decompose method', () => {
+    test('should return the elements in order', () => {
+      expect(new CairoArray([1, 2, 3], U8, S).decompose(S)).toEqual([1n, 2n, 3n]);
+    });
+
+    test('should decompose each level of a nested array', () => {
+      expect(new CairoArray([[1, 2], [3]], NESTED, S).decompose(S)).toEqual([[1n, 2n], [3n]]);
+    });
+  });
+
+  describe('round-trip consistency', () => {
+    test('should survive a serialize then read back cycle', () => {
+      const cases: [string, any[]][] = [
+        [U8, []],
+        [U8, [1, 2, 3]],
+        [SPAN, [7]],
+        [NESTED, [[1, 2], [3]]],
+        [
+          OF_TUPLES,
+          [
+            [1, 2],
+            [3, 4],
+          ],
+        ],
+      ];
+      cases.forEach(([type, values]) => {
+        const array = new CairoArray(values, type, S);
+        const readBack = new CairoArray(asResponse(array).values(), type, S);
+        expect(readBack.decompose(S)).toEqual(array.decompose(S));
+      });
+    });
+
+    test('should read a long string back as its chunks', () => {
+      const array = new CairoArray(LONG_TEXT, FELTS, S);
+      const readBack = new CairoArray(asResponse(array).values(), FELTS, S);
+      expect([...readBack.toApiRequest()]).toEqual(LONG_TEXT_FELTS);
+    });
+  });
+});

--- a/__tests__/utils/cairoDataTypes/CairoClassHashAndContractAddress.test.ts
+++ b/__tests__/utils/cairoDataTypes/CairoClassHashAndContractAddress.test.ts
@@ -1,0 +1,104 @@
+import { CairoClassHash, CairoContractAddress, Literal } from '../../../src';
+import { validateAndParseAddress } from '../../../src/utils/address';
+import { ADDR_BOUND, PRIME } from '../../../src/global/constants';
+import { cairoTypeStrategy as S } from '../../../src/utils/calldata/parser/cairoTypeStrategy';
+
+/** An address written the way a node writes it, so that beta's own validator will read it. */
+const padded = (value: bigint) => `0x${value.toString(16).padStart(64, '0')}`;
+
+describe('CairoClassHash and CairoContractAddress Unit Tests', () => {
+  describe.each([
+    ['CairoClassHash', CairoClassHash, Literal.ClassHash],
+    ['CairoContractAddress', CairoContractAddress, Literal.ContractAddress],
+  ] as const)('%s', (_name, CairoType, abiSelector) => {
+    test('should read the same value from a number, a decimal string and a hex string', () => {
+      expect(new CairoType('0x1234').toBigInt()).toBe(4660n);
+      expect(new CairoType(4660).toBigInt()).toBe(4660n);
+      expect(new CairoType('4660').toBigInt()).toBe(4660n);
+    });
+
+    test('should answer to its own abi type and no other', () => {
+      expect(CairoType.abiSelector).toBe(abiSelector);
+      expect(CairoType.isAbiType(abiSelector)).toBe(true);
+      expect(CairoType.isAbiType('core::felt252')).toBe(false);
+    });
+
+    test('should serialize to one decimal-string felt', () => {
+      expect([...new CairoType('0x1234').toApiRequest()]).toEqual(['4660']);
+      expect(new CairoType('0x1234').toApiRequest()).toHaveProperty('__compiled__', true);
+    });
+
+    test('should return an unpadded hexadecimal string', () => {
+      expect(new CairoType(4660).toHexString()).toBe('0x1234');
+      expect(new CairoType('0x0034').toHexString()).toBe('0x34');
+    });
+
+    test('should refuse text, as an EthAddress does', () => {
+      expect(() => new CairoType('abc')).toThrow('cannot be built from text');
+      expect(CairoType.is('abc')).toBe(false);
+    });
+
+    test('should refuse what a felt252 refuses', () => {
+      expect(() => new CairoType(null)).toThrow('null value is not allowed for felt252');
+      expect(() => new CairoType({})).toThrow("Unsupported data type 'object' for felt252");
+      expect(CairoType.is(null)).toBe(false);
+    });
+
+    test('should read one felt off a response', () => {
+      expect(CairoType.factoryFromApiResponse(['0x1234'].values()).toBigInt()).toBe(4660n);
+    });
+
+    test('should be registered in the strategy, in both directions', () => {
+      expect(typeof S.constructors[abiSelector]).toBe('function');
+      expect(typeof S.response[abiSelector]).toBe('function');
+      const built = S.constructors[abiSelector]('0x1234', S);
+      expect([...built.toApiRequest()]).toEqual(['4660']);
+      expect(S.response[abiSelector](built, S)).toBe(4660n);
+    });
+
+    test('should survive a serialize then read back cycle', () => {
+      const felts = [...new CairoType('0x1234').toApiRequest()].map(
+        (felt) => `0x${BigInt(felt).toString(16)}`
+      );
+      expect(CairoType.factoryFromApiResponse(felts.values()).toBigInt()).toBe(4660n);
+    });
+  });
+
+  describe('the two bounds differ, and only one of them binds', () => {
+    test('a contract address stops at ADDR_BOUND, which is narrower than the field', () => {
+      expect(ADDR_BOUND).toBeLessThan(PRIME);
+      expect(new CairoContractAddress(ADDR_BOUND - 1n).toBigInt()).toBe(ADDR_BOUND - 1n);
+      expect(() => new CairoContractAddress(ADDR_BOUND)).toThrow(
+        'Value is out of ContractAddress range'
+      );
+      expect(() => new CairoContractAddress(PRIME - 1n)).toThrow(
+        'Value is out of ContractAddress range'
+      );
+    });
+
+    test('a class hash stops only at the field, being a hash output', () => {
+      expect(new CairoClassHash(PRIME - 1n).toBigInt()).toBe(PRIME - 1n);
+      // wider than an address may be, which is the whole difference between the two
+      expect(new CairoClassHash(ADDR_BOUND).toBigInt()).toBe(ADDR_BOUND);
+      expect(() => new CairoClassHash(PRIME)).toThrow('is out of felt252 range');
+    });
+  });
+
+  describe('agreement with the address validator already in the library', () => {
+    test.each([
+      ['ADDR_BOUND - 1', ADDR_BOUND - 1n],
+      ['ADDR_BOUND', ADDR_BOUND],
+      ['2 ** 251', 2n ** 251n],
+    ])('should say what validateAndParseAddress says about %s', (_label, value) => {
+      const acceptedHere = CairoContractAddress.is(value);
+      let acceptedThere: boolean;
+      try {
+        validateAndParseAddress(padded(value));
+        acceptedThere = true;
+      } catch {
+        acceptedThere = false;
+      }
+      expect(acceptedHere).toBe(acceptedThere);
+    });
+  });
+});

--- a/__tests__/utils/cairoDataTypes/CairoNonZero.test.ts
+++ b/__tests__/utils/cairoDataTypes/CairoNonZero.test.ts
@@ -1,0 +1,183 @@
+import { CallData, cairo } from '../../../src';
+import { CairoNonZero } from '../../../src/utils/cairoDataTypes/nonZero';
+import { CairoUint8 } from '../../../src/utils/cairoDataTypes/uint8';
+import { CairoUint256 } from '../../../src/utils/cairoDataTypes/uint256';
+import { cairoTypeStrategy as S } from '../../../src/utils/calldata/parser/cairoTypeStrategy';
+
+const NZ8 = 'core::zeroable::NonZero::<core::integer::u8>';
+const NZ256 = 'core::zeroable::NonZero::<core::integer::u256>';
+const NZ_FELT = 'core::zeroable::NonZero::<core::felt252>';
+
+describe('CairoNonZero class Unit Tests', () => {
+  describe('what the content may be', () => {
+    test('should build from a number', () => {
+      const nonZero = new CairoNonZero(8, NZ8, S);
+      expect(nonZero.content).toEqual(new CairoUint8(8));
+      expect(nonZero.contentType).toBe(NZ8);
+      expect([...nonZero.toApiRequest()]).toEqual(['8']);
+      expect(nonZero.decompose(S)).toBe(8n);
+    });
+
+    test('should build from a response', () => {
+      const nonZero = new CairoNonZero(['9'].values(), NZ8, S);
+      expect(nonZero.content).toEqual(new CairoUint8(9));
+      expect([...nonZero.toApiRequest()]).toEqual(['9']);
+      expect(nonZero.decompose(S)).toBe(9n);
+    });
+
+    test('should take a CairoType already built', () => {
+      const value = new CairoUint8(7);
+      const nonZero = new CairoNonZero(value, NZ8, S);
+      expect(nonZero.content).toEqual(value);
+      expect([...nonZero.toApiRequest()]).toEqual(['7']);
+    });
+
+    test('should copy a CairoNonZero handed to it whole', () => {
+      const copy = new CairoNonZero(new CairoNonZero(8, NZ8, S), NZ8, S);
+      expect([...copy.toApiRequest()]).toEqual(['8']);
+      expect(copy.contentType).toBe(NZ8);
+    });
+
+    test('should wrap a u256, whatever shape it is given in', () => {
+      const expected = new CairoUint256(1000);
+      [cairo.uint256(1000), expected, 1000].forEach((value) => {
+        const nonZero = new CairoNonZero(value, NZ256, S);
+        expect(nonZero.content).toEqual(expected);
+        expect([...nonZero.toApiRequest()]).toEqual(['1000', '0']);
+        expect(nonZero.decompose(S)).toBe(1000n);
+      });
+    });
+
+    test('should wrap a felt252', () => {
+      expect([...new CairoNonZero(5, NZ_FELT, S).toApiRequest()]).toEqual(['5']);
+    });
+  });
+
+  describe('zero is what this type exists to refuse', () => {
+    test.each([
+      ['u8', 'core::zeroable::NonZero::<core::integer::u8>'],
+      ['u16', 'core::zeroable::NonZero::<core::integer::u16>'],
+      ['u32', 'core::zeroable::NonZero::<core::integer::u32>'],
+      ['u64', 'core::zeroable::NonZero::<core::integer::u64>'],
+      ['u96', 'core::zeroable::NonZero::<core::integer::u96>'],
+      ['u128', 'core::zeroable::NonZero::<core::integer::u128>'],
+      ['u256', 'core::zeroable::NonZero::<core::integer::u256>'],
+      ['felt252', 'core::zeroable::NonZero::<core::felt252>'],
+    ])('should refuse a zero given raw as %s', (_name, type) => {
+      expect(() => new CairoNonZero(0, type, S)).toThrow(
+        'ValidateValue: value 0 is not authorized in NonZero type.'
+      );
+    });
+
+    test('should let a zero through when it is already built', () => {
+      // the check runs on a value this class builds itself; one handed in is taken as it stands
+      expect([...new CairoNonZero(new CairoUint8(0), NZ8, S).toApiRequest()]).toEqual(['0']);
+    });
+
+    test('should let a zero through when it comes from a response', () => {
+      // what a node answers is not the caller's mistake to catch
+      expect([...new CairoNonZero(['0'].values(), NZ8, S).toApiRequest()]).toEqual(['0']);
+    });
+  });
+
+  describe('the types Cairo allows here', () => {
+    test('should refuse u512, which Cairo does not support', () => {
+      expect(
+        () => new CairoNonZero(1, 'core::zeroable::NonZero::<core::integer::u512>', S)
+      ).toThrow('Validate: core::integer::u512 type is not authorized for NonZero type.');
+    });
+
+    test('should refuse a signed integer', () => {
+      expect(() => new CairoNonZero(1, 'core::zeroable::NonZero::<core::integer::i8>', S)).toThrow(
+        'Validate: core::integer::i8 type is not authorized for NonZero type.'
+      );
+    });
+
+    test('should refuse a composite', () => {
+      expect(
+        () =>
+          new CairoNonZero(
+            [1],
+            'core::zeroable::NonZero::<core::array::Array::<core::integer::u8>>',
+            S
+          )
+      ).toThrow('is not authorized for NonZero type.');
+    });
+  });
+
+  describe('static methods', () => {
+    test('getNonZeroType', () => {
+      expect(CairoNonZero.getNonZeroType(NZ8)).toBe('core::integer::u8');
+      expect(CairoNonZero.getNonZeroType(NZ256)).toBe('core::integer::u256');
+    });
+
+    test('isAbiType', () => {
+      expect(CairoNonZero.isAbiType(NZ8)).toBe(true);
+      expect(CairoNonZero.isAbiType('core::integer::u8')).toBe(false);
+    });
+
+    test('validate', () => {
+      expect(() => CairoNonZero.validate(1, NZ8)).not.toThrow();
+      expect(() => CairoNonZero.validate(1, 'core::integer::u8')).toThrow(
+        'The type core::integer::u8 is not a Cairo Non Zero. Needs core::zeroable::NonZero::<T>.'
+      );
+    });
+
+    test('is should be the non-throwing form of validate, and say nothing about zero', () => {
+      expect(CairoNonZero.is(1, NZ8)).toBe(true);
+      expect(CairoNonZero.is(0, NZ8)).toBe(true);
+      expect(CairoNonZero.is(1, 'core::integer::u8')).toBe(false);
+    });
+  });
+
+  describe('the dynamic selector', () => {
+    test('should name the class, on the class and on an instance', () => {
+      expect(CairoNonZero.dynamicSelector).toBe('CairoNonZero');
+      expect(new CairoNonZero(8, NZ8, S).dynamicSelector).toBe('CairoNonZero');
+    });
+
+    test('should be registered in the strategy', () => {
+      expect(S.dynamicSelectors.CairoNonZero(NZ8)).toBe(true);
+      expect(S.dynamicSelectors.CairoNonZero('core::integer::u8')).toBe(false);
+      expect(typeof S.constructors.CairoNonZero).toBe('function');
+      expect(typeof S.response.CairoNonZero).toBe('function');
+    });
+  });
+
+  describe('toApiRequest method', () => {
+    test('should add no felt of its own', () => {
+      // the whole point: a NonZero is a promise about a value, not a shape around it
+      expect([...new CairoNonZero(8, NZ8, S).toApiRequest()]).toEqual(['8']);
+      expect([...new CairoNonZero(1000, NZ256, S).toApiRequest()]).toHaveLength(2);
+    });
+
+    test('should flag the result as compiled', () => {
+      expect(new CairoNonZero(8, NZ8, S).toApiRequest()).toHaveProperty('__compiled__', true);
+    });
+  });
+
+  describe('CallData.compile integration', () => {
+    test('should serialize an instance as its wrapped value', () => {
+      expect(CallData.compile([new CairoNonZero(8, NZ8, S)] as any)).toEqual(['8']);
+      expect(CallData.compile([new CairoNonZero(1000, NZ256, S)] as any)).toEqual(['1000', '0']);
+    });
+  });
+
+  describe('round-trip consistency', () => {
+    test('should survive a serialize then read back cycle', () => {
+      const cases: [string, any][] = [
+        [NZ8, 8],
+        [NZ256, 1000],
+        [NZ_FELT, 5],
+      ];
+      cases.forEach(([type, value]) => {
+        const nonZero = new CairoNonZero(value, type, S);
+        const response = [...nonZero.toApiRequest()].map(
+          (felt) => `0x${BigInt(felt).toString(16)}`
+        );
+        const readBack = new CairoNonZero(response.values(), type, S);
+        expect([...readBack.toApiRequest()]).toEqual([...nonZero.toApiRequest()]);
+      });
+    });
+  });
+});

--- a/__tests__/utils/cairoDataTypes/CairoStruct.test.ts
+++ b/__tests__/utils/cairoDataTypes/CairoStruct.test.ts
@@ -1,0 +1,263 @@
+import { CallData, type AbiStruct } from '../../../src';
+import { CairoArray } from '../../../src/utils/cairoDataTypes/array';
+import { CairoStruct } from '../../../src/utils/cairoDataTypes/cairoStruct';
+import { CairoUint8 } from '../../../src/utils/cairoDataTypes/uint8';
+import {
+  cairoTypeStrategy,
+  structStrategy,
+} from '../../../src/utils/calldata/parser/cairoTypeStrategy';
+
+// hand-written rather than taken from a compiled contract: these are unit tests of the class, and
+// the abi definition is all it ever reads
+const POINT = {
+  type: 'struct',
+  name: 'test::Point',
+  members: [
+    { name: 'x', type: 'core::integer::u8' },
+    { name: 'y', type: 'core::integer::u32' },
+  ],
+} as AbiStruct;
+
+const LINE = {
+  type: 'struct',
+  name: 'test::Line',
+  members: [
+    { name: 'a', type: 'test::Point' },
+    { name: 'b', type: 'test::Point' },
+  ],
+} as AbiStruct;
+
+const HOLDER = {
+  type: 'struct',
+  name: 'test::Holder',
+  members: [
+    { name: 'values', type: 'core::array::Array::<core::integer::u8>' },
+    { name: 'pair', type: '(core::integer::u8, core::integer::u8)' },
+  ],
+} as AbiStruct;
+
+/** The language's types, then the contract's — which is what the second argument is for. */
+const S = [cairoTypeStrategy, structStrategy([POINT, LINE, HOLDER])];
+
+/** The felts a struct serializes to, as the hex strings a node would answer with. */
+const asResponse = (struct: CairoStruct): string[] =>
+  [...struct.toApiRequest()].map((felt) => `0x${BigInt(felt).toString(16)}`);
+
+describe('CairoStruct class Unit Tests', () => {
+  describe('construction from the values a caller passes', () => {
+    test('should read an object by the abi member names, in the abi order', () => {
+      const struct = new CairoStruct({ y: 2, x: 1 }, POINT, S);
+      expect([...struct.toApiRequest()]).toEqual(['1', '2']);
+      expect(struct.decompose(S)).toEqual({ x: 1n, y: 2n });
+    });
+
+    test('should take an array as already being in that order', () => {
+      const struct = new CairoStruct([1, 2], POINT, S);
+      expect([...struct.toApiRequest()]).toEqual(['1', '2']);
+      expect(struct.decompose(S)).toEqual({ x: 1n, y: 2n });
+    });
+
+    test('should take a member that is already built', () => {
+      expect([...new CairoStruct([new CairoUint8(1), 2], POINT, S).toApiRequest()]).toEqual([
+        '1',
+        '2',
+      ]);
+    });
+
+    test('should copy a struct handed to it whole', () => {
+      const copy = new CairoStruct(new CairoStruct({ x: 1, y: 2 }, POINT, S), POINT, S);
+      expect([...copy.toApiRequest()]).toEqual(['1', '2']);
+      expect(copy.abiStruct.name).toBe('test::Point');
+      expect(copy.dynamicSelector).toBe('test::Point');
+    });
+
+    test('should accept a single strategy where the members need no other', () => {
+      // the struct itself is given by argument, so only its members are looked up, and here they
+      // are all types of the language
+      expect([...new CairoStruct({ x: 1, y: 2 }, POINT, cairoTypeStrategy).toApiRequest()]).toEqual(
+        ['1', '2']
+      );
+    });
+
+    test('should refuse an object that is missing a member', () => {
+      expect(() => new CairoStruct({ x: 1, z: 2 }, POINT, S)).toThrow(
+        'Your object needs a property with key : y .'
+      );
+    });
+
+    test('should refuse a member count the abi does not declare', () => {
+      expect(() => new CairoStruct([1], POINT, S)).toThrow(
+        'Invalid input: expected 2 members, got 1'
+      );
+      expect(() => new CairoStruct([1, 2, 3], POINT, S)).toThrow(
+        'Invalid input: expected 2 members, got 3'
+      );
+    });
+
+    test('should refuse a member type no strategy knows', () => {
+      const unknown = {
+        type: 'struct',
+        name: 'test::Unknown',
+        members: [{ name: 'a', type: 'core::foo::Bar' }],
+      } as AbiStruct;
+      expect(() => new CairoStruct({ a: 1 }, unknown, S)).toThrow(
+        '"core::foo::Bar" is not a valid Cairo type'
+      );
+    });
+  });
+
+  describe('construction from a response', () => {
+    test('should read the members off the iterator', () => {
+      const struct = new CairoStruct(['0x0', '0x64'].values(), POINT, S);
+      expect([...struct.toApiRequest()]).toEqual(['0', '100']);
+      expect(struct.decompose(S)).toEqual({ x: 0n, y: 100n });
+    });
+
+    test('should consume exactly what the abi declares, leaving the rest', () => {
+      const iterator = ['0x1', '0x2', '0x9'].values();
+      // eslint-disable-next-line no-new
+      new CairoStruct(iterator, POINT, S);
+      expect(iterator.next().value).toBe('0x9');
+    });
+  });
+
+  describe('nesting', () => {
+    test('should hold another struct, found by its exact name', () => {
+      const line = new CairoStruct({ a: { x: 1, y: 2 }, b: { x: 3, y: 4 } }, LINE, S);
+      expect([...line.toApiRequest()]).toEqual(['1', '2', '3', '4']);
+      expect(line.decompose(S)).toEqual({ a: { x: 1n, y: 2n }, b: { x: 3n, y: 4n } });
+    });
+
+    test('should read a nested struct back off a flat response', () => {
+      const line = new CairoStruct(['0x1', '0x2', '0x3', '0x4'].values(), LINE, S);
+      expect(line.decompose(S)).toEqual({ a: { x: 1n, y: 2n }, b: { x: 3n, y: 4n } });
+    });
+
+    test('should hold an array and a tuple, each keeping its own shape', () => {
+      const holder = new CairoStruct({ values: [1, 2, 3], pair: [4, 5] }, HOLDER, S);
+      // the array carries its length, the tuple does not
+      expect([...holder.toApiRequest()]).toEqual(['3', '1', '2', '3', '4', '5']);
+      expect(holder.decompose(S)).toEqual({ values: [1n, 2n, 3n], pair: { 0: 4n, 1: 5n } });
+    });
+
+    test('should sit inside an array in turn', () => {
+      const array = new CairoArray(
+        [
+          { x: 1, y: 2 },
+          { x: 3, y: 4 },
+        ],
+        'core::array::Array::<test::Point>',
+        S
+      );
+      expect([...array.toApiRequest()]).toEqual(['2', '1', '2', '3', '4']);
+      expect(array.decompose(S)).toEqual([
+        { x: 1n, y: 2n },
+        { x: 3n, y: 4n },
+      ]);
+    });
+  });
+
+  describe('reading an abi definition', () => {
+    test('should give the member types and names, in the abi order', () => {
+      expect(CairoStruct.getStructMembersTypes(POINT)).toEqual([
+        'core::integer::u8',
+        'core::integer::u32',
+      ]);
+      expect(CairoStruct.extractStructMembersNames(POINT)).toEqual(['x', 'y']);
+    });
+  });
+
+  describe('validate and is', () => {
+    test('should check the member count against the abi', () => {
+      expect(() => CairoStruct.validate({ x: 1, y: 2 }, POINT)).not.toThrow();
+      expect(() => CairoStruct.validate([1], POINT)).toThrow(
+        'Invalid input: expected 2 members, got 1'
+      );
+    });
+
+    test('should check only the shape when there is no abi to check against', () => {
+      expect(() => CairoStruct.validate({ anything: 1 })).not.toThrow();
+      expect(() => CairoStruct.validate([1, 2, 3])).not.toThrow();
+      expect(() => CairoStruct.validate('nope')).toThrow(
+        'Invalid input: expected Array or Object, got string'
+      );
+    });
+
+    test('should refuse an abi entry that is not a struct', () => {
+      const notAStruct = { type: 'enum', name: 'test::E', members: [] } as unknown as AbiStruct;
+      expect(() => CairoStruct.validate({ a: 1 }, notAStruct)).toThrow(
+        'Invalid ABI: expected struct, got enum'
+      );
+    });
+
+    test('is should be the non-throwing form of validate', () => {
+      expect(CairoStruct.is({ x: 1, y: 2 }, POINT)).toBe(true);
+      expect(CairoStruct.is([1], POINT)).toBe(false);
+      expect(CairoStruct.is('nope')).toBe(false);
+    });
+  });
+
+  describe('a struct has no abi type to recognise', () => {
+    test('should not offer an isAbiType, unlike every other composite', () => {
+      // its abi type is the name the contract chose, which looks like any other type; it is found
+      // by exact name in a strategy instead, which is what structStrategy builds
+      expect('isAbiType' in CairoStruct).toBe(false);
+    });
+  });
+
+  describe('structStrategy', () => {
+    test('should key one entry per struct, by its abi name', () => {
+      const strategy = structStrategy([POINT, LINE]);
+      expect(Object.keys(strategy.constructors)).toEqual(['test::Point', 'test::Line']);
+      expect(Object.keys(strategy.response)).toEqual(['test::Point', 'test::Line']);
+    });
+
+    test('should add no dynamic selector, which would shadow every other type', () => {
+      expect(structStrategy([POINT]).dynamicSelectors).toEqual({});
+    });
+
+    test('should build and read back through those entries', () => {
+      const strategy = structStrategy([POINT]);
+      const built = strategy.constructors['test::Point']({ x: 1, y: 2 }, S);
+      expect([...built.toApiRequest()]).toEqual(['1', '2']);
+      expect(strategy.response['test::Point'](built, S)).toEqual({ x: 1n, y: 2n });
+    });
+  });
+
+  describe('toApiRequest method', () => {
+    test('should carry no length prefix, as a tuple does not', () => {
+      expect([...new CairoStruct({ x: 1, y: 2 }, POINT, S).toApiRequest()]).toHaveLength(2);
+    });
+
+    test('should flag the result as compiled', () => {
+      expect(new CairoStruct({ x: 1, y: 2 }, POINT, S).toApiRequest()).toHaveProperty(
+        '__compiled__',
+        true
+      );
+    });
+  });
+
+  describe('CallData.compile integration', () => {
+    test('should serialize an instance as its members', () => {
+      expect(CallData.compile([new CairoStruct({ x: 1, y: 2 }, POINT, S)] as any)).toEqual([
+        '1',
+        '2',
+      ]);
+    });
+  });
+
+  describe('round-trip consistency', () => {
+    test('should survive a serialize then read back cycle', () => {
+      const cases: [AbiStruct, any][] = [
+        [POINT, { x: 1, y: 2 }],
+        [LINE, { a: { x: 1, y: 2 }, b: { x: 3, y: 4 } }],
+        [HOLDER, { values: [1, 2, 3], pair: [4, 5] }],
+      ];
+      cases.forEach(([abi, values]) => {
+        const struct = new CairoStruct(values, abi, S);
+        const readBack = new CairoStruct(asResponse(struct).values(), abi, S);
+        expect(readBack.decompose(S)).toEqual(struct.decompose(S));
+      });
+    });
+  });
+});

--- a/__tests__/utils/cairoDataTypes/CairoTuple.test.ts
+++ b/__tests__/utils/cairoDataTypes/CairoTuple.test.ts
@@ -1,0 +1,341 @@
+import { CallData } from '../../../src';
+import { CairoTuple } from '../../../src/utils/cairoDataTypes/tuple';
+import { CairoUint8 } from '../../../src/utils/cairoDataTypes/uint8';
+import { cairoTypeStrategy } from '../../../src/utils/calldata/parser/cairoTypeStrategy';
+
+const S = cairoTypeStrategy;
+const PAIR = '(core::integer::u8, core::integer::u32)';
+const NESTED = '((core::integer::u8, core::integer::u8), core::integer::u32)';
+const DEEP = '(((core::integer::u8, core::integer::u8), core::integer::u8), core::integer::u8)';
+
+/** The felts a tuple serializes to, as the hex strings a node would answer with. */
+const asResponse = (tuple: CairoTuple): string[] =>
+  [...tuple.toApiRequest()].map((felt) => `0x${BigInt(felt).toString(16)}`);
+
+describe('CairoTuple class Unit Tests', () => {
+  describe('construction from the values a caller passes', () => {
+    test('should build from an array', () => {
+      expect([...new CairoTuple([1, 2], PAIR, S).toApiRequest()]).toEqual(['1', '2']);
+    });
+
+    test('should build from an object keyed by position', () => {
+      expect([...new CairoTuple({ 0: 1, 1: 2 }, PAIR, S).toApiRequest()]).toEqual(['1', '2']);
+    });
+
+    test('should build from an object keyed by anything, in insertion order', () => {
+      expect([...new CairoTuple({ a: 1, b: 2 }, PAIR, S).toApiRequest()]).toEqual(['1', '2']);
+    });
+
+    test('should take a member that is already built', () => {
+      expect([...new CairoTuple([new CairoUint8(1), 2], PAIR, S).toApiRequest()]).toEqual([
+        '1',
+        '2',
+      ]);
+    });
+
+    test('should copy a tuple handed to it whole', () => {
+      const copy = new CairoTuple(new CairoTuple([1, 2], PAIR, S), PAIR, S);
+      expect([...copy.toApiRequest()]).toEqual(['1', '2']);
+      expect(copy.tupleType).toBe(PAIR);
+    });
+
+    test('should hold a single member without turning it into a bare value', () => {
+      const single = new CairoTuple([42], '(core::integer::u8)', S);
+      expect(single.content).toHaveLength(1);
+      expect([...single.toApiRequest()]).toEqual(['42']);
+    });
+
+    test('should read every input shape a felt252 accepts', () => {
+      const mixed = new CairoTuple(
+        [1, '2', 3n],
+        '(core::felt252, core::felt252, core::felt252)',
+        S
+      );
+      expect([...mixed.toApiRequest()]).toEqual(['1', '2', '3']);
+    });
+
+    test('should hold members of different types', () => {
+      const mixed = new CairoTuple(
+        [1, 'ab', 2n, true],
+        '(core::integer::u8, core::felt252, core::integer::u256, core::bool)',
+        S
+      );
+      // 'ab' is text, so felt252 takes its UTF-8 bytes; a u256 spreads over two felts
+      expect([...mixed.toApiRequest()]).toEqual(['1', '24930', '2', '0', '1']);
+    });
+
+    test('should hold as many members as the type declares', () => {
+      const size = 50;
+      const type = `(${Array(size).fill('core::integer::u8').join(', ')})`;
+      const values = Array.from({ length: size }, (_, index) => index + 1);
+      const felts = [...new CairoTuple(values, type, S).toApiRequest()];
+      expect(felts).toHaveLength(size);
+      expect(felts[0]).toBe('1');
+      expect(felts[size - 1]).toBe('50');
+    });
+
+    test('should refuse a member the strategy does not know', () => {
+      expect(() => new CairoTuple([1], '(core::foo::Bar)', S)).toThrow(
+        '"core::foo::Bar" is not a valid Cairo type'
+      );
+    });
+
+    test('should refuse a member count the type does not declare', () => {
+      expect(() => new CairoTuple([1, 2], '(core::integer::u8)', S)).toThrow(
+        'ABI type (core::integer::u8): expected 1 items, got 2 items.'
+      );
+    });
+  });
+
+  describe('construction from a response', () => {
+    test('should read the members off the iterator', () => {
+      expect([...new CairoTuple(['0x1', '0x2'].values(), PAIR, S).toApiRequest()]).toEqual([
+        '1',
+        '2',
+      ]);
+    });
+
+    test('should consume exactly what the type declares, leaving the rest', () => {
+      const iterator = ['0x1', '0x2', '0x9'].values();
+      // eslint-disable-next-line no-new
+      new CairoTuple(iterator, PAIR, S);
+      expect(iterator.next().value).toBe('0x9');
+    });
+  });
+
+  describe('nesting', () => {
+    test('should build a tuple of tuples', () => {
+      expect([...new CairoTuple([[1, 2], 3], NESTED, S).toApiRequest()]).toEqual(['1', '2', '3']);
+    });
+
+    test('should nest as deep as the type goes', () => {
+      expect([...new CairoTuple([[[1, 2], 3], 4], DEEP, S).toApiRequest()]).toEqual([
+        '1',
+        '2',
+        '3',
+        '4',
+      ]);
+    });
+
+    test('should read a nested tuple back off a flat response', () => {
+      // nothing in the felts says where the inner tuple ends; only the type does
+      const tuple = new CairoTuple(['0x1', '0x2', '0x3'].values(), NESTED, S);
+      expect(tuple.decompose(S)).toEqual({ 0: { 0: 1n, 1: 2n }, 1: 3n });
+    });
+
+    test('should accept an inner tuple that is already built', () => {
+      const inner = new CairoTuple([1, 2], '(core::integer::u8, core::integer::u8)', S);
+      expect([...new CairoTuple([inner, 3], NESTED, S).toApiRequest()]).toEqual(['1', '2', '3']);
+    });
+  });
+
+  describe('the empty tuple', () => {
+    test('should have no members', () => {
+      expect(CairoTuple.getTupleElementTypes('()')).toEqual([]);
+      expect([...new CairoTuple([], '()', S).toApiRequest()]).toEqual([]);
+      expect(new CairoTuple([], '()', S).decompose(S)).toEqual({});
+    });
+  });
+
+  describe('reading a tuple type', () => {
+    test('should split a Cairo 1 tuple into its member types', () => {
+      expect(CairoTuple.getTupleElementTypes(PAIR)).toEqual([
+        'core::integer::u8',
+        'core::integer::u32',
+      ]);
+    });
+
+    test('should keep a nested member whole', () => {
+      expect(CairoTuple.getTupleElementTypes(NESTED)).toEqual([
+        '(core::integer::u8, core::integer::u8)',
+        'core::integer::u32',
+      ]);
+    });
+
+    test('should split a Cairo 0 named tuple into names and types', () => {
+      expect(CairoTuple.getTupleElementTypes('(x:felt, y:felt)')).toEqual([
+        { name: 'x', type: 'felt' },
+        { name: 'y', type: 'felt' },
+      ]);
+    });
+
+    test('should name the members, or number them when the type does not', () => {
+      expect(CairoTuple.extractTupleMembersNames(PAIR)).toEqual(['0', '1']);
+      expect(CairoTuple.extractTupleMembersNames('(x:felt, y:felt)')).toEqual(['x', 'y']);
+    });
+
+    test('a Cairo 0 named tuple is read but cannot be built by this strategy', () => {
+      // the members are named and typed correctly, but 'felt' is a Cairo 0 type name and the
+      // strategy only registers the Cairo 1 ones, so there is nothing to build the member with
+      expect(() => new CairoTuple([1, 2], '(x:felt, y:felt)', S)).toThrow(
+        '"felt" is not a valid Cairo type'
+      );
+    });
+  });
+
+  describe('the guard against a type that does not survive being split', () => {
+    test('should refuse a Cairo 1 type whose members do not recompose it', () => {
+      // without this, the parser eats the character after the comma and hands back a member type
+      // that does not exist: ["core::integer::u8", "ore::integer::u32"]
+      expect(() =>
+        CairoTuple.getTupleElementTypes('(core::integer::u8,core::integer::u32)')
+      ).toThrow('is not a valid Cairo type (its members do not recompose it');
+    });
+
+    test('should refuse it at construction too', () => {
+      expect(() => new CairoTuple([1, 2], '(core::integer::u8,core::integer::u32)', S)).toThrow(
+        'is not a valid Cairo type (its members do not recompose it'
+      );
+    });
+
+    test('should leave alone a nested generic whose own comma carries no space', () => {
+      // read by bracket matching rather than by commas, so it comes back whole and is valid
+      expect(
+        CairoTuple.getTupleElementTypes(
+          '(core::result::Result::<core::integer::u8,core::integer::u8>, core::integer::u8)'
+        )
+      ).toEqual([
+        'core::result::Result::<core::integer::u8,core::integer::u8>',
+        'core::integer::u8',
+      ]);
+    });
+
+    test('should leave alone a Cairo 0 tuple, which is split with every space stripped', () => {
+      expect(CairoTuple.getTupleElementTypes('(x:felt,y:felt)')).toEqual([
+        { name: 'x', type: 'felt' },
+        { name: 'y', type: 'felt' },
+      ]);
+    });
+  });
+
+  describe('validate, is and isAbiType', () => {
+    test('should accept an array or an object for a tuple type', () => {
+      expect(() => CairoTuple.validate([1, 2], PAIR)).not.toThrow();
+      expect(() => CairoTuple.validate({ 0: 1, 1: 2 }, PAIR)).not.toThrow();
+    });
+
+    test('should refuse a type that is not a tuple', () => {
+      expect(() => CairoTuple.validate([1, 2], 'core::integer::u8')).toThrow(
+        'The type core::integer::u8 is not a Cairo tuple. Expected format: (type1, type2, ...)'
+      );
+    });
+
+    test('should refuse an input that is neither an array nor an object', () => {
+      expect(() => CairoTuple.validate('nope', PAIR)).toThrow(
+        'Invalid input: expected Array or Object, got string'
+      );
+    });
+
+    test('is should be the non-throwing form of validate', () => {
+      expect(CairoTuple.is([1, 2], PAIR)).toBe(true);
+      expect(CairoTuple.is('nope', PAIR)).toBe(false);
+      expect(CairoTuple.is([1, 2], 'core::integer::u8')).toBe(false);
+    });
+
+    test('isAbiType should recognise every tuple shape', () => {
+      expect(CairoTuple.isAbiType(PAIR)).toBe(true);
+      expect(CairoTuple.isAbiType(NESTED)).toBe(true);
+      expect(CairoTuple.isAbiType('(x:felt, y:felt)')).toBe(true);
+      expect(CairoTuple.isAbiType('()')).toBe(true);
+      expect(CairoTuple.isAbiType('(a)')).toBe(true);
+      expect(CairoTuple.isAbiType('(very::long::type::name)')).toBe(true);
+    });
+
+    test('isAbiType should refuse anything that is not one', () => {
+      expect(CairoTuple.isAbiType('core::integer::u32')).toBe(false);
+      expect(CairoTuple.isAbiType('[core::integer::u32; 8]')).toBe(false);
+      expect(CairoTuple.isAbiType('[type; 0]')).toBe(false);
+      expect(CairoTuple.isAbiType('tuple_but_no_parens')).toBe(false);
+    });
+  });
+
+  describe('the dynamic selector', () => {
+    test('should name the class, on the class and on an instance', () => {
+      expect(CairoTuple.dynamicSelector).toBe('CairoTuple');
+      expect(new CairoTuple([1, 2], PAIR, S).dynamicSelector).toBe('CairoTuple');
+    });
+
+    test('should be registered in the strategy, which is what makes nesting work', () => {
+      expect(S.dynamicSelectors[CairoTuple.dynamicSelector](PAIR)).toBe(true);
+      expect(S.dynamicSelectors[CairoTuple.dynamicSelector]('core::integer::u8')).toBe(false);
+      expect(typeof S.constructors[CairoTuple.dynamicSelector]).toBe('function');
+      expect(typeof S.response[CairoTuple.dynamicSelector]).toBe('function');
+    });
+
+    test('should refuse to build without the abi type it stands for', () => {
+      expect(() => S.constructors[CairoTuple.dynamicSelector]([1, 2], S)).toThrow(
+        'A CairoTuple cannot be built without the abi type it stands for'
+      );
+    });
+  });
+
+  describe('toApiRequest method', () => {
+    test('should carry no length prefix', () => {
+      // the whole difference with an array: a tuple's size is in its type, not on the wire
+      expect([...new CairoTuple([1, 2], PAIR, S).toApiRequest()]).toHaveLength(2);
+    });
+
+    test('should flag the result as compiled', () => {
+      expect(new CairoTuple([1, 2], PAIR, S).toApiRequest()).toHaveProperty('__compiled__', true);
+    });
+  });
+
+  describe('CallData.compile integration', () => {
+    test('should serialize an instance as its members, with no length prefix', () => {
+      expect(CallData.compile([new CairoTuple([10, 20], PAIR, S)] as any)).toEqual(['10', '20']);
+    });
+
+    test('should sit alongside ordinary values', () => {
+      expect(CallData.compile([new CairoTuple([10, 20], PAIR, S), 30, 'test'] as any)).toEqual([
+        '10',
+        '20',
+        '30',
+        '1952805748',
+      ]);
+    });
+
+    test('should flatten a nested tuple among others', () => {
+      expect(
+        CallData.compile([
+          new CairoTuple([1, 2], PAIR, S),
+          new CairoTuple([[5, 6], 7], NESTED, S),
+        ] as any)
+      ).toEqual(['1', '2', '5', '6', '7']);
+    });
+  });
+
+  describe('compile static method', () => {
+    test('should key the members by position', () => {
+      expect(CairoTuple.compile([10, 20, 30])).toEqual({ 0: 10, 1: 20, 2: 30 });
+    });
+  });
+
+  describe('decompose method', () => {
+    test('should return the members keyed by position', () => {
+      expect(new CairoTuple([1, 2], PAIR, S).decompose(S)).toEqual({ 0: 1n, 1: 2n });
+    });
+
+    test('should decompose each level of a nested tuple', () => {
+      expect(new CairoTuple([[[1, 2], 3], 4], DEEP, S).decompose(S)).toEqual({
+        0: { 0: { 0: 1n, 1: 2n }, 1: 3n },
+        1: 4n,
+      });
+    });
+  });
+
+  describe('round-trip consistency', () => {
+    test('should survive a serialize then read back cycle', () => {
+      const cases: [string, any[]][] = [
+        [PAIR, [1, 2]],
+        ['(core::integer::u8)', [42]],
+        [NESTED, [[1, 2], 3]],
+        [DEEP, [[[1, 2], 3], 4]],
+      ];
+      cases.forEach(([type, values]) => {
+        const tuple = new CairoTuple(values, type, S);
+        const readBack = new CairoTuple(asResponse(tuple).values(), type, S);
+        expect(readBack.decompose(S)).toEqual(tuple.decompose(S));
+      });
+    });
+  });
+});

--- a/__tests__/utils/cairoDataTypes/CairoTypeCustomEnum.test.ts
+++ b/__tests__/utils/cairoDataTypes/CairoTypeCustomEnum.test.ts
@@ -1,0 +1,336 @@
+import {
+  CallData,
+  CairoCustomEnum,
+  CairoOption,
+  CairoOptionVariant,
+  CairoResult,
+  CairoResultVariant,
+  type AbiEnum,
+  type AbiStruct,
+} from '../../../src';
+import { CairoStruct } from '../../../src/utils/cairoDataTypes/cairoStruct';
+import { CairoTypeCustomEnum } from '../../../src/utils/cairoDataTypes/cairoTypeCustomEnum';
+import { CairoTypeOption } from '../../../src/utils/cairoDataTypes/cairoTypeOption';
+import { CairoTypeResult } from '../../../src/utils/cairoDataTypes/cairoTypeResult';
+import {
+  cairoTypeStrategy,
+  enumStrategy,
+  structStrategy,
+} from '../../../src/utils/calldata/parser/cairoTypeStrategy';
+
+const POINT = {
+  type: 'struct',
+  name: 'test::Point',
+  members: [
+    { name: 'x', type: 'core::integer::u8' },
+    { name: 'y', type: 'core::integer::u8' },
+  ],
+} as AbiStruct;
+
+const INNER = {
+  type: 'enum',
+  name: 'test::Inner',
+  variants: [
+    { name: 'NoAnswer', type: '()' },
+    { name: 'Success', type: '(core::integer::u8, core::integer::u8)' },
+  ],
+} as AbiEnum;
+
+const MY_ENUM = {
+  type: 'enum',
+  name: 'test::MyEnum',
+  variants: [
+    { name: 'Empty', type: '()' },
+    { name: 'LocationError', type: 'test::Point' },
+    { name: 'Status', type: 'test::Inner' },
+    { name: 'Damage', type: 'core::option::Option::<core::integer::u8>' },
+    { name: 'Report', type: 'core::result::Result::<core::integer::u32, core::integer::u64>' },
+    { name: 'ErrorList', type: 'core::array::Array::<core::integer::u8>' },
+    { name: 'Coords', type: '[core::integer::u8; 3]' },
+  ],
+} as AbiEnum;
+
+const S = [cairoTypeStrategy, structStrategy([POINT]), enumStrategy([MY_ENUM, INNER])];
+
+/** A CairoCustomEnum names every variant, the inactive ones undefined. */
+const asEnum = (abi: AbiEnum, active: string, value: unknown) =>
+  new CairoCustomEnum(
+    Object.fromEntries(
+      abi.variants.map((variant) => [variant.name, variant.name === active ? value : undefined])
+    )
+  );
+
+describe('CairoTypeCustomEnum class Unit Tests', () => {
+  describe('the variant', () => {
+    test('should serialize the index then the value', () => {
+      const custom = new CairoTypeCustomEnum({ x: 4, y: 5 }, MY_ENUM, S, 1);
+      expect(custom.enumVariant).toBe(1);
+      expect(custom.dynamicSelector).toBe('test::MyEnum');
+      expect([...custom.toApiRequest()]).toEqual(['1', '4', '5']);
+    });
+
+    test('should refuse an index the abi does not declare', () => {
+      expect(() => new CairoTypeCustomEnum(1, MY_ENUM, S, 99)).toThrow(
+        'The custom enum test::MyEnum variant must be in the range 0..6. You requested variant #99'
+      );
+    });
+
+    test('should refuse an enum with nothing to carry', () => {
+      expect(() => new CairoTypeCustomEnum(undefined, MY_ENUM, S, 1)).toThrow(
+        '"content" parameter has to be defined.'
+      );
+      expect(() => new CairoTypeCustomEnum(null, MY_ENUM, S, 1)).toThrow(
+        '"content" parameter has to be defined.'
+      );
+    });
+
+    test('should refuse raw data with no index to go by', () => {
+      expect(() => new CairoTypeCustomEnum({ x: 4, y: 5 }, MY_ENUM, S)).toThrow(
+        '"variant" parameter is mandatory when creating a new Cairo custom enum from a Cairo Enum or raw data.'
+      );
+    });
+
+    test('should refuse an index alongside a response iterator', () => {
+      expect(() => new CairoTypeCustomEnum(['1'].values(), MY_ENUM, S, 1)).toThrow(
+        'when "content" parameter is an iterator, do not define "variant" parameter.'
+      );
+    });
+  });
+
+  describe('what the content may be', () => {
+    test('should take a CairoCustomEnum, which names its own variant', () => {
+      const custom = new CairoTypeCustomEnum(
+        new CairoCustomEnum({ LocationError: { x: 4, y: 5 } }),
+        MY_ENUM,
+        S
+      );
+      expect(custom.enumVariant).toBe(1);
+      expect([...custom.toApiRequest()]).toEqual(['1', '4', '5']);
+    });
+
+    test('should refuse a CairoCustomEnum whose variant the abi does not declare', () => {
+      expect(() => new CairoTypeCustomEnum(new CairoCustomEnum({ Nope: 1 }), MY_ENUM, S)).toThrow(
+        'Nope activeVariant is unknown in AbiEnum.'
+      );
+    });
+
+    test('should take a CairoType already built, with the index spelled out', () => {
+      const point = new CairoStruct({ x: 4, y: 5 }, POINT, S);
+      expect([...new CairoTypeCustomEnum(point, MY_ENUM, S, 1).toApiRequest()]).toEqual([
+        '1',
+        '4',
+        '5',
+      ]);
+      expect(() => new CairoTypeCustomEnum(point, MY_ENUM, S)).toThrow(
+        '"variant" parameter is mandatory when creating a new Cairo enum from a CairoType.'
+      );
+    });
+
+    test('should copy a CairoTypeCustomEnum, keeping what it carried', () => {
+      const original = new CairoTypeCustomEnum({ x: 4, y: 5 }, MY_ENUM, S, 1);
+      const copy = new CairoTypeCustomEnum(original, MY_ENUM, S);
+      expect(copy.enumVariant).toBe(1);
+      expect(copy.abiEnum).toEqual(MY_ENUM);
+      expect([...copy.toApiRequest()]).toEqual(['1', '4', '5']);
+    });
+
+    test('should refuse an index alongside a CairoTypeCustomEnum', () => {
+      const original = new CairoTypeCustomEnum({ x: 4, y: 5 }, MY_ENUM, S, 1);
+      expect(() => new CairoTypeCustomEnum(original, MY_ENUM, S, 1)).toThrow(
+        'when "content" parameter is a CairoTypeCustomEnum do not define "variant" parameter.'
+      );
+    });
+
+    test('should read the index and the value off a response', () => {
+      const custom = new CairoTypeCustomEnum(['1', '4', '5'].values(), MY_ENUM, S);
+      expect(custom.enumVariant).toBe(1);
+      expect([...custom.toApiRequest()]).toEqual(['1', '4', '5']);
+    });
+
+    test('should consume exactly its own felts, leaving the rest', () => {
+      const iterator = ['1', '4', '5', '9'].values();
+      // eslint-disable-next-line no-new
+      new CairoTypeCustomEnum(iterator, MY_ENUM, S);
+      expect(iterator.next().value).toBe('9');
+    });
+  });
+
+  describe('an option or a result as a variant', () => {
+    // these two are built here rather than through the strategy: the strategy is handed the enum's
+    // index, and an option or a result would read it as its own branch
+    test('should take a CairoOption for an option variant', () => {
+      const option = new CairoOption(CairoOptionVariant.Some, 5n);
+      const custom = new CairoTypeCustomEnum(option, MY_ENUM, S, 3);
+      expect([...custom.toApiRequest()]).toEqual(['3', '0', '5']);
+      expect(custom.decompose(S)).toEqual(asEnum(MY_ENUM, 'Damage', option));
+    });
+
+    test('should take a CairoTypeOption just as well', () => {
+      const option = new CairoTypeOption(
+        5,
+        'core::option::Option::<core::integer::u8>',
+        S,
+        CairoOptionVariant.Some
+      );
+      expect([...new CairoTypeCustomEnum(option, MY_ENUM, S, 3).toApiRequest()]).toEqual([
+        '3',
+        '0',
+        '5',
+      ]);
+    });
+
+    test('should require the index for a CairoOption', () => {
+      expect(
+        () => new CairoTypeCustomEnum(new CairoOption(CairoOptionVariant.Some, 5n), MY_ENUM, S)
+      ).toThrow(
+        '"variant" parameter is mandatory when creating a new Cairo custom enum from a CairoOption.'
+      );
+    });
+
+    test('should take a CairoResult for a result variant', () => {
+      const result = new CairoResult(CairoResultVariant.Ok, 5n);
+      const custom = new CairoTypeCustomEnum(result, MY_ENUM, S, 4);
+      expect([...custom.toApiRequest()]).toEqual(['4', '0', '5']);
+      expect(custom.decompose(S)).toEqual(asEnum(MY_ENUM, 'Report', result));
+    });
+
+    test('should take a CairoTypeResult just as well', () => {
+      const result = new CairoTypeResult(
+        5,
+        'core::result::Result::<core::integer::u32, core::integer::u64>',
+        S,
+        CairoResultVariant.Ok
+      );
+      expect([...new CairoTypeCustomEnum(result, MY_ENUM, S, 4).toApiRequest()]).toEqual([
+        '4',
+        '0',
+        '5',
+      ]);
+    });
+
+    test('should require the index for a CairoResult', () => {
+      expect(
+        () => new CairoTypeCustomEnum(new CairoResult(CairoResultVariant.Ok, 5n), MY_ENUM, S)
+      ).toThrow(
+        '"variant" parameter is mandatory when creating a new Cairo custom enum from a CairoResult.'
+      );
+    });
+  });
+
+  describe('enums of enums', () => {
+    test('should nest one enum inside another', () => {
+      const inner = new CairoCustomEnum({ Success: { 0: 10, 1: 20 } });
+      const outer = new CairoCustomEnum({ Status: inner });
+      const custom = new CairoTypeCustomEnum(outer, MY_ENUM, S);
+      // the outer index, the inner index, then the tuple
+      expect([...custom.toApiRequest()]).toEqual(['2', '1', '10', '20']);
+    });
+
+    test('should read a nested enum back', () => {
+      const custom = new CairoTypeCustomEnum(['2', '1', '10', '20'].values(), MY_ENUM, S);
+      expect([...custom.toApiRequest()]).toEqual(['2', '1', '10', '20']);
+      expect(custom.decompose(S)).toEqual(
+        asEnum(MY_ENUM, 'Status', asEnum(INNER, 'Success', { 0: 10n, 1: 20n }))
+      );
+    });
+  });
+
+  describe('other composites as variants', () => {
+    test('should carry a struct', () => {
+      const custom = new CairoTypeCustomEnum({ x: 4, y: 5 }, MY_ENUM, S, 1);
+      expect(custom.decompose(S)).toEqual(asEnum(MY_ENUM, 'LocationError', { x: 4n, y: 5n }));
+    });
+
+    test('should carry an array', () => {
+      const custom = new CairoTypeCustomEnum([7, 8], MY_ENUM, S, 5);
+      expect([...custom.toApiRequest()]).toEqual(['5', '2', '7', '8']);
+      expect(custom.decompose(S)).toEqual(asEnum(MY_ENUM, 'ErrorList', [7n, 8n]));
+    });
+
+    test('should read an array variant back off a response', () => {
+      const custom = new CairoTypeCustomEnum(['5', '2', '7', '8'].values(), MY_ENUM, S);
+      expect([...custom.toApiRequest()]).toEqual(['5', '2', '7', '8']);
+    });
+
+    test('should carry a fixed array, which adds no length of its own', () => {
+      const custom = new CairoTypeCustomEnum([1, 2, 3], MY_ENUM, S, 6);
+      expect([...custom.toApiRequest()]).toEqual(['6', '1', '2', '3']);
+      expect(custom.decompose(S)).toEqual(asEnum(MY_ENUM, 'Coords', [1n, 2n, 3n]));
+    });
+
+    test('should read a fixed array variant back off a response', () => {
+      const custom = new CairoTypeCustomEnum(['6', '1', '2', '3'].values(), MY_ENUM, S);
+      expect([...custom.toApiRequest()]).toEqual(['6', '1', '2', '3']);
+    });
+  });
+
+  describe('static methods', () => {
+    test('getVariantTypes', () => {
+      expect(CairoTypeCustomEnum.getVariantTypes(INNER)).toEqual([
+        '()',
+        '(core::integer::u8, core::integer::u8)',
+      ]);
+    });
+
+    test('extractEnumMembersNames', () => {
+      expect(CairoTypeCustomEnum.extractEnumMembersNames(INNER)).toEqual(['NoAnswer', 'Success']);
+    });
+
+    test('isAbiType says no more than that the name could be one', () => {
+      expect(CairoTypeCustomEnum.isAbiType('test::MyEnum')).toBe(true);
+      expect(CairoTypeCustomEnum.isAbiType('wrong')).toBe(false);
+    });
+
+    test('validate and is', () => {
+      expect(() => CairoTypeCustomEnum.validate(7, 'test::MyEnum', 1)).not.toThrow();
+      expect(() => CairoTypeCustomEnum.validate(7, 'wrong', 1)).toThrow(
+        'The type wrong is not a Cairo Enum. Needs impl::name.'
+      );
+      expect(CairoTypeCustomEnum.is(7, 'test::MyEnum', 1)).toBe(true);
+      expect(CairoTypeCustomEnum.is(7, 'wrong', 1)).toBe(false);
+    });
+  });
+
+  describe('enumStrategy', () => {
+    test('should key one entry per enum, by its abi name', () => {
+      const strategy = enumStrategy([MY_ENUM, INNER]);
+      expect(Object.keys(strategy.constructors)).toEqual(['test::MyEnum', 'test::Inner']);
+      expect(Object.keys(strategy.response)).toEqual(['test::MyEnum', 'test::Inner']);
+    });
+
+    test('should add no dynamic selector, which would shadow every other type', () => {
+      expect(enumStrategy([MY_ENUM]).dynamicSelectors).toEqual({});
+    });
+
+    test('should forward the variant, which a raw value cannot say', () => {
+      const strategy = enumStrategy([MY_ENUM]);
+      const built = strategy.constructors['test::MyEnum']({ x: 4, y: 5 }, S, 'test::MyEnum', 1);
+      expect([...built.toApiRequest()]).toEqual(['1', '4', '5']);
+    });
+  });
+
+  describe('CallData.compile integration', () => {
+    test('should serialize an instance as its index and value', () => {
+      expect(
+        CallData.compile([new CairoTypeCustomEnum({ x: 4, y: 5 }, MY_ENUM, S, 1)] as any)
+      ).toEqual(['1', '4', '5']);
+    });
+  });
+
+  describe('round-trip consistency', () => {
+    test('should survive a serialize then read back cycle', () => {
+      const cases: [number, any][] = [
+        [1, { x: 4, y: 5 }],
+        [3, new CairoOption(CairoOptionVariant.Some, 5n)],
+        [4, new CairoResult(CairoResultVariant.Ok, 5n)],
+        [5, [7, 8]],
+      ];
+      cases.forEach(([variant, value]) => {
+        const custom = new CairoTypeCustomEnum(value, MY_ENUM, S, variant);
+        const response = [...custom.toApiRequest()].map((felt) => `0x${BigInt(felt).toString(16)}`);
+        const readBack = new CairoTypeCustomEnum(response.values(), MY_ENUM, S);
+        expect([...readBack.toApiRequest()]).toEqual([...custom.toApiRequest()]);
+      });
+    });
+  });
+});

--- a/__tests__/utils/cairoDataTypes/CairoTypeFixedArray.test.ts
+++ b/__tests__/utils/cairoDataTypes/CairoTypeFixedArray.test.ts
@@ -1,0 +1,237 @@
+import { CallData } from '../../../src';
+import { CairoArray } from '../../../src/utils/cairoDataTypes/array';
+import { CairoTypeFixedArray } from '../../../src/utils/cairoDataTypes/cairoTypeFixedArray';
+import { CairoFixedArray } from '../../../src/utils/cairoDataTypes/fixedArray';
+import { CairoTuple } from '../../../src/utils/cairoDataTypes/tuple';
+import { CairoUint8 } from '../../../src/utils/cairoDataTypes/uint8';
+import { cairoTypeStrategy as S } from '../../../src/utils/calldata/parser/cairoTypeStrategy';
+
+const F3 = '[core::integer::u8; 3]';
+const F2 = '[core::integer::u8; 2]';
+const NESTED = '[[core::integer::u8; 2]; 2]';
+
+describe('CairoTypeFixedArray class Unit Tests', () => {
+  describe('the public CairoFixedArray is left alone', () => {
+    test('should still compile a list into the struct CallData expects', () => {
+      expect(new CairoFixedArray([10, 20, 30], F3).compile()).toEqual({ 0: 10, 1: 20, 2: 30 });
+    });
+
+    test('should still not serialize itself, which is what this class adds', () => {
+      expect('toApiRequest' in new CairoFixedArray([1, 2, 3], F3)).toBe(false);
+    });
+  });
+
+  describe('construction from the values a caller passes', () => {
+    test('should build from an array, with no length on the wire', () => {
+      expect([...new CairoTypeFixedArray([1, 2, 3], F3, S).toApiRequest()]).toEqual([
+        '1',
+        '2',
+        '3',
+      ]);
+    });
+
+    test('should build from the object CairoFixedArray.compile produces', () => {
+      const compiled = CairoFixedArray.compile([1, 2, 3]);
+      expect([...new CairoTypeFixedArray(compiled, F3, S).toApiRequest()]).toEqual(['1', '2', '3']);
+    });
+
+    test('should take an element that is already built', () => {
+      expect([...new CairoTypeFixedArray([new CairoUint8(1), 2], F2, S).toApiRequest()]).toEqual([
+        '1',
+        '2',
+      ]);
+    });
+
+    test('should copy a CairoTypeFixedArray handed to it whole', () => {
+      const copy = new CairoTypeFixedArray(new CairoTypeFixedArray([1, 2, 3], F3, S), F3, S);
+      expect([...copy.toApiRequest()]).toEqual(['1', '2', '3']);
+      expect(copy.arrayType).toBe(F3);
+    });
+
+    test('should refuse a count the type does not declare', () => {
+      expect(() => new CairoTypeFixedArray([1, 2], F3, S)).toThrow(
+        'ABI type [core::integer::u8; 3]: expected 3 items, got 2 items'
+      );
+      expect(() => new CairoTypeFixedArray([1, 2, 3, 4], F3, S)).toThrow(
+        'ABI type [core::integer::u8; 3]: expected 3 items, got 4 items'
+      );
+    });
+
+    test('should refuse an element type the strategy does not know', () => {
+      expect(() => new CairoTypeFixedArray([1], '[core::foo::Bar; 1]', S)).toThrow(
+        '"core::foo::Bar" is not a valid Cairo type'
+      );
+    });
+  });
+
+  describe('construction from a response', () => {
+    test('should read as many elements as the type declares', () => {
+      const array = new CairoTypeFixedArray(['0x1', '0x2', '0x3'].values(), F3, S);
+      expect(array.decompose(S)).toEqual([1n, 2n, 3n]);
+    });
+
+    test('should consume exactly that many, leaving the rest', () => {
+      const iterator = ['0x1', '0x2', '0x3', '0x9'].values();
+      // eslint-disable-next-line no-new
+      new CairoTypeFixedArray(iterator, F3, S);
+      expect(iterator.next().value).toBe('0x9');
+    });
+  });
+
+  describe('nesting', () => {
+    test('should hold fixed arrays, none of them carrying a length', () => {
+      const array = new CairoTypeFixedArray(
+        [
+          [1, 2],
+          [3, 4],
+        ],
+        NESTED,
+        S
+      );
+      expect([...array.toApiRequest()]).toEqual(['1', '2', '3', '4']);
+      expect(array.decompose(S)).toEqual([
+        [1n, 2n],
+        [3n, 4n],
+      ]);
+    });
+
+    test('should read a nested fixed array back off a flat response', () => {
+      const array = new CairoTypeFixedArray(['0x1', '0x2', '0x3', '0x4'].values(), NESTED, S);
+      expect(array.decompose(S)).toEqual([
+        [1n, 2n],
+        [3n, 4n],
+      ]);
+    });
+
+    test('should sit inside a dynamic array, which does carry its length', () => {
+      const array = new CairoArray([[1, 2, 3]], `core::array::Array::<${F3}>`, S);
+      expect([...array.toApiRequest()]).toEqual(['1', '1', '2', '3']);
+      expect(array.decompose(S)).toEqual([[1n, 2n, 3n]]);
+    });
+
+    test('should sit inside a tuple', () => {
+      const tuple = new CairoTuple([[1, 2], 9], `(${F2}, core::integer::u8)`, S);
+      expect([...tuple.toApiRequest()]).toEqual(['1', '2', '9']);
+    });
+  });
+
+  describe('reading a fixed array type', () => {
+    test('should give the element type and the size', () => {
+      expect(CairoTypeFixedArray.getFixedArrayType('[core::integer::u32; 8]')).toBe(
+        'core::integer::u32'
+      );
+      expect(CairoTypeFixedArray.getFixedArraySize('[core::integer::u32; 8]')).toBe(8);
+    });
+
+    test('should keep a nested inner array whole', () => {
+      expect(CairoTypeFixedArray.getFixedArrayType(NESTED)).toBe('[core::integer::u8; 2]');
+      expect(CairoTypeFixedArray.getFixedArraySize(NESTED)).toBe(2);
+    });
+
+    test('should read a type exactly as the public class does', () => {
+      // both delegate to the same reader, so a type cannot mean two things
+      [F3, F2, NESTED, '[core::integer::u32; 8]'].forEach((type) => {
+        expect(CairoTypeFixedArray.getFixedArrayType(type)).toBe(
+          CairoFixedArray.getFixedArrayType(type)
+        );
+        expect(CairoTypeFixedArray.getFixedArraySize(type)).toBe(
+          CairoFixedArray.getFixedArraySize(type)
+        );
+      });
+    });
+  });
+
+  describe('validate, is and isAbiType', () => {
+    test('should check the count, unlike a dynamic array', () => {
+      expect(() => CairoTypeFixedArray.validate([1, 2, 3], F3)).not.toThrow();
+      expect(() => CairoTypeFixedArray.validate([1, 2], F3)).toThrow(
+        'expected 3 items, got 2 items'
+      );
+    });
+
+    test('should refuse a type that is not a fixed array', () => {
+      expect(() => CairoTypeFixedArray.validate([1], 'core::integer::u8')).toThrow(
+        'The type core::integer::u8 is not a Cairo fixed array. Needs [type; length].'
+      );
+    });
+
+    test('should refuse an input that is neither an array nor an object', () => {
+      expect(() => CairoTypeFixedArray.validate('nope', F3)).toThrow(
+        'Invalid input: expected Array or Object, got string'
+      );
+    });
+
+    test('is should be the non-throwing form of validate', () => {
+      expect(CairoTypeFixedArray.is([1, 2, 3], F3)).toBe(true);
+      expect(CairoTypeFixedArray.is([1, 2], F3)).toBe(false);
+      expect(CairoTypeFixedArray.is('nope', F3)).toBe(false);
+    });
+
+    test('isAbiType should tell a fixed array from a dynamic one', () => {
+      expect(CairoTypeFixedArray.isAbiType('[core::integer::u32; 8]')).toBe(true);
+      expect(CairoTypeFixedArray.isAbiType(NESTED)).toBe(true);
+      expect(CairoTypeFixedArray.isAbiType('[core::integer::u32;8]')).toBe(false);
+      expect(CairoTypeFixedArray.isAbiType('core::array::Array::<core::integer::u8>')).toBe(false);
+      expect(CairoTypeFixedArray.isAbiType('core::integer::u32')).toBe(false);
+    });
+  });
+
+  describe('the dynamic selector', () => {
+    test('should name the class, on the class and on an instance', () => {
+      expect(CairoTypeFixedArray.dynamicSelector).toBe('CairoTypeFixedArray');
+      expect(new CairoTypeFixedArray([1, 2, 3], F3, S).dynamicSelector).toBe('CairoTypeFixedArray');
+    });
+
+    test('should be registered in the strategy, which is what makes nesting work', () => {
+      expect(S.dynamicSelectors.CairoTypeFixedArray(F3)).toBe(true);
+      expect(S.dynamicSelectors.CairoTypeFixedArray('core::integer::u8')).toBe(false);
+      expect(typeof S.constructors.CairoTypeFixedArray).toBe('function');
+      expect(typeof S.response.CairoTypeFixedArray).toBe('function');
+    });
+  });
+
+  describe('toApiRequest method', () => {
+    test('should carry no length, the type having it', () => {
+      expect([...new CairoTypeFixedArray([1, 2, 3], F3, S).toApiRequest()]).toHaveLength(3);
+    });
+
+    test('should flag the result as compiled', () => {
+      expect(new CairoTypeFixedArray([1, 2, 3], F3, S).toApiRequest()).toHaveProperty(
+        '__compiled__',
+        true
+      );
+    });
+  });
+
+  describe('CallData.compile integration', () => {
+    test('should serialize an instance as its elements', () => {
+      expect(CallData.compile([new CairoTypeFixedArray([1, 2, 3], F3, S)] as any)).toEqual([
+        '1',
+        '2',
+        '3',
+      ]);
+    });
+  });
+
+  describe('round-trip consistency', () => {
+    test('should survive a serialize then read back cycle', () => {
+      const cases: [string, any[]][] = [
+        [F3, [1, 2, 3]],
+        [F2, [7, 8]],
+        [
+          NESTED,
+          [
+            [1, 2],
+            [3, 4],
+          ],
+        ],
+      ];
+      cases.forEach(([type, values]) => {
+        const array = new CairoTypeFixedArray(values, type, S);
+        const response = [...array.toApiRequest()].map((felt) => `0x${BigInt(felt).toString(16)}`);
+        const readBack = new CairoTypeFixedArray(response.values(), type, S);
+        expect(readBack.decompose(S)).toEqual(array.decompose(S));
+      });
+    });
+  });
+});

--- a/__tests__/utils/cairoDataTypes/CairoTypeOption.test.ts
+++ b/__tests__/utils/cairoDataTypes/CairoTypeOption.test.ts
@@ -1,0 +1,398 @@
+import {
+  CallData,
+  CairoOption,
+  CairoOptionVariant,
+  CairoCustomEnum,
+  CairoResult,
+  CairoResultVariant,
+  type AbiEnum,
+  type AbiStruct,
+} from '../../../src';
+import { CairoArray } from '../../../src/utils/cairoDataTypes/array';
+import { CairoStruct } from '../../../src/utils/cairoDataTypes/cairoStruct';
+import { CairoTypeOption } from '../../../src/utils/cairoDataTypes/cairoTypeOption';
+import { CairoTuple } from '../../../src/utils/cairoDataTypes/tuple';
+import { CairoUint8 } from '../../../src/utils/cairoDataTypes/uint8';
+import {
+  cairoTypeStrategy,
+  enumStrategy,
+  structStrategy,
+} from '../../../src/utils/calldata/parser/cairoTypeStrategy';
+
+const { Some, None } = CairoOptionVariant;
+
+const POINT = {
+  type: 'struct',
+  name: 'test::Point',
+  members: [
+    { name: 'x', type: 'core::integer::u8' },
+    { name: 'y', type: 'core::integer::u32' },
+  ],
+} as AbiStruct;
+
+const MY_ENUM = {
+  type: 'enum',
+  name: 'test::MyEnum',
+  variants: [
+    { name: 'Empty', type: '()' },
+    { name: 'Number', type: 'core::integer::u8' },
+  ],
+} as AbiEnum;
+
+const S = [cairoTypeStrategy, structStrategy([POINT]), enumStrategy([MY_ENUM])];
+
+const U8 = 'core::option::Option::<core::integer::u8>';
+const U16 = 'core::option::Option::<core::integer::u16>';
+const OF_ARRAY = 'core::option::Option::<core::array::Array::<core::integer::u8>>';
+const OF_TUPLE =
+  'core::option::Option::<(core::integer::u8, core::array::Array::<core::integer::u8>)>';
+const OF_STRUCT = 'core::option::Option::<test::Point>';
+
+/** `Option<Option<...<u8>>>`, nested `depth` times. */
+const optionType = (depth: number): string =>
+  depth === 0 ? 'core::integer::u8' : `core::option::Option::<${optionType(depth - 1)}>`;
+
+/** `Some(Some(...Some(value)))`, nested `depth` times. */
+const someChain = (depth: number, value: any): CairoOption<any> =>
+  depth === 0 ? value : new CairoOption(Some, someChain(depth - 1, value));
+
+/** Peel a decomposed option down to what it finally carries. */
+const peel = (option: any): any => {
+  if (!(option instanceof CairoOption)) {
+    return option;
+  }
+  return option.isNone() ? 'None' : peel(option.unwrap());
+};
+
+describe('CairoTypeOption class Unit Tests', () => {
+  describe('the variant', () => {
+    test('should serialize Some as its branch then the value', () => {
+      const option = new CairoTypeOption(7, U8, S, Some);
+      expect(option.isVariantSome).toBe(true);
+      expect([...option.toApiRequest()]).toEqual(['0', '7']);
+    });
+
+    test('should serialize None as one felt, and nothing else', () => {
+      const option = new CairoTypeOption(undefined, U8, S, None);
+      expect(option.isVariantSome).toBe(false);
+      expect(option.content).toBeUndefined();
+      expect([...option.toApiRequest()]).toEqual(['1']);
+    });
+
+    test('should refuse a variant that is neither branch', () => {
+      expect(() => new CairoTypeOption(undefined, U8, S, 3)).toThrow(
+        'In Cairo option, only 0 or 1 variants are authorized.'
+      );
+    });
+
+    test('should refuse a Some with nothing to carry', () => {
+      expect(() => new CairoTypeOption(undefined, U8, S, Some)).toThrow(
+        '"content" parameter has to be defined when Some variant is selected'
+      );
+    });
+
+    test('should refuse a None that carries something', () => {
+      expect(() => new CairoTypeOption(7, U8, S, None)).toThrow(
+        '"content" parameter has to be NOT defined when None variant is selected'
+      );
+    });
+
+    test('should refuse a variant alongside a response iterator', () => {
+      expect(() => new CairoTypeOption(['0x0'].values(), U8, S, Some)).toThrow(
+        'when "content" parameter is an iterator, do not define "variant" parameter.'
+      );
+    });
+
+    test('should refuse raw data with no variant to go by', () => {
+      // nothing distinguishes Some(0) from None, so the caller has to say
+      expect(() => new CairoTypeOption(7, U8, S)).toThrow(
+        '"variant" parameter is mandatory when creating a new Cairo option from a "CairoType" or raw data.'
+      );
+    });
+  });
+
+  describe('what the content may be', () => {
+    test('should take a CairoOption, which says its own branch', () => {
+      expect([...new CairoTypeOption(new CairoOption(Some, 7), U8, S).toApiRequest()]).toEqual([
+        '0',
+        '7',
+      ]);
+      expect([...new CairoTypeOption(new CairoOption(None), U8, S).toApiRequest()]).toEqual(['1']);
+    });
+
+    test('should take a CairoType already built, with the branch spelled out', () => {
+      const inner = new CairoTypeOption('0x0a', U8, S, Some);
+      const outer = new CairoTypeOption(inner, U8, S, Some);
+      expect(outer.isVariantSome).toBe(true);
+      // a CairoTypeOption handed in is copied, not wrapped: what it carried is what is kept
+      expect(outer.content).toEqual(new CairoUint8(10));
+      expect(outer.optionCairoType).toBe(U8);
+      expect([...outer.toApiRequest()]).toEqual(['0', '10']);
+    });
+
+    test('should require the variant for a CairoType already built', () => {
+      // a built value says nothing about its branch, so leaving the variant out would quietly
+      // make it a None and drop what it carries. CairoTypeResult and CairoTypeCustomEnum guard
+      // this the same way.
+      expect(() => new CairoTypeOption(new CairoUint8(7), U8, S)).toThrow(
+        '"variant" parameter is mandatory when creating a new Cairo option from a CairoType.'
+      );
+      expect([...new CairoTypeOption(new CairoUint8(7), U8, S, Some).toApiRequest()]).toEqual([
+        '0',
+        '7',
+      ]);
+    });
+
+    test('should read the branch and the value off a response', () => {
+      expect([...new CairoTypeOption(['0x0', '0x64'].values(), U8, S).toApiRequest()]).toEqual([
+        '0',
+        '100',
+      ]);
+      expect([...new CairoTypeOption(['0x1'].values(), U8, S).toApiRequest()]).toEqual(['1']);
+    });
+
+    test('should refuse a branch a response cannot hold', () => {
+      expect(() => new CairoTypeOption(['0x5'].values(), U8, S)).toThrow(
+        'Invalid Option variant in iterator.'
+      );
+    });
+
+    test('should consume exactly its own felts, leaving the rest', () => {
+      const iterator = ['0x0', '0x7', '0x9'].values();
+      // eslint-disable-next-line no-new
+      new CairoTypeOption(iterator, U8, S);
+      expect(iterator.next().value).toBe('0x9');
+    });
+  });
+
+  describe('what the option may carry', () => {
+    test('should carry an array', () => {
+      const option = new CairoTypeOption([1, 2, 3], OF_ARRAY, S, Some);
+      expect([...option.toApiRequest()]).toEqual(['0', '3', '1', '2', '3']);
+      expect(option.decompose(S).unwrap()).toEqual([1n, 2n, 3n]);
+    });
+
+    test('should carry an array already built', () => {
+      const array = new CairoArray([7, 8], 'core::array::Array::<core::integer::u8>', S);
+      const option = new CairoTypeOption(array, OF_ARRAY, S, Some);
+      expect([...option.toApiRequest()]).toEqual(['0', '2', '7', '8']);
+      expect(option.decompose(S)).toEqual(new CairoOption(Some, [7n, 8n]));
+    });
+
+    test('should carry a tuple', () => {
+      const tuple = new CairoTuple(
+        [234, [1, 2, 3]],
+        '(core::integer::u8, core::array::Array::<core::integer::u8>)',
+        S
+      );
+      const option = new CairoTypeOption(tuple, OF_TUPLE, S, Some);
+      expect([...option.toApiRequest()]).toEqual(['0', '234', '3', '1', '2', '3']);
+    });
+
+    test('should carry a struct', () => {
+      const option = new CairoTypeOption({ x: 1, y: 2 }, OF_STRUCT, S, Some);
+      expect([...option.toApiRequest()]).toEqual(['0', '1', '2']);
+      expect(option.decompose(S).unwrap()).toEqual({ x: 1n, y: 2n });
+    });
+
+    test('should carry a struct already built', () => {
+      const option = new CairoTypeOption(
+        new CairoStruct({ x: 1, y: 2 }, POINT, S),
+        OF_STRUCT,
+        S,
+        Some
+      );
+      expect([...option.toApiRequest()]).toEqual(['0', '1', '2']);
+    });
+
+    test('should carry a fixed array', () => {
+      const type = 'core::option::Option::<[core::integer::u8; 3]>';
+      const option = new CairoTypeOption([1, 2, 3], type, S, Some);
+      // the fixed array adds no length of its own, so only the branch precedes the elements
+      expect([...option.toApiRequest()]).toEqual(['0', '1', '2', '3']);
+      expect(option.decompose(S).unwrap()).toEqual([1n, 2n, 3n]);
+    });
+
+    test('should carry a result', () => {
+      const type =
+        'core::option::Option::<core::result::Result::<core::integer::u8, core::integer::u16>>';
+      const option = new CairoTypeOption(new CairoResult(CairoResultVariant.Ok, 7), type, S, Some);
+      expect([...option.toApiRequest()]).toEqual(['0', '0', '7']);
+    });
+
+    test('should carry a custom enum', () => {
+      const type = 'core::option::Option::<test::MyEnum>';
+      const option = new CairoTypeOption(new CairoCustomEnum({ Number: 7 }), type, S, Some);
+      expect([...option.toApiRequest()]).toEqual(['0', '1', '7']);
+    });
+  });
+
+  describe('options of options', () => {
+    test('should nest three deep, which is the shape that used to fail', () => {
+      const option2 = someChain(3, 5n);
+      const option = new CairoTypeOption(option2, optionType(3), S, Some);
+      expect([...option.toApiRequest()]).toEqual(['0', '0', '0', '5']);
+      expect(option.decompose(S)).toEqual(option2);
+    });
+
+    test('should nest as deep as the type goes, in both directions', () => {
+      [1, 2, 3, 4, 5].forEach((depth) => {
+        const type = optionType(depth);
+        const value = someChain(depth, 8);
+        const felts = [...new CairoTypeOption(value, type, S).toApiRequest()];
+        expect(felts).toEqual([...Array(depth).fill('0'), '8']);
+
+        const response = felts.map((felt) => `0x${BigInt(felt).toString(16)}`);
+        expect(peel(new CairoTypeOption(response.values(), type, S).decompose(S))).toBe(8n);
+      });
+    });
+
+    test('should carry a None at the innermost level', () => {
+      const value = new CairoOption(Some, new CairoOption(Some, new CairoOption(None)));
+      expect([...new CairoTypeOption(value, optionType(3), S).toApiRequest()]).toEqual([
+        '0',
+        '0',
+        '1',
+      ]);
+    });
+
+    test('should carry a None at an intermediate level', () => {
+      const value = new CairoOption(Some, new CairoOption(None));
+      expect([...new CairoTypeOption(value, optionType(3), S).toApiRequest()]).toEqual(['0', '1']);
+    });
+
+    test('should be a None at the outermost level', () => {
+      expect([
+        ...new CairoTypeOption(new CairoOption(None), optionType(3), S).toApiRequest(),
+      ]).toEqual(['1']);
+    });
+  });
+
+  describe('options mixed with the other composites', () => {
+    test('should sit in an array', () => {
+      const type = 'core::array::Array::<core::option::Option::<core::integer::u8>>';
+      const array = new CairoArray([new CairoOption(Some, 7), new CairoOption(None)], type, S);
+      expect([...array.toApiRequest()]).toEqual(['2', '0', '7', '1']);
+      expect(array.decompose(S).map(peel)).toEqual([7n, 'None']);
+    });
+
+    test('should hold an array that holds options', () => {
+      const type =
+        'core::option::Option::<core::array::Array::<core::option::Option::<core::integer::u8>>>';
+      const value = new CairoOption(Some, [new CairoOption(Some, 7), new CairoOption(None)]);
+      const option = new CairoTypeOption(value, type, S);
+      expect([...option.toApiRequest()]).toEqual(['0', '2', '0', '7', '1']);
+      expect(option.decompose(S).unwrap().map(peel)).toEqual([7n, 'None']);
+    });
+
+    test('should sit in a tuple that sits in nothing else', () => {
+      const type =
+        '(core::option::Option::<(core::integer::u8, core::integer::u8)>, core::integer::u8)';
+      const tuple = new CairoTuple([new CairoOption(Some, [1, 2]), 9], type, S);
+      expect([...tuple.toApiRequest()]).toEqual(['0', '1', '2', '9']);
+    });
+
+    test('should refuse raw elements in an array of options', () => {
+      // a bare 7 says nothing about the branch, so the caller passes CairoOption instances
+      const type = 'core::array::Array::<core::option::Option::<core::integer::u8>>';
+      expect(() => new CairoArray([7, 8], type, S)).toThrow('"variant" parameter is mandatory');
+    });
+  });
+
+  describe('static methods', () => {
+    test('is', () => {
+      expect(CairoTypeOption.is(200, U16, Some)).toBe(true);
+      expect(CairoTypeOption.is(200, 'core::error::<core::integer::u16>', Some)).toBe(false);
+    });
+
+    test('isAbiType', () => {
+      expect(CairoTypeOption.isAbiType(U16)).toBe(true);
+      expect(CairoTypeOption.isAbiType('core::wrong::<core::integer::u16>')).toBe(false);
+    });
+
+    test('validate', () => {
+      expect(() => CairoTypeOption.validate(200, U16, Some)).not.toThrow();
+      expect(() =>
+        CairoTypeOption.validate(200, 'core::wrong::<core::integer::u16>', Some)
+      ).toThrow(
+        'The type core::wrong::<core::integer::u16> is not a Cairo option. Needs core::option::Option::<type>.'
+      );
+      expect(() => CairoTypeOption.validate(200, U16, 5)).toThrow(
+        'In Cairo option, only 0 or 1 variants are authorized.'
+      );
+    });
+
+    test('getVariantSomeType', () => {
+      expect(CairoTypeOption.getVariantSomeType(U16)).toBe('core::integer::u16');
+      expect(() =>
+        CairoTypeOption.getVariantSomeType('core::option::Option::core::integer::u16>')
+      ).toThrow(
+        'ABI type core::option::Option::core::integer::u16> do not includes a valid type of data.'
+      );
+    });
+  });
+
+  describe('the dynamic selector', () => {
+    test('should name the class, on the class and on an instance', () => {
+      expect(CairoTypeOption.dynamicSelector).toBe('CairoTypeOption');
+      expect(new CairoTypeOption(7, U8, S, Some).dynamicSelector).toBe('CairoTypeOption');
+    });
+
+    test('should be registered in the strategy, and forward the variant', () => {
+      expect(cairoTypeStrategy.dynamicSelectors.CairoTypeOption(U8)).toBe(true);
+      // the only entry that reads the fourth argument
+      const built = cairoTypeStrategy.constructors.CairoTypeOption(7, S, U8, Some);
+      expect([...built.toApiRequest()]).toEqual(['0', '7']);
+    });
+  });
+
+  describe('copy constructor behavior', () => {
+    test('should keep what the original carried, its own type included', () => {
+      const original = new CairoTypeOption(10, U8, S, Some);
+      const copy = new CairoTypeOption(original, U16, S);
+      expect(copy.content).toBe(original.content);
+      expect(copy.isVariantSome).toBe(original.isVariantSome);
+      // the type given to the copy is ignored: the original's is what survives
+      expect(copy.optionCairoType).toBe(U8);
+    });
+  });
+
+  describe('CallData.compile integration', () => {
+    test('should serialize an instance, in the array form and the object form', () => {
+      const some = () => new CairoTypeOption(7, U8, S, Some);
+      const none = () => new CairoTypeOption(undefined, U8, S, None);
+      expect(CallData.compile([some()] as any)).toEqual(['0', '7']);
+      expect(CallData.compile([none()] as any)).toEqual(['1']);
+      expect(CallData.compile({ input: some() } as any)).toEqual(['0', '7']);
+      expect(CallData.compile({ input: none() } as any)).toEqual(['1']);
+    });
+  });
+
+  describe('calls the contract does not cover', () => {
+    // outside what the API ever emits, and asserted here so that a change of behaviour shows up
+    // rather than passing unnoticed
+    test('a CairoOption wrapping a built option is flattened by the copy', () => {
+      const inner = new CairoTypeOption(10, U8, S, Some);
+      const option = new CairoTypeOption(new CairoOption(Some, inner), U8, S);
+      expect([...option.toApiRequest()]).toEqual(['0', '10']);
+    });
+  });
+
+  describe('round-trip consistency', () => {
+    test('should survive a serialize then read back cycle', () => {
+      const cases: [string, any][] = [
+        [U8, new CairoOption(Some, 7)],
+        [U8, new CairoOption(None)],
+        [OF_ARRAY, new CairoOption(Some, [1, 2, 3])],
+        [OF_STRUCT, new CairoOption(Some, { x: 1, y: 2 })],
+        [optionType(3), someChain(3, 5)],
+      ];
+      cases.forEach(([type, value]) => {
+        const option = new CairoTypeOption(value, type, S);
+        const response = [...option.toApiRequest()].map((felt) => `0x${BigInt(felt).toString(16)}`);
+        const readBack = new CairoTypeOption(response.values(), type, S);
+        expect([...readBack.toApiRequest()]).toEqual([...option.toApiRequest()]);
+      });
+    });
+  });
+});

--- a/__tests__/utils/cairoDataTypes/CairoTypeResult.test.ts
+++ b/__tests__/utils/cairoDataTypes/CairoTypeResult.test.ts
@@ -1,0 +1,361 @@
+import {
+  CallData,
+  CairoResult,
+  CairoResultVariant,
+  CairoOption,
+  CairoOptionVariant,
+  CairoCustomEnum,
+  type AbiEnum,
+  type AbiStruct,
+} from '../../../src';
+import { CairoArray } from '../../../src/utils/cairoDataTypes/array';
+import { CairoTypeOption } from '../../../src/utils/cairoDataTypes/cairoTypeOption';
+import { CairoTypeResult } from '../../../src/utils/cairoDataTypes/cairoTypeResult';
+import { CairoTuple } from '../../../src/utils/cairoDataTypes/tuple';
+import { CairoUint8 } from '../../../src/utils/cairoDataTypes/uint8';
+import { CairoUint16 } from '../../../src/utils/cairoDataTypes/uint16';
+import {
+  cairoTypeStrategy,
+  enumStrategy,
+  structStrategy,
+} from '../../../src/utils/calldata/parser/cairoTypeStrategy';
+import type { CairoTypeStrategy } from '../../../src/utils/calldata/parser/cairoTypeStrategy.type';
+
+const { Ok, Err } = CairoResultVariant;
+
+const MY_ENUM = {
+  type: 'enum',
+  name: 'test::MyEnum',
+  variants: [
+    { name: 'Empty', type: '()' },
+    { name: 'Number', type: 'core::integer::u8' },
+  ],
+} as AbiEnum;
+
+const POINT = {
+  type: 'struct',
+  name: 'test::Point',
+  members: [
+    { name: 'x', type: 'core::integer::u8' },
+    { name: 'y', type: 'core::integer::u32' },
+  ],
+} as AbiStruct;
+
+const S = [cairoTypeStrategy, structStrategy([POINT]), enumStrategy([MY_ENUM])];
+
+const T = 'core::result::Result::<core::integer::u8, core::integer::u16>';
+const OF_ARRAY =
+  'core::result::Result::<core::array::Array::<core::integer::u8>, core::integer::u16>';
+const OF_TUPLE =
+  'core::result::Result::<(core::integer::u8, core::integer::u8), core::integer::u16>';
+const OF_OPTION =
+  'core::result::Result::<core::option::Option::<core::integer::u8>, core::integer::u16>';
+const OF_STRUCT = 'core::result::Result::<test::Point, core::integer::u16>';
+const T3 =
+  'core::result::Result::<core::integer::u16, core::result::Result::<core::result::Result::<core::integer::u16, core::integer::u8>, core::integer::u16>>';
+
+describe('CairoTypeResult class Unit Tests', () => {
+  describe('the variant', () => {
+    test('should build the Ok branch from the first type', () => {
+      const result = new CairoTypeResult(8, T, S, Ok);
+      expect(result.isVariantOk).toBe(true);
+      expect(result.content).toEqual(new CairoUint8(8));
+      expect(result.resultCairoType).toBe(T);
+      expect([...result.toApiRequest()]).toEqual(['0', '8']);
+    });
+
+    test('should build the Err branch from the second type', () => {
+      const result = new CairoTypeResult(8, T, S, Err);
+      expect(result.isVariantOk).toBe(false);
+      // the same value, read as the other branch's type
+      expect(result.content).toEqual(new CairoUint16(8));
+      expect([...result.toApiRequest()]).toEqual(['1', '8']);
+    });
+
+    test('should refuse a variant that is neither branch', () => {
+      expect(() => new CairoTypeResult(8, T, S, 3)).toThrow(
+        'In Cairo Result, only 0 or 1 variants are authorized.'
+      );
+    });
+
+    test('should refuse a result with nothing to carry', () => {
+      // unlike an option, both branches of a result carry a value
+      expect(() => new CairoTypeResult(undefined, T, S, Ok)).toThrow(
+        '"content" parameter has to be defined.'
+      );
+      expect(() => new CairoTypeResult(null, T, S, Ok)).toThrow(
+        '"content" parameter has to be defined.'
+      );
+    });
+
+    test('should refuse raw data with no variant to go by', () => {
+      expect(() => new CairoTypeResult(8, T, S)).toThrow(
+        '"variant" parameter is mandatory when creating a new Cairo Result from a Cairo Enum or raw data.'
+      );
+    });
+
+    test('should accept several strategies, and search them in order', () => {
+      const empty: CairoTypeStrategy = { constructors: {}, dynamicSelectors: {}, response: {} };
+      expect(() => new CairoTypeResult(8, T, [cairoTypeStrategy, empty], Ok)).not.toThrow();
+      expect(() => new CairoTypeResult(8, T, [empty, cairoTypeStrategy], Ok)).not.toThrow();
+    });
+
+    test('should refuse a variant alongside a response iterator', () => {
+      expect(() => new CairoTypeResult(['0', '100'].values(), T, S, Ok)).toThrow(
+        'when "content" parameter is an iterator, do not define "variant" parameter.'
+      );
+    });
+  });
+
+  describe('what the content may be', () => {
+    test('should take a CairoResult, which says its own branch', () => {
+      const result = new CairoTypeResult(new CairoResult(Ok, 8n), T, S);
+      expect(result.isVariantOk).toBe(true);
+      expect(result.content).toEqual(new CairoUint8(8));
+      expect(result.resultCairoType).toBe(T);
+    });
+
+    test('should refuse a variant alongside a CairoResult', () => {
+      expect(() => new CairoTypeResult(new CairoResult(Ok, 8n), T, S, Ok)).toThrow(
+        'when "content" parameter is a CairoResult and subType is false, do not define "variant" parameter.'
+      );
+    });
+
+    test('should copy a CairoTypeResult, keeping what it carried', () => {
+      const original = new CairoTypeResult('0x0a', T, S, Err);
+      const copy = new CairoTypeResult(original, T, S);
+      expect(copy.isVariantOk).toBe(false);
+      expect(copy.content).toEqual(new CairoUint16(10));
+      expect(copy.resultCairoType).toBe(T);
+    });
+
+    test('should refuse a variant alongside a CairoTypeResult', () => {
+      const original = new CairoTypeResult('0x0a', T, S, Err);
+      expect(() => new CairoTypeResult(original, T, S, Err)).toThrow(
+        'when "content" parameter is a CairoTypeResult, do not define "variant" parameter.'
+      );
+    });
+
+    test('should require the variant for a CairoType already built', () => {
+      // the guard CairoTypeOption does not have: a built value says nothing about its branch
+      expect(() => new CairoTypeResult(new CairoUint8(8), T, S)).toThrow(
+        '"variant" parameter is mandatory when creating a new Cairo Result from a CairoType.'
+      );
+      expect([...new CairoTypeResult(new CairoUint8(8), T, S, Ok).toApiRequest()]).toEqual([
+        '0',
+        '8',
+      ]);
+    });
+
+    test('should read the branch and the value off a response', () => {
+      const result = new CairoTypeResult(['0', '100'].values(), T, S);
+      expect(result.isVariantOk).toBe(true);
+      expect(result.content).toEqual(new CairoUint8(100));
+    });
+
+    test('should consume exactly its own felts, leaving the rest', () => {
+      const iterator = ['0x0', '0x7', '0x9'].values();
+      // eslint-disable-next-line no-new
+      new CairoTypeResult(iterator, T, S);
+      expect(iterator.next().value).toBe('0x9');
+    });
+  });
+
+  describe('what the result may carry', () => {
+    test('should carry an array on the Ok branch', () => {
+      const result = new CairoTypeResult([1, 2, 3], OF_ARRAY, S, Ok);
+      expect([...result.toApiRequest()]).toEqual(['0', '3', '1', '2', '3']);
+      expect(result.decompose(S)).toEqual(new CairoResult(Ok, [1n, 2n, 3n]));
+    });
+
+    test('should carry the other type on the Err branch', () => {
+      const result = new CairoTypeResult(9, OF_ARRAY, S, Err);
+      expect([...result.toApiRequest()]).toEqual(['1', '9']);
+      expect(result.decompose(S)).toEqual(new CairoResult(Err, 9n));
+    });
+
+    test('should carry a tuple', () => {
+      const tuple = new CairoTuple([1, 2], '(core::integer::u8, core::integer::u8)', S);
+      expect([...new CairoTypeResult(tuple, OF_TUPLE, S, Ok).toApiRequest()]).toEqual([
+        '0',
+        '1',
+        '2',
+      ]);
+    });
+
+    test('should carry an option', () => {
+      const option = new CairoTypeOption(
+        7,
+        'core::option::Option::<core::integer::u8>',
+        S,
+        CairoOptionVariant.Some
+      );
+      expect([...new CairoTypeResult(option, OF_OPTION, S, Ok).toApiRequest()]).toEqual([
+        '0',
+        '0',
+        '7',
+      ]);
+    });
+
+    test('should carry a struct', () => {
+      const result = new CairoTypeResult({ x: 1, y: 2 }, OF_STRUCT, S, Ok);
+      expect([...result.toApiRequest()]).toEqual(['0', '1', '2']);
+      expect(result.decompose(S)).toEqual(new CairoResult(Ok, { x: 1n, y: 2n }));
+    });
+
+    test('should carry a fixed array, on either branch', () => {
+      const type = 'core::result::Result::<core::integer::u8, [core::integer::u16; 2]>';
+      expect([...new CairoTypeResult([100, 2], type, S, Err).toApiRequest()]).toEqual([
+        '1',
+        '100',
+        '2',
+      ]);
+      // the same felts read back, which is the case PR #1484 asserted
+      expect([...new CairoTypeResult(['1', '100', '2'].values(), type, S).toApiRequest()]).toEqual([
+        '1',
+        '100',
+        '2',
+      ]);
+    });
+
+    test('should carry a custom enum', () => {
+      const type = 'core::result::Result::<test::MyEnum, core::integer::u16>';
+      const result = new CairoTypeResult(new CairoCustomEnum({ Number: 7 }), type, S, Ok);
+      expect([...result.toApiRequest()]).toEqual(['0', '1', '7']);
+    });
+  });
+
+  describe('results of results', () => {
+    test('should nest three deep, with the branches mixed', () => {
+      const result0 = new CairoResult(Err, 5n);
+      const result1 = new CairoResult(Ok, result0);
+      const result2 = new CairoResult(Err, result1);
+      const result = new CairoTypeResult(result2, T3, S);
+      expect([...result.toApiRequest()]).toEqual(['1', '0', '1', '5']);
+      expect(result.decompose(S)).toEqual(result2);
+    });
+
+    test('should read the same three levels back off a response', () => {
+      const result = new CairoTypeResult(['0x1', '0x0', '0x1', '0x5'].values(), T3, S);
+      expect([...result.toApiRequest()]).toEqual(['1', '0', '1', '5']);
+    });
+  });
+
+  describe('results mixed with the other composites', () => {
+    test('should sit in an array', () => {
+      const type = `core::array::Array::<${T}>`;
+      const array = new CairoArray([new CairoResult(Ok, 7), new CairoResult(Err, 9)], type, S);
+      expect([...array.toApiRequest()]).toEqual(['2', '0', '7', '1', '9']);
+      expect(array.decompose(S)).toEqual([new CairoResult(Ok, 7n), new CairoResult(Err, 9n)]);
+    });
+
+    test('should sit in a tuple', () => {
+      const type = `(${T}, core::integer::u8)`;
+      const tuple = new CairoTuple([new CairoResult(Ok, 7), 9], type, S);
+      expect([...tuple.toApiRequest()]).toEqual(['0', '7', '9']);
+    });
+
+    test('should hold an option that holds a value', () => {
+      const value = new CairoResult(Ok, new CairoOption(CairoOptionVariant.Some, 7));
+      expect([...new CairoTypeResult(value, OF_OPTION, S).toApiRequest()]).toEqual(['0', '0', '7']);
+    });
+  });
+
+  describe('static methods', () => {
+    test('is', () => {
+      expect(CairoTypeResult.is(200, T, Ok)).toBe(true);
+      expect(CairoTypeResult.is(200, 'wrong', 3)).toBe(false);
+    });
+
+    test('isAbiType', () => {
+      expect(CairoTypeResult.isAbiType(T)).toBe(true);
+      expect(CairoTypeResult.isAbiType('core::integer::u16')).toBe(false);
+    });
+
+    test('validate', () => {
+      expect(() => CairoTypeResult.validate(200, T, Err)).not.toThrow();
+      expect(() => CairoTypeResult.validate(200, 'core::wrong::<core::integer::u16>', Ok)).toThrow(
+        'The type core::wrong::<core::integer::u16> is not a Cairo Result. Needs core::result::Result::<type1, type2>.'
+      );
+      expect(() => CairoTypeResult.validate(200, T, 5)).toThrow(
+        'In Cairo Result, only 0 or 1 variants are authorized.'
+      );
+    });
+
+    test('getVariantTypes', () => {
+      expect(CairoTypeResult.getVariantTypes(T)).toEqual([
+        'core::integer::u8',
+        'core::integer::u16',
+      ]);
+      expect(() =>
+        CairoTypeResult.getVariantTypes('core::result::Result::core::integer::u16>')
+      ).toThrow(
+        'ABI type core::result::Result::core::integer::u16> do not includes 2 types enclosed in <>.'
+      );
+    });
+
+    test('getVariantTypes should keep a composite branch whole', () => {
+      expect(CairoTypeResult.getVariantTypes(OF_TUPLE)).toEqual([
+        '(core::integer::u8, core::integer::u8)',
+        'core::integer::u16',
+      ]);
+    });
+  });
+
+  describe('the dynamic selector', () => {
+    test('should name the class, on the class and on an instance', () => {
+      expect(CairoTypeResult.dynamicSelector).toBe('CairoTypeResult');
+      expect(new CairoTypeResult(8, T, S, Ok).dynamicSelector).toBe('CairoTypeResult');
+    });
+
+    test('should be registered in the strategy, and forward the variant', () => {
+      expect(cairoTypeStrategy.dynamicSelectors.CairoTypeResult(T)).toBe(true);
+      const built = cairoTypeStrategy.constructors.CairoTypeResult(8, S, T, Err);
+      expect([...built.toApiRequest()]).toEqual(['1', '8']);
+    });
+  });
+
+  describe('copy constructor behavior', () => {
+    test('should keep what the original carried, its own type included', () => {
+      const original = new CairoTypeResult(10, T, S, Ok);
+      const copy = new CairoTypeResult(
+        original,
+        'core::result::Result::<core::integer::u32, core::integer::u64>',
+        S
+      );
+      expect(copy.content).toBe(original.content);
+      expect(copy.isVariantOk).toBe(original.isVariantOk);
+      // the type given to the copy is ignored: the original's is what survives
+      expect(copy.resultCairoType).toBe(T);
+    });
+  });
+
+  describe('CallData.compile integration', () => {
+    test('should serialize either branch', () => {
+      expect(CallData.compile([new CairoTypeResult(7, T, S, Ok)] as any)).toEqual(['0', '7']);
+      expect(CallData.compile([new CairoTypeResult(7, T, S, Err)] as any)).toEqual(['1', '7']);
+      expect(CallData.compile({ input: new CairoTypeResult(7, T, S, Ok) } as any)).toEqual([
+        '0',
+        '7',
+      ]);
+    });
+  });
+
+  describe('round-trip consistency', () => {
+    test('should survive a serialize then read back cycle', () => {
+      const cases: [string, any][] = [
+        [T, new CairoResult(Ok, 7)],
+        [T, new CairoResult(Err, 9)],
+        [OF_ARRAY, new CairoResult(Ok, [1, 2, 3])],
+        [OF_STRUCT, new CairoResult(Ok, { x: 1, y: 2 })],
+        [T3, new CairoResult(Err, new CairoResult(Ok, new CairoResult(Err, 5n)))],
+      ];
+      cases.forEach(([type, value]) => {
+        const result = new CairoTypeResult(value, type, S);
+        const response = [...result.toApiRequest()].map((felt) => `0x${BigInt(felt).toString(16)}`);
+        const readBack = new CairoTypeResult(response.values(), type, S);
+        expect([...readBack.toApiRequest()]).toEqual([...result.toApiRequest()]);
+      });
+    });
+  });
+});

--- a/src/global/constants.ts
+++ b/src/global/constants.ts
@@ -46,6 +46,12 @@ export const RANGE_I128 = range(-(2n ** 127n), 2n ** 127n - 1n);
 // https://github.com/starkware-libs/starknet-specs/blob/29bab650be6b1847c92d4461d4c33008b5e50b1a/api/starknet_api_openrpc.json#L1259
 export const RANGE_ETH_ADDRESS = range(ZERO, 2n ** 160n - 1n);
 
+// A contract address is narrower than the field it lives in: an address is computed modulo
+// ADDR_BOUND, and `validateAndParseAddress` already refuses anything past it. The 252-bit bound
+// the RPC spec states is looser than both, and never the one that binds.
+// There is no such narrowing for a class hash, which is a hash output and so any felt252.
+export const RANGE_CONTRACT_ADDRESS = range(ZERO, ADDR_BOUND - 1n);
+
 export const LegacyUDC = {
   ADDRESS: '0x041a78e741e5af2fec34b695679bc6891742439f7afb8484ecd7766661ad02bf',
   ENTRYPOINT: 'deployContract',

--- a/src/utils/cairoDataTypes/array.ts
+++ b/src/utils/cairoDataTypes/array.ts
@@ -1,0 +1,344 @@
+import type { AllowArray } from '../../types';
+import assert from '../assert';
+import { getArrayType, isTypeArray } from '../calldata/cairo';
+import type { CairoTypeStrategy } from '../calldata/parser/cairoTypeStrategy.type';
+import { addCompiledFlag } from '../helpers';
+import { getNext, isBigNumberish } from '../num';
+import { splitLongString } from '../shortString';
+import { CairoBytes31 } from './bytes31';
+import { CairoFelt252 } from './felt';
+import { isCairoType, type CairoType } from './cairoType.interface';
+import { findConstructor, findResponseParser } from './strategyLookup';
+
+/**
+ * A Cairo dynamic array : any number of values, all of the same type.
+ *
+ * Its abi type is `core::array::Array::<T>` or `core::array::Span::<T>`, and both are handled the
+ * same way. Unlike a tuple, whose size is in its type, an array carries its length on the wire :
+ * the felts start with how many elements follow.
+ *
+ * Text is accepted where the elements are felt252 or bytes31, and is split into the 31-character
+ * chunks each of those holds — which is how a long string reaches a contract that takes an array
+ * of felts.
+ * @example
+ * ```typescript
+ * const array = new CairoArray([1, 2, 3], 'core::array::Array::<core::integer::u8>', cairoTypeStrategy);
+ * array.toApiRequest(); //                 ["3", "1", "2", "3"]     length first
+ * array.decompose(cairoTypeStrategy); //   [1n, 2n, 3n]
+ * ```
+ */
+export class CairoArray {
+  /**
+   * The name this class is registered under in a strategy's `dynamicSelectors`.
+   * @example
+   * ```typescript
+   * const result = CairoArray.dynamicSelector;
+   * // result = "CairoArray"
+   * ```
+   */
+  static dynamicSelector = 'CairoArray' as const;
+
+  /**
+   * The selector on the instance, which is how a composite holding it knows what built it.
+   * @example
+   * ```typescript
+   * const array = new CairoArray([1], 'core::array::Array::<core::integer::u8>', cairoTypeStrategy);
+   * const result = array.dynamicSelector;
+   * // result = "CairoArray"
+   * ```
+   */
+  public readonly dynamicSelector = CairoArray.dynamicSelector;
+
+  /**
+   * The elements, each already built as the type the array declares.
+   * @example
+   * ```typescript
+   * const array = new CairoArray([1, 2, 3], 'core::array::Array::<core::integer::u8>', cairoTypeStrategy);
+   * const result = array.content.length;
+   * // result = 3
+   * ```
+   */
+  public readonly content: CairoType[];
+
+  /**
+   * The abi type this array was built for.
+   * @example
+   * ```typescript
+   * const array = new CairoArray([1], 'core::array::Span::<core::integer::u8>', cairoTypeStrategy);
+   * const result = array.arrayType;
+   * // result = "core::array::Span::<core::integer::u8>"
+   * ```
+   */
+  public readonly arrayType: string;
+
+  /**
+   * Build an array, from values a caller passed or from the felts of a response.
+   *
+   * Elements are accepted raw, or already built and taken as they stand. An object is read by its
+   * values, and text is split into chunks where the element type holds text.
+   * @param {unknown} content the elements, as an array, an object, text, or the response iterator
+   * @param {string} arrayType the abi type, `core::array::Array::<T>` or `Span::<T>`
+   * @param {AllowArray<CairoTypeStrategy>} parsingStrategy how to build each element
+   * @throws {Error} when the type is not an array, or when its element type no strategy knows
+   * @example
+   * ```typescript
+   * const fromArray = new CairoArray([1, 2], 'core::array::Array::<core::integer::u8>', cairoTypeStrategy);
+   * fromArray.toApiRequest(); // ["2", "1", "2"]
+   *
+   * const fromResponse = new CairoArray(
+   *   ['0x2', '0x1', '0x2'].values(),
+   *   'core::array::Array::<core::integer::u8>',
+   *   cairoTypeStrategy
+   * );
+   * fromResponse.toApiRequest(); // ["2", "1", "2"]
+   * ```
+   */
+  constructor(content: unknown, arrayType: string, parsingStrategy: AllowArray<CairoTypeStrategy>) {
+    this.arrayType = arrayType;
+    const strategies = Array.isArray(parsingStrategy) ? parsingStrategy : [parsingStrategy];
+
+    if (content && typeof content === 'object' && 'next' in content) {
+      this.content = CairoArray.parser(content as Iterator<string>, arrayType, strategies);
+      return;
+    }
+    if (content instanceof CairoArray) {
+      this.content = content.content;
+      this.arrayType = content.arrayType;
+      return;
+    }
+
+    const elementType = CairoArray.getArrayElementType(arrayType);
+    const elements = CairoArray.splitTextIfHeld(content, elementType);
+    CairoArray.validate(elements, arrayType);
+
+    const build = findConstructor(strategies, elementType);
+    if (!build) {
+      throw new Error(`"${elementType}" is not a valid Cairo type`);
+    }
+    this.content = CairoArray.extractValuesArray(elements).map((value) =>
+      isCairoType(value) ? value : build(value, strategies, elementType)
+    );
+  }
+
+  /**
+   * Turn text into the chunks an array of felt252 or bytes31 holds, or leave the input alone.
+   *
+   * Both of those types carry at most 31 bytes, so a longer string cannot be one element. Text is
+   * only split where the array actually holds text : anywhere else a string is a number written
+   * out, and splitting it would be nonsense.
+   * @param {unknown} content the value the caller passed
+   * @param {string} elementType the type the array declares
+   * @returns {unknown} the chunks, or the input unchanged
+   * @example
+   * ```typescript
+   * // called from the constructor
+   * const array = new CairoArray('hello', 'core::array::Array::<core::felt252>', cairoTypeStrategy);
+   * array.toApiRequest();
+   * // ["1", "448378203247"]     one chunk, holding the five bytes of "hello"
+   * ```
+   */
+  private static splitTextIfHeld(content: unknown, elementType: string): unknown {
+    const holdsText =
+      elementType === CairoFelt252.abiSelector || elementType === CairoBytes31.abiSelector;
+    return typeof content === 'string' && !isBigNumberish(content) && holdsText
+      ? splitLongString(content)
+      : content;
+  }
+
+  /**
+   * Read an array off a response : its length, then that many elements.
+   *
+   * The length felt comes as a node wrote it, which is hexadecimal, but this class writes it in
+   * decimal — so it is read as a number rather than parsed in a fixed base, and both spellings
+   * give the same count.
+   * @param {Iterator<string>} responseIterator the response felts, positioned on the length
+   * @param {string} arrayType the abi type, `core::array::Array::<T>` or `Span::<T>`
+   * @param {CairoTypeStrategy[]} strategies how to build each element
+   * @returns {CairoType[]} the elements that were read
+   * @throws {Error} when the element type is one no strategy knows
+   * @example
+   * ```typescript
+   * // called from the constructor when it is handed an iterator
+   * const array = new CairoArray(
+   *   ['0x2', '0x1', '0x2'].values(),
+   *   'core::array::Array::<core::integer::u8>',
+   *   cairoTypeStrategy
+   * );
+   * array.decompose(cairoTypeStrategy);
+   * // [1n, 2n]
+   * ```
+   */
+  private static parser(
+    responseIterator: Iterator<string>,
+    arrayType: string,
+    strategies: CairoTypeStrategy[]
+  ): CairoType[] {
+    const elementType = CairoArray.getArrayElementType(arrayType);
+    const length = Number(BigInt(getNext(responseIterator)));
+
+    const build = findConstructor(strategies, elementType);
+    if (!build) {
+      throw new Error(`No parser found for element type: ${elementType} in parsing strategy`);
+    }
+    return Array.from({ length }, () => build(responseIterator, strategies, elementType));
+  }
+
+  /**
+   * Line the elements up, whatever shape the input took.
+   *
+   * An array is already one. An object is read by its values, in the insertion order JavaScript
+   * keeps — an array has no names to go by, so position is all there is.
+   * @param {unknown} input the elements, as an array or an object
+   * @returns {any[]} the elements in order
+   * @example
+   * ```typescript
+   * // called from the constructor
+   * const array = new CairoArray({ 0: 1, 1: 2 }, 'core::array::Array::<core::integer::u8>', cairoTypeStrategy);
+   * array.toApiRequest();
+   * // ["2", "1", "2"]
+   * ```
+   */
+  private static extractValuesArray(input: unknown): any[] {
+    return Array.isArray(input) ? input : Object.values(input as object);
+  }
+
+  /**
+   * The type of the elements an array holds.
+   * @param {string} type the abi type to read
+   * @returns {string} the element type
+   * @example
+   * ```typescript
+   * const result = CairoArray.getArrayElementType('core::array::Array::<core::integer::u32>');
+   * // result = "core::integer::u32"
+   * const result2 = CairoArray.getArrayElementType('core::array::Span::<core::integer::u8>');
+   * // result2 = "core::integer::u8"
+   * ```
+   */
+  static getArrayElementType(type: string): string {
+    return getArrayType(type);
+  }
+
+  /**
+   * Throw unless this input can be read as an array of this type.
+   *
+   * Only the shape is checked : an array type, and elements given as a list or an object. How
+   * many there are is not, since an array declares no length — that is the whole difference with
+   * a tuple.
+   * @param {unknown} input the elements to check
+   * @param {string} type the abi type they are meant for
+   * @throws {Error} when the type is not an array, or the input is neither an array nor an object
+   * @example
+   * ```typescript
+   * CairoArray.validate([1, 2], 'core::array::Array::<core::integer::u8>'); // passes
+   * CairoArray.validate([1, 2], 'core::integer::u8');
+   * // throws Error("The type core::integer::u8 is not a Cairo dynamic array. Needs
+   * //               core::array::Array::<T> or core::array::Span::<T>.")
+   * ```
+   */
+  static validate(input: unknown, type: string): void {
+    assert(
+      CairoArray.isAbiType(type),
+      `The type ${type} is not a Cairo dynamic array. Needs core::array::Array::<T> or core::array::Span::<T>.`
+    );
+    assert(
+      Array.isArray(input) || (typeof input === 'object' && input !== null),
+      `Invalid input: expected Array or Object, got ${typeof input}`
+    );
+  }
+
+  /**
+   * Can this input be read as an array of this type?
+   *
+   * The non-throwing form of {@link CairoArray.validate}.
+   * @param {unknown} input the elements to test
+   * @param {string} type the abi type they are meant for
+   * @returns {boolean} true when the shape fits
+   * @example
+   * ```typescript
+   * const result = CairoArray.is([1, 2], 'core::array::Array::<core::integer::u8>');
+   * // result = true
+   * const result2 = CairoArray.is('nope', 'core::array::Array::<core::integer::u8>');
+   * // result2 = false
+   * ```
+   */
+  static is(input: unknown, type: string): boolean {
+    try {
+      CairoArray.validate(input, type);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Is this abi type a dynamic array?
+   * @param {string} type the abi type to test
+   * @returns {boolean} true for `core::array::Array::<T>` and `core::array::Span::<T>`
+   * @example
+   * ```typescript
+   * const result = CairoArray.isAbiType('core::array::Array::<core::integer::u32>');
+   * // result = true
+   * const result2 = CairoArray.isAbiType('core::array::Span::<core::integer::u8>');
+   * // result2 = true
+   * const result3 = CairoArray.isAbiType('[core::integer::u32; 8]');
+   * // result3 = false     (a fixed array declares its length in its type)
+   * ```
+   */
+  static isAbiType(type: string): boolean {
+    return isTypeArray(type);
+  }
+
+  /**
+   * Serialize to the felts a contract call carries.
+   *
+   * The count comes first, then the elements. A nested array carries its own count in turn, which
+   * is what lets the whole of it be read back from one flat list.
+   * @returns {string[]} the length then the elements' felts, flagged as compiled
+   * @example
+   * ```typescript
+   * const array = new CairoArray([1, 2, 3], 'core::array::Array::<core::integer::u8>', cairoTypeStrategy);
+   * const result = array.toApiRequest();
+   * // result = ["3", "1", "2", "3"]
+   * ```
+   */
+  public toApiRequest(): string[] {
+    return addCompiledFlag([
+      String(this.content.length),
+      ...this.content.flatMap((element) => element.toApiRequest()),
+    ]);
+  }
+
+  /**
+   * Read the array back as the plain values a caller reads.
+   *
+   * Each element is handed to the strategy entry for its type — or for what built it, when that
+   * is a composite, which is what its `dynamicSelector` says.
+   * @param {AllowArray<CairoTypeStrategy>} strategyDecompose how to read each element back
+   * @returns {any[]} the elements' values, in order
+   * @throws {Error} when no strategy can read an element back
+   * @example
+   * ```typescript
+   * const array = new CairoArray([1, 2, 3], 'core::array::Array::<core::integer::u8>', cairoTypeStrategy);
+   * const result = array.decompose(cairoTypeStrategy);
+   * // result = [1n, 2n, 3n]
+   * ```
+   */
+  public decompose(strategyDecompose: AllowArray<CairoTypeStrategy>): any[] {
+    const strategies = Array.isArray(strategyDecompose) ? strategyDecompose : [strategyDecompose];
+    const elementType = CairoArray.getArrayElementType(this.arrayType);
+
+    return this.content.map((element) => {
+      const parserName =
+        'dynamicSelector' in element
+          ? (element as { dynamicSelector: string }).dynamicSelector
+          : elementType;
+      const read = findResponseParser(strategies, parserName);
+      if (!read) {
+        throw new Error(
+          `No response parser found for element type: ${parserName} in parsing strategy`
+        );
+      }
+      return read(element, strategies);
+    });
+  }
+}

--- a/src/utils/cairoDataTypes/cairoStruct.ts
+++ b/src/utils/cairoDataTypes/cairoStruct.ts
@@ -1,0 +1,320 @@
+import type { AbiStruct, AllowArray } from '../../types';
+import assert from '../assert';
+import { isCairo1Type, isLen } from '../calldata/cairo';
+import type { CairoTypeStrategy } from '../calldata/parser/cairoTypeStrategy.type';
+import { addCompiledFlag } from '../helpers';
+import { isCairoType, type CairoType } from './cairoType.interface';
+import { findConstructor, findResponseParser } from './strategyLookup';
+
+/**
+ * A Cairo struct : a fixed set of named members, each of its own type.
+ *
+ * Unlike a tuple or an array, a struct has no shape to recognize — its abi type is just the name
+ * the contract gave it, `my_contract::Point`, which looks like any other type. So there is no
+ * `isAbiType` here : a struct is found by its exact name among a strategy's constructors, and the
+ * strategy that carries those names is built from the abi that declares them.
+ *
+ * On the wire a struct is its members one after another, with nothing in front — its shape is
+ * entirely in the abi, exactly as a tuple's is in its type.
+ * @example
+ * ```typescript
+ * const point: AbiStruct = {
+ *   type: 'struct',
+ *   name: 'test::Point',
+ *   members: [
+ *     { name: 'x', type: 'core::integer::u8' },
+ *     { name: 'y', type: 'core::integer::u32' },
+ *   ],
+ * };
+ * const strategies = [cairoTypeStrategy, structStrategy([point])];
+ * const struct = new CairoStruct({ x: 1, y: 2 }, point, strategies);
+ * struct.toApiRequest(); //          ["1", "2"]
+ * struct.decompose(strategies); //   { x: 1n, y: 2n }
+ * ```
+ */
+export class CairoStruct {
+  /**
+   * The name this struct is registered under, which is the name the abi gave it.
+   *
+   * Every other composite has one selector for the whole class; a struct has one per struct, so
+   * this is set from the abi rather than declared on the class.
+   * @example
+   * ```typescript
+   * const struct = new CairoStruct({ x: 1, y: 2 }, point, strategies);
+   * const result = struct.dynamicSelector;
+   * // result = "test::Point"
+   * ```
+   */
+  public readonly dynamicSelector: string;
+
+  /**
+   * The members, each already built as the type the abi declares for it.
+   * @example
+   * ```typescript
+   * const result = new CairoStruct({ x: 1, y: 2 }, point, strategies).content.length;
+   * // result = 2
+   * ```
+   */
+  public readonly content: CairoType[];
+
+  /**
+   * The abi definition this struct was built from.
+   * @example
+   * ```typescript
+   * const result = new CairoStruct({ x: 1, y: 2 }, point, strategies).abiStruct.name;
+   * // result = "test::Point"
+   * ```
+   */
+  public readonly abiStruct: AbiStruct;
+
+  /**
+   * Build a struct, from values a caller passed or from the felts of a response.
+   *
+   * An object is read by the member names the abi declares, in the abi's order — so the order the
+   * caller wrote them in does not matter. An array is taken as already being in that order.
+   * @param {unknown} content the members, as an object, an array, or the response iterator
+   * @param {AbiStruct} abiStruct the abi definition of this struct
+   * @param {AllowArray<CairoTypeStrategy>} parsingStrategy how to build each member, which must
+   * carry this struct's own name for a struct that holds another
+   * @throws {Error} when a member is missing, when the count does not match, or when a member
+   * type no strategy knows is met
+   * @example
+   * ```typescript
+   * new CairoStruct({ x: 1, y: 2 }, point, strategies).toApiRequest(); // ["1", "2"]
+   * new CairoStruct({ y: 2, x: 1 }, point, strategies).toApiRequest(); // ["1", "2"]  abi order
+   * new CairoStruct([1, 2], point, strategies).toApiRequest(); //        ["1", "2"]
+   * ```
+   */
+  constructor(
+    content: unknown,
+    abiStruct: AbiStruct,
+    parsingStrategy: AllowArray<CairoTypeStrategy>
+  ) {
+    this.abiStruct = abiStruct;
+    this.dynamicSelector = abiStruct.name;
+    const strategies = Array.isArray(parsingStrategy) ? parsingStrategy : [parsingStrategy];
+
+    if (content && typeof content === 'object' && 'next' in content) {
+      this.content = CairoStruct.parser(content as Iterator<string>, abiStruct, strategies);
+      return;
+    }
+    if (content instanceof CairoStruct) {
+      this.content = content.content;
+      this.abiStruct = content.abiStruct;
+      this.dynamicSelector = content.dynamicSelector;
+      return;
+    }
+
+    CairoStruct.validate(content, abiStruct);
+    const memberTypes = CairoStruct.getStructMembersTypes(abiStruct);
+    this.content = CairoStruct.extractValuesArray(content, abiStruct).map((value, index) => {
+      if (isCairoType(value)) {
+        return value;
+      }
+      const build = findConstructor(strategies, memberTypes[index]);
+      if (!build) {
+        throw new Error(`"${memberTypes[index]}" is not a valid Cairo type`);
+      }
+      return build(value, strategies, memberTypes[index]);
+    });
+  }
+
+  /**
+   * Read a struct off a response, one member after another.
+   *
+   * Nothing marks where a struct ends on the wire, so the abi is what says how many felts to take
+   * and what each of them is.
+   * @param {Iterator<string>} responseIterator the response felts, positioned on this struct
+   * @param {AbiStruct} abiStruct the abi definition of this struct
+   * @param {CairoTypeStrategy[]} strategies how to build each member
+   * @returns {CairoType[]} the members that were read
+   * @throws {Error} when a member type is one no strategy knows
+   * @example
+   * ```typescript
+   * // called from the constructor when it is handed an iterator
+   * const struct = new CairoStruct(['0x1', '0x2'].values(), point, strategies);
+   * struct.decompose(strategies);
+   * // { x: 1n, y: 2n }
+   * ```
+   */
+  private static parser(
+    responseIterator: Iterator<string>,
+    abiStruct: AbiStruct,
+    strategies: CairoTypeStrategy[]
+  ): CairoType[] {
+    return CairoStruct.getStructMembersTypes(abiStruct).map((memberType) => {
+      const build = findConstructor(strategies, memberType);
+      if (!build) {
+        throw new Error(`No parser found for element type: ${memberType} in parsing strategy`);
+      }
+      return build(responseIterator, strategies, memberType);
+    });
+  }
+
+  /**
+   * Line the members up in the order the abi declares, whatever shape the input took.
+   *
+   * An array is already in that order. An object is read member by member, and one that is
+   * missing raises — except a Cairo 0 length member, which a contract derives rather than
+   * receives.
+   * @param {unknown} input the members, as an array or an object
+   * @param {AbiStruct} abiStruct the abi definition, which gives the names and their order
+   * @returns {any[]} the members in the abi's order
+   * @throws {Error} when the object has no property for a member the abi declares
+   * @example
+   * ```typescript
+   * // called from the constructor
+   * new CairoStruct({ y: 2, x: 1 }, point, strategies).toApiRequest();
+   * // ["1", "2"]     read in the abi's order, not the object's
+   * ```
+   */
+  private static extractValuesArray(input: unknown, abiStruct: AbiStruct): any[] {
+    if (Array.isArray(input)) {
+      return input;
+    }
+    const inputObject = input as Record<string, any>;
+    return abiStruct.members.map((member) => {
+      const missing = typeof inputObject[member.name] === 'undefined';
+      if (missing && (isCairo1Type(member.type) || !isLen(member.name))) {
+        throw new Error(`Your object needs a property with key : ${member.name} .`);
+      }
+      return inputObject[member.name];
+    });
+  }
+
+  /**
+   * The types of the members, in the abi's order.
+   * @param {AbiStruct} abiStruct the abi definition to read
+   * @returns {string[]} one type per member
+   * @example
+   * ```typescript
+   * const result = CairoStruct.getStructMembersTypes(point);
+   * // result = ["core::integer::u8", "core::integer::u32"]
+   * ```
+   */
+  static getStructMembersTypes(abiStruct: AbiStruct): string[] {
+    return abiStruct.members.map((member) => member.type);
+  }
+
+  /**
+   * The names of the members, in the abi's order.
+   * @param {AbiStruct} abiStruct the abi definition to read
+   * @returns {string[]} one name per member
+   * @example
+   * ```typescript
+   * const result = CairoStruct.extractStructMembersNames(point);
+   * // result = ["x", "y"]
+   * ```
+   */
+  static extractStructMembersNames(abiStruct: AbiStruct): string[] {
+    return abiStruct.members.map((member) => member.name);
+  }
+
+  /**
+   * Throw unless this input can be read as this struct.
+   *
+   * Given an abi, the member count is checked too : a struct is a fixed set, so a list of the
+   * wrong size is refused rather than padded or cut. Without one, only the shape is checked.
+   * @param {unknown} input the members to check
+   * @param {AbiStruct} [abiStruct] the abi definition, when there is one to check against
+   * @throws {Error} when the input is neither an array nor an object, when the abi is not a
+   * struct, or when the member count does not match
+   * @example
+   * ```typescript
+   * CairoStruct.validate({ x: 1, y: 2 }, point); // passes
+   * CairoStruct.validate([1], point);
+   * // throws Error("Invalid input: expected 2 members, got 1")
+   * ```
+   */
+  static validate(input: unknown, abiStruct?: AbiStruct): void {
+    assert(
+      Array.isArray(input) || (typeof input === 'object' && input !== null),
+      `Invalid input: expected Array or Object, got ${typeof input}`
+    );
+    if (!abiStruct) {
+      return;
+    }
+    assert(abiStruct.type === 'struct', `Invalid ABI: expected struct, got ${abiStruct.type}`);
+    const count = Array.isArray(input) ? input.length : Object.keys(input).length;
+    assert(
+      abiStruct.members.length === count,
+      `Invalid input: expected ${abiStruct.members.length} members, got ${count}`
+    );
+  }
+
+  /**
+   * Can this input be read as this struct?
+   *
+   * The non-throwing form of {@link CairoStruct.validate}.
+   * @param {unknown} input the members to test
+   * @param {AbiStruct} [abiStruct] the abi definition, when there is one to check against
+   * @returns {boolean} true when the shape fits
+   * @example
+   * ```typescript
+   * const result = CairoStruct.is({ x: 1, y: 2 }, point);
+   * // result = true
+   * const result2 = CairoStruct.is([1], point);
+   * // result2 = false     (one member short)
+   * ```
+   */
+  static is(input: unknown, abiStruct?: AbiStruct): boolean {
+    try {
+      CairoStruct.validate(input, abiStruct);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Serialize to the felts a contract call carries.
+   *
+   * The members follow one another with nothing in front, as a tuple's do : what a struct holds
+   * is said by the abi, not by the calldata.
+   * @returns {string[]} the members' felts, in the abi's order, flagged as compiled
+   * @example
+   * ```typescript
+   * const result = new CairoStruct({ x: 1, y: 2 }, point, strategies).toApiRequest();
+   * // result = ["1", "2"]
+   * ```
+   */
+  public toApiRequest(): string[] {
+    return addCompiledFlag(this.content.flatMap((member) => member.toApiRequest()));
+  }
+
+  /**
+   * Read the struct back as the plain object a caller reads.
+   *
+   * Each member is handed to the strategy entry for its type — or for what built it, when that is
+   * a composite, which is what its `dynamicSelector` says. The result is keyed by member name.
+   * @param {AllowArray<CairoTypeStrategy>} strategyDecompose how to read each member back
+   * @returns {Object} the members' values, keyed by name
+   * @throws {Error} when no strategy can read a member back
+   * @example
+   * ```typescript
+   * const result = new CairoStruct({ x: 1, y: 2 }, point, strategies).decompose(strategies);
+   * // result = { x: 1n, y: 2n }
+   * ```
+   */
+  public decompose(strategyDecompose: AllowArray<CairoTypeStrategy>): Object {
+    const strategies = Array.isArray(strategyDecompose) ? strategyDecompose : [strategyDecompose];
+    const memberTypes = CairoStruct.getStructMembersTypes(this.abiStruct);
+    const names = CairoStruct.extractStructMembersNames(this.abiStruct);
+
+    const values = this.content.map((member, index) => {
+      const parserName =
+        'dynamicSelector' in member
+          ? (member as { dynamicSelector: string }).dynamicSelector
+          : memberTypes[index];
+      const read = findResponseParser(strategies, parserName);
+      if (!read) {
+        throw new Error(
+          `No response parser found for element type: ${parserName} in parsing strategy`
+        );
+      }
+      return read(member, strategies);
+    });
+
+    return Object.fromEntries(names.map((name, index) => [name, values[index]]));
+  }
+}

--- a/src/utils/cairoDataTypes/cairoType.interface.ts
+++ b/src/utils/cairoDataTypes/cairoType.interface.ts
@@ -1,0 +1,50 @@
+/**
+ * What the Cairo data type classes have in common: each one turns itself into the felts a
+ * contract call carries.
+ *
+ * This is an interface rather than a base class on purpose. TypeScript matches it structurally,
+ * so every class in this directory already satisfies it without declaring anything — a base class
+ * would have had to be added to each of them, and any class that forgot would not have raised :
+ * an `instanceof` check would simply have answered false and sent the value down the wrong branch.
+ *
+ * The composite types are what this exists for : an array, a tuple or a struct holds elements of
+ * types it does not know, and only ever needs to ask each of them for its felts.
+ * @example
+ * ```typescript
+ * const elements: CairoType[] = [new CairoUint8(1), new CairoFelt252('Hello')];
+ * const felts = elements.flatMap((element) => element.toApiRequest());
+ * // felts = ["1", "310939249775"]
+ * ```
+ */
+export interface CairoType {
+  /**
+   * Serialize to the felts a contract call carries, as decimal strings.
+   */
+  toApiRequest(): string[];
+}
+
+/**
+ * Is this value one of the Cairo type classes, rather than the raw data one is built from?
+ *
+ * The composites accept both — `[1, 2]` and `[new CairoUint8(1), new CairoUint8(2)]` describe the
+ * same array — and this is what tells them apart. It asks for a callable `toApiRequest`, so an
+ * object merely carrying a property of that name is not mistaken for one.
+ * @param {unknown} value the value to test
+ * @returns {boolean} true when the value can serialize itself
+ * @example
+ * ```typescript
+ * const result = isCairoType(new CairoUint8(44));
+ * // result = true
+ * const result2 = isCairoType(44);
+ * // result2 = false
+ * const result3 = isCairoType({ toApiRequest: 'not a function' });
+ * // result3 = false
+ * ```
+ */
+export function isCairoType(value: unknown): value is CairoType {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as CairoType).toApiRequest === 'function'
+  );
+}

--- a/src/utils/cairoDataTypes/cairoTypeCustomEnum.ts
+++ b/src/utils/cairoDataTypes/cairoTypeCustomEnum.ts
@@ -1,0 +1,420 @@
+import type { AbiEnum, AllowArray } from '../../types';
+import assert from '../assert';
+import { isCairo1Type } from '../calldata/cairo';
+import {
+  CairoCustomEnum,
+  CairoOption,
+  CairoOptionVariant,
+  CairoResult,
+  CairoResultVariant,
+  type CairoEnumRaw,
+} from '../calldata/enum';
+import type { CairoTypeStrategy, VariantType } from '../calldata/parser/cairoTypeStrategy.type';
+import { addCompiledFlag } from '../helpers';
+import { getNext } from '../num';
+import { isUndefined } from '../typed';
+import { isCairoType, type CairoType } from './cairoType.interface';
+import { CairoTypeOption } from './cairoTypeOption';
+import { CairoTypeResult } from './cairoTypeResult';
+import { findConstructor, findResponseParser } from './strategyLookup';
+
+/**
+ * A Cairo custom enum : one of several named variants, each carrying its own type.
+ *
+ * On the wire it is the index of the active variant, then that variant's value. Which variant is
+ * meant cannot be read off the value, so building one from raw data asks for the index — unless
+ * the content is a {@link CairoCustomEnum}, which names its own active variant.
+ *
+ * Like a struct, a custom enum has no shape to recognize : its abi type is the name the contract
+ * chose. It is found by that exact name among a strategy's constructors, which is what
+ * `enumStrategy` builds from an abi.
+ * @example
+ * ```typescript
+ * const abiEnum: AbiEnum = {
+ *   type: 'enum',
+ *   name: 'test::MyEnum',
+ *   variants: [
+ *     { name: 'Empty', type: '()' },
+ *     { name: 'Number', type: 'core::integer::u8' },
+ *   ],
+ * };
+ * const strategies = [cairoTypeStrategy, enumStrategy([abiEnum])];
+ * new CairoTypeCustomEnum(7, abiEnum, strategies, 1).toApiRequest();
+ * // ["1", "7"]
+ * ```
+ */
+export class CairoTypeCustomEnum {
+  /**
+   * The name this enum is registered under, which is the name the abi gave it.
+   * @example
+   * ```typescript
+   * const result = new CairoTypeCustomEnum(7, abiEnum, strategies, 1).dynamicSelector;
+   * // result = "test::MyEnum"
+   * ```
+   */
+  public readonly dynamicSelector: string;
+
+  /**
+   * The value the active variant carries.
+   * @example
+   * ```typescript
+   * const result = new CairoTypeCustomEnum(7, abiEnum, strategies, 1).content.toApiRequest();
+   * // result = ["7"]
+   * ```
+   */
+  public readonly content: CairoType;
+
+  /**
+   * The abi definition this enum was built from.
+   * @example
+   * ```typescript
+   * const result = new CairoTypeCustomEnum(7, abiEnum, strategies, 1).abiEnum.name;
+   * // result = "test::MyEnum"
+   * ```
+   */
+  public readonly abiEnum: AbiEnum;
+
+  /**
+   * The index of the active variant, in the abi's order.
+   * @example
+   * ```typescript
+   * const result = new CairoTypeCustomEnum(7, abiEnum, strategies, 1).enumVariant;
+   * // result = 1
+   * ```
+   */
+  public readonly enumVariant: number;
+
+  /**
+   * Build a custom enum, from a value a caller passed or from the felts of a response.
+   *
+   * A {@link CairoCustomEnum} names its own active variant, so `variant` must be left out with one
+   * — as with the response iterator and with a `CairoTypeCustomEnum` being copied. Anywhere else
+   * it is required, the index being the only thing that says which variant a value belongs to.
+   *
+   * A {@link CairoOption} or a {@link CairoResult} is turned into its own Cairo type here rather
+   * than through the strategy : the strategy is handed `variant`, and those two would read it as
+   * their own branch instead of as the enum's index.
+   *
+   * `subType` is what makes an enum of enums work. Handed a `CairoCustomEnum`, this constructor
+   * unwraps it and calls itself with what was inside; the flag stops that second call from
+   * unwrapping again and losing a level.
+   * @param {unknown} content the value, a `CairoCustomEnum`, an instance already built, or the
+   * response iterator
+   * @param {AbiEnum} abiEnum the abi definition of this enum
+   * @param {AllowArray<CairoTypeStrategy>} parsingStrategy how to build the variant's value
+   * @param {number} [variant] the index of the active variant, when the content does not say
+   * @param {boolean} [subType=false] true when called from the unwrapping of a nested
+   * `CairoCustomEnum`, which is the only caller that should set it
+   * @throws {Error} when the content is missing, the variant is missing or out of range, or the
+   * variant type is one no strategy knows
+   * @example
+   * ```typescript
+   * new CairoTypeCustomEnum(7, abiEnum, strategies, 1).toApiRequest();
+   * // ["1", "7"]
+   * new CairoTypeCustomEnum(new CairoCustomEnum({ Number: 7 }), abiEnum, strategies).toApiRequest();
+   * // ["1", "7"]     the CairoCustomEnum names its own variant
+   * ```
+   */
+  constructor(
+    content: unknown,
+    abiEnum: AbiEnum,
+    parsingStrategy: AllowArray<CairoTypeStrategy>,
+    variant?: number,
+    subType: boolean = false
+  ) {
+    this.dynamicSelector = abiEnum.name;
+    this.abiEnum = abiEnum;
+    const strategies = Array.isArray(parsingStrategy) ? parsingStrategy : [parsingStrategy];
+    assert(!isUndefined(content), '"content" parameter has to be defined.');
+    assert(content !== null, '"content" parameter has to be defined.');
+
+    if (content && typeof content === 'object' && 'next' in content) {
+      assert(
+        isUndefined(variant),
+        'when "content" parameter is an iterator, do not define "variant" parameter.'
+      );
+      const variantFromIterator = Number(getNext(content as Iterator<string>));
+      this.enumVariant = variantFromIterator;
+      const elementTypes = CairoTypeCustomEnum.getVariantTypes(abiEnum);
+      this.content = CairoTypeCustomEnum.parser(
+        content as Iterator<string>,
+        elementTypes[variantFromIterator],
+        strategies
+      );
+      return;
+    }
+
+    if (content instanceof CairoTypeCustomEnum) {
+      assert(
+        isUndefined(variant),
+        'when "content" parameter is a CairoTypeCustomEnum do not define "variant" parameter.'
+      );
+      this.content = content.content;
+      this.enumVariant = content.enumVariant;
+      this.dynamicSelector = content.dynamicSelector;
+      this.abiEnum = content.abiEnum;
+      return;
+    }
+
+    CairoTypeCustomEnum.validate(content, abiEnum.name, variant);
+
+    if (isCairoType(content)) {
+      assert(
+        !isUndefined(variant),
+        '"variant" parameter is mandatory when creating a new Cairo enum from a CairoType.'
+      );
+      this.content = content;
+      this.enumVariant = variant;
+      return;
+    }
+
+    if (content instanceof CairoOption) {
+      assert(
+        !isUndefined(variant),
+        '"variant" parameter is mandatory when creating a new Cairo custom enum from a CairoOption.'
+      );
+      this.content = new CairoTypeOption(
+        content.unwrap(),
+        CairoTypeCustomEnum.getVariantTypes(abiEnum)[variant],
+        strategies,
+        content.isSome() ? CairoOptionVariant.Some : CairoOptionVariant.None
+      );
+      this.enumVariant = variant;
+      return;
+    }
+
+    if (content instanceof CairoResult) {
+      assert(
+        !isUndefined(variant),
+        '"variant" parameter is mandatory when creating a new Cairo custom enum from a CairoResult.'
+      );
+      this.content = new CairoTypeResult(
+        content.unwrap(),
+        CairoTypeCustomEnum.getVariantTypes(abiEnum)[variant],
+        strategies,
+        content.isOk() ? CairoResultVariant.Ok : CairoResultVariant.Err
+      );
+      this.enumVariant = variant;
+      return;
+    }
+
+    if (content instanceof CairoCustomEnum) {
+      if (!subType) {
+        const subVariant = CairoTypeCustomEnum.extractEnumMembersNames(abiEnum).indexOf(
+          content.activeVariant()
+        );
+        assert(subVariant >= 0, `${content.activeVariant()} activeVariant is unknown in AbiEnum.`);
+        const customEnum = new CairoTypeCustomEnum(
+          content.unwrap(),
+          abiEnum,
+          strategies,
+          subVariant,
+          true // recursive sub-type
+        );
+        this.content = customEnum.content;
+        this.enumVariant = customEnum.enumVariant;
+        return;
+      }
+      assert(
+        !isUndefined(variant),
+        '"variant" parameter is mandatory when creating a new Cairo custom enum from a CairoCustomEnum.'
+      );
+    }
+
+    // not an iterator, not a CairoType -> so it is low level data (BigNumberish, array, object)
+    assert(
+      !isUndefined(variant),
+      '"variant" parameter is mandatory when creating a new Cairo custom enum from a Cairo Enum or raw data.'
+    );
+    const numberVariant = Number(variant);
+    assert(
+      numberVariant < abiEnum.variants.length && numberVariant >= 0,
+      `The custom enum ${abiEnum.name} variant must be in the range 0..${abiEnum.variants.length - 1}. You requested variant #${numberVariant}`
+    );
+    this.enumVariant = variant;
+    const elementType = CairoTypeCustomEnum.getVariantTypes(abiEnum)[variant];
+    const build = findConstructor(strategies, elementType);
+    if (!build) {
+      throw new Error(`"${elementType}" is not a valid Cairo type`);
+    }
+    this.content = build(content, strategies, elementType, variant);
+  }
+
+  /**
+   * Read the value of the active variant off a response, its index having been consumed.
+   * @param {Iterator<string>} responseIterator the response felts, positioned on the value
+   * @param {string} variantCairoType the type of the variant that was read
+   * @param {CairoTypeStrategy[]} strategies how to build the value
+   * @returns {CairoType} the value that was read
+   * @throws {Error} when the variant type is one no strategy knows
+   * @example
+   * ```typescript
+   * // called from the constructor when it is handed an iterator
+   * new CairoTypeCustomEnum(['0x1', '0x7'].values(), abiEnum, strategies).toApiRequest();
+   * // ["1", "7"]
+   * ```
+   */
+  private static parser(
+    responseIterator: Iterator<string>,
+    variantCairoType: string,
+    strategies: CairoTypeStrategy[]
+  ): CairoType {
+    const build = findConstructor(strategies, variantCairoType);
+    if (!build) {
+      throw new Error(`No parser found for element type: ${variantCairoType} in parsing strategy`);
+    }
+    return build(responseIterator, strategies, variantCairoType);
+  }
+
+  /**
+   * Throw unless this name can be a Cairo 1 type at all.
+   *
+   * There is nothing more to check : a custom enum's abi type is the name the contract chose, and
+   * what the value is worth is the business of the active variant's type.
+   * @param {unknown} _input the value, which this does not read
+   * @param {string} type the abi name it is meant for
+   * @param {VariantType} _variant the variant, which this does not read
+   * @throws {Error} when the name is not a Cairo 1 type name
+   * @example
+   * ```typescript
+   * CairoTypeCustomEnum.validate(7, 'test::MyEnum', 1); // passes
+   * CairoTypeCustomEnum.validate(7, 'wrong', 1);
+   * // throws Error("The type wrong is not a Cairo Enum. Needs impl::name.")
+   * ```
+   */
+  static validate(_input: unknown, type: string, _variant: VariantType | undefined): void {
+    assert(
+      CairoTypeCustomEnum.isAbiType(type),
+      `The type ${type} is not a Cairo Enum. Needs impl::name.`
+    );
+  }
+
+  /**
+   * Can this name be a Cairo custom enum?
+   *
+   * The non-throwing form of {@link CairoTypeCustomEnum.validate}.
+   * @param {unknown} input the value to test
+   * @param {string} type the abi name it is meant for
+   * @param {VariantType} variant the variant
+   * @returns {boolean} true when the name could be one
+   * @example
+   * ```typescript
+   * const result = CairoTypeCustomEnum.is(7, 'test::MyEnum', 1);
+   * // result = true
+   * const result2 = CairoTypeCustomEnum.is(7, 'wrong', 1);
+   * // result2 = false
+   * ```
+   */
+  static is(input: unknown, type: string, variant: VariantType): boolean {
+    try {
+      CairoTypeCustomEnum.validate(input, type, variant);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Could this abi type name a Cairo custom enum?
+   *
+   * Only the shape of the name is testable — a custom enum has no pattern of its own, so this
+   * says no more than that the name looks like a Cairo 1 type. It is deliberately not used as a
+   * dynamic selector : one that answered true this widely would shadow every other type.
+   * @param {string} type the abi type to test
+   * @returns {boolean} true when the name contains `::`
+   * @example
+   * ```typescript
+   * const result = CairoTypeCustomEnum.isAbiType('my_contract::my_enum');
+   * // result = true
+   * const result2 = CairoTypeCustomEnum.isAbiType('wrong');
+   * // result2 = false
+   * ```
+   */
+  static isAbiType(type: string): boolean {
+    return isCairo1Type(type);
+  }
+
+  /**
+   * The types of the variants, in the abi's order.
+   * @param {AbiEnum} type the abi definition to read
+   * @returns {string[]} one type per variant
+   * @example
+   * ```typescript
+   * const result = CairoTypeCustomEnum.getVariantTypes(abiEnum);
+   * // result = ["()", "core::integer::u8"]
+   * ```
+   */
+  static getVariantTypes(type: AbiEnum): string[] {
+    return type.variants.map((member) => member.type);
+  }
+
+  /**
+   * The names of the variants, in the abi's order.
+   * @param {AbiEnum} type the abi definition to read
+   * @returns {string[]} one name per variant
+   * @example
+   * ```typescript
+   * const result = CairoTypeCustomEnum.extractEnumMembersNames(abiEnum);
+   * // result = ["Empty", "Number"]
+   * ```
+   */
+  static extractEnumMembersNames(type: AbiEnum): string[] {
+    return type.variants.map((member) => member.name);
+  }
+
+  /**
+   * Serialize to the felts a contract call carries.
+   *
+   * The index of the active variant comes first, then its value.
+   * @returns {string[]} the variant index then the value, flagged as compiled
+   * @example
+   * ```typescript
+   * const result = new CairoTypeCustomEnum(7, abiEnum, strategies, 1).toApiRequest();
+   * // result = ["1", "7"]
+   * ```
+   */
+  public toApiRequest(): string[] {
+    const result: string[] = [this.enumVariant.toString(10)];
+    result.push(...this.content.toApiRequest());
+    return addCompiledFlag(result.flat());
+  }
+
+  /**
+   * Read the enum back as the {@link CairoCustomEnum} a caller reads.
+   *
+   * Every variant the abi declares appears in the result, the inactive ones as `undefined` — which
+   * is how `CairoCustomEnum` tells which one is active.
+   * @param {AllowArray<CairoTypeStrategy>} strategyDecompose how to read the value back
+   * @returns {CairoCustomEnum} the enum, with its active variant carrying the value
+   * @throws {Error} when no strategy can read the value back
+   * @example
+   * ```typescript
+   * const result = new CairoTypeCustomEnum(7, abiEnum, strategies, 1).decompose(strategies);
+   * // result = CairoCustomEnum { Empty: undefined, Number: 7n }
+   * ```
+   */
+  public decompose(strategyDecompose: AllowArray<CairoTypeStrategy>): CairoCustomEnum {
+    const { content } = this;
+    const strategies = Array.isArray(strategyDecompose) ? strategyDecompose : [strategyDecompose];
+    const elementType = CairoTypeCustomEnum.getVariantTypes(this.abiEnum)[this.enumVariant];
+    const elementNames = CairoTypeCustomEnum.extractEnumMembersNames(this.abiEnum);
+    const parserName =
+      'dynamicSelector' in content
+        ? (content as { dynamicSelector: string }).dynamicSelector
+        : elementType;
+    const read = findResponseParser(strategies, parserName);
+    if (!read) {
+      throw new Error(
+        `No response parser found for element type: ${elementType} in parsing strategy`
+      );
+    }
+    const resultObject: CairoEnumRaw = elementNames.reduce(
+      (current: CairoEnumRaw, name: string, index: number) => ({
+        ...current,
+        [name]: index === this.enumVariant ? read(content, strategies) : undefined,
+      }),
+      {}
+    );
+    return new CairoCustomEnum(resultObject);
+  }
+}

--- a/src/utils/cairoDataTypes/cairoTypeFixedArray.ts
+++ b/src/utils/cairoDataTypes/cairoTypeFixedArray.ts
@@ -1,0 +1,324 @@
+import type { AllowArray } from '../../types';
+import assert from '../assert';
+import type { CairoTypeStrategy } from '../calldata/parser/cairoTypeStrategy.type';
+import { addCompiledFlag } from '../helpers';
+import { isCairoType, type CairoType } from './cairoType.interface';
+import { CairoFixedArray } from './fixedArray';
+import { findConstructor, findResponseParser } from './strategyLookup';
+
+/**
+ * A Cairo fixed array : a known number of values, all of the same type.
+ *
+ * Its abi type is `[T; length]`, and both halves matter — the length is part of the type, so an
+ * array of the wrong size is refused rather than padded or cut. On the wire it carries no length
+ * of its own, exactly like a tuple : the type already says how many elements follow.
+ *
+ * This is the internal shape, the one that serializes itself and reads itself back. The public
+ * {@link CairoFixedArray} is the other half of the story : it turns a list into the struct
+ * `CallData.compile` expects, and it is what a caller writes today. The two coexist while the
+ * encoding is being moved over, and this one delegates its type reading to it so that both read a
+ * `[T; length]` the same way.
+ * @example
+ * ```typescript
+ * const array = new CairoTypeFixedArray([1, 2, 3], '[core::integer::u8; 3]', cairoTypeStrategy);
+ * array.toApiRequest(); //                 ["1", "2", "3"]     no length on the wire
+ * array.decompose(cairoTypeStrategy); //   [1n, 2n, 3n]
+ * ```
+ */
+export class CairoTypeFixedArray {
+  /**
+   * The name this class is registered under in a strategy's `dynamicSelectors`.
+   * @example
+   * ```typescript
+   * const result = CairoTypeFixedArray.dynamicSelector;
+   * // result = "CairoTypeFixedArray"
+   * ```
+   */
+  static dynamicSelector = 'CairoTypeFixedArray' as const;
+
+  /**
+   * The selector on the instance, which is how a composite holding it knows what built it.
+   * @example
+   * ```typescript
+   * const array = new CairoTypeFixedArray([1], '[core::integer::u8; 1]', cairoTypeStrategy);
+   * const result = array.dynamicSelector;
+   * // result = "CairoTypeFixedArray"
+   * ```
+   */
+  public readonly dynamicSelector = CairoTypeFixedArray.dynamicSelector;
+
+  /**
+   * The elements, each already built as the type the array declares.
+   * @example
+   * ```typescript
+   * const array = new CairoTypeFixedArray([1, 2, 3], '[core::integer::u8; 3]', cairoTypeStrategy);
+   * const result = array.content.length;
+   * // result = 3
+   * ```
+   */
+  public readonly content: CairoType[];
+
+  /**
+   * The abi type this array was built for.
+   * @example
+   * ```typescript
+   * const array = new CairoTypeFixedArray([1], '[core::integer::u8; 1]', cairoTypeStrategy);
+   * const result = array.arrayType;
+   * // result = "[core::integer::u8; 1]"
+   * ```
+   */
+  public readonly arrayType: string;
+
+  /**
+   * Build a fixed array, from values a caller passed or from the felts of a response.
+   *
+   * Elements are accepted raw, or already built and taken as they stand. An object is read by its
+   * values, which is the shape {@link CairoFixedArray.compile} produces.
+   * @param {unknown} content the elements, as an array, an object, or the response iterator
+   * @param {string} arrayType the abi type, `[T; length]`
+   * @param {AllowArray<CairoTypeStrategy>} parsingStrategy how to build each element
+   * @throws {Error} when the type is not a fixed array, when the element count does not match, or
+   * when the element type is one no strategy knows
+   * @example
+   * ```typescript
+   * const type = '[core::integer::u8; 2]';
+   * new CairoTypeFixedArray([1, 2], type, cairoTypeStrategy).toApiRequest();
+   * // ["1", "2"]
+   * new CairoTypeFixedArray(['0x1', '0x2'].values(), type, cairoTypeStrategy).toApiRequest();
+   * // ["1", "2"]
+   * ```
+   */
+  constructor(content: unknown, arrayType: string, parsingStrategy: AllowArray<CairoTypeStrategy>) {
+    this.arrayType = arrayType;
+    const strategies = Array.isArray(parsingStrategy) ? parsingStrategy : [parsingStrategy];
+
+    if (content && typeof content === 'object' && 'next' in content) {
+      this.content = CairoTypeFixedArray.parser(content as Iterator<string>, arrayType, strategies);
+      return;
+    }
+    if (content instanceof CairoTypeFixedArray) {
+      this.content = content.content;
+      this.arrayType = content.arrayType;
+      return;
+    }
+
+    CairoTypeFixedArray.validate(content, arrayType);
+    const elementType = CairoTypeFixedArray.getFixedArrayType(arrayType);
+    const build = findConstructor(strategies, elementType);
+    if (!build) {
+      throw new Error(`"${elementType}" is not a valid Cairo type`);
+    }
+    this.content = CairoTypeFixedArray.extractValuesArray(content).map((value) =>
+      isCairoType(value) ? value : build(value, strategies, elementType)
+    );
+  }
+
+  /**
+   * Read a fixed array off a response, one element after another.
+   *
+   * Nothing marks where it ends on the wire, so the type is what says how many to take.
+   * @param {Iterator<string>} responseIterator the response felts, positioned on this array
+   * @param {string} arrayType the abi type, `[T; length]`
+   * @param {CairoTypeStrategy[]} strategies how to build each element
+   * @returns {CairoType[]} the elements that were read
+   * @throws {Error} when the element type is one no strategy knows
+   * @example
+   * ```typescript
+   * // called from the constructor when it is handed an iterator
+   * const array = new CairoTypeFixedArray(
+   *   ['0x1', '0x2'].values(),
+   *   '[core::integer::u8; 2]',
+   *   cairoTypeStrategy
+   * );
+   * array.decompose(cairoTypeStrategy);
+   * // [1n, 2n]
+   * ```
+   */
+  private static parser(
+    responseIterator: Iterator<string>,
+    arrayType: string,
+    strategies: CairoTypeStrategy[]
+  ): CairoType[] {
+    const elementType = CairoTypeFixedArray.getFixedArrayType(arrayType);
+    const size = CairoTypeFixedArray.getFixedArraySize(arrayType);
+    const build = findConstructor(strategies, elementType);
+    if (!build) {
+      throw new Error(`No parser found for element type: ${elementType} in parsing strategy`);
+    }
+    return Array.from({ length: size }, () => build(responseIterator, strategies, elementType));
+  }
+
+  /**
+   * Line the elements up, whatever shape the input took.
+   * @param {unknown} input the elements, as an array or an object
+   * @returns {any[]} the elements in order
+   * @example
+   * ```typescript
+   * // called from the constructor: this is the shape CairoFixedArray.compile produces
+   * const array = new CairoTypeFixedArray(
+   *   { 0: 1, 1: 2 },
+   *   '[core::integer::u8; 2]',
+   *   cairoTypeStrategy
+   * );
+   * array.toApiRequest();
+   * // ["1", "2"]
+   * ```
+   */
+  private static extractValuesArray(input: unknown): any[] {
+    return Array.isArray(input) ? input : Object.values(input as object);
+  }
+
+  /**
+   * How many elements this type declares.
+   * @param {string} type the abi type to read
+   * @returns {number} the declared length
+   * @example
+   * ```typescript
+   * const result = CairoTypeFixedArray.getFixedArraySize('[core::integer::u32; 8]');
+   * // result = 8
+   * ```
+   */
+  static getFixedArraySize(type: string): number {
+    return CairoFixedArray.getFixedArraySize(type);
+  }
+
+  /**
+   * The type of the elements this array holds.
+   * @param {string} type the abi type to read
+   * @returns {string} the element type
+   * @example
+   * ```typescript
+   * const result = CairoTypeFixedArray.getFixedArrayType('[core::integer::u32; 8]');
+   * // result = "core::integer::u32"
+   * const result2 = CairoTypeFixedArray.getFixedArrayType('[[core::integer::u8; 2]; 3]');
+   * // result2 = "[core::integer::u8; 2]"     the inner array, kept whole
+   * ```
+   */
+  static getFixedArrayType(type: string): string {
+    return CairoFixedArray.getFixedArrayType(type);
+  }
+
+  /**
+   * Throw unless this input can be read as a fixed array of this type.
+   *
+   * The element count is checked here, unlike a dynamic array's : a fixed array declares its
+   * length in its type, so a list of the wrong size is the caller's mistake.
+   * @param {unknown} input the elements to check
+   * @param {string} type the abi type they are meant for
+   * @throws {Error} when the type is not a fixed array, when the input is neither an array nor an
+   * object, or when the element count does not match
+   * @example
+   * ```typescript
+   * CairoTypeFixedArray.validate([1, 2, 3], '[core::integer::u8; 3]'); // passes
+   * CairoTypeFixedArray.validate([1, 2], '[core::integer::u8; 3]');
+   * // throws Error("ABI type [core::integer::u8; 3]: expected 3 items, got 2 items")
+   * ```
+   */
+  static validate(input: unknown, type: string): void {
+    assert(
+      CairoTypeFixedArray.isAbiType(type),
+      `The type ${type} is not a Cairo fixed array. Needs [type; length].`
+    );
+    assert(
+      Array.isArray(input) || (typeof input === 'object' && input !== null),
+      `Invalid input: expected Array or Object, got ${typeof input}`
+    );
+    const values = CairoTypeFixedArray.extractValuesArray(input);
+    const size = CairoTypeFixedArray.getFixedArraySize(type);
+    assert(
+      values.length === size,
+      `ABI type ${type}: expected ${size} items, got ${values.length} items`
+    );
+  }
+
+  /**
+   * Can this input be read as a fixed array of this type?
+   *
+   * The non-throwing form of {@link CairoTypeFixedArray.validate}.
+   * @param {unknown} input the elements to test
+   * @param {string} type the abi type they are meant for
+   * @returns {boolean} true when the shape and the count both fit
+   * @example
+   * ```typescript
+   * const result = CairoTypeFixedArray.is([1, 2, 3], '[core::integer::u8; 3]');
+   * // result = true
+   * const result2 = CairoTypeFixedArray.is([1, 2], '[core::integer::u8; 3]');
+   * // result2 = false     (one element short)
+   * ```
+   */
+  static is(input: unknown, type: string): boolean {
+    try {
+      CairoTypeFixedArray.validate(input, type);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Is this abi type a fixed array?
+   *
+   * Answered by the public {@link CairoFixedArray}, so that both classes recognize the same
+   * strings while the encoding is being moved over.
+   * @param {string} type the abi type to test
+   * @returns {boolean} true for `[T; length]`, nested or not
+   * @example
+   * ```typescript
+   * const result = CairoTypeFixedArray.isAbiType('[core::integer::u32; 8]');
+   * // result = true
+   * const result2 = CairoTypeFixedArray.isAbiType('core::array::Array::<core::integer::u8>');
+   * // result2 = false     (a dynamic array carries its length on the wire)
+   * ```
+   */
+  static isAbiType(type: string): boolean {
+    return CairoFixedArray.isTypeFixedArray(type);
+  }
+
+  /**
+   * Serialize to the felts a contract call carries.
+   *
+   * The elements follow one another with nothing in front : the length is in the type, not on the
+   * wire — which is the whole difference with a dynamic array.
+   * @returns {string[]} the elements' felts, in order, flagged as compiled
+   * @example
+   * ```typescript
+   * const array = new CairoTypeFixedArray([1, 2, 3], '[core::integer::u8; 3]', cairoTypeStrategy);
+   * const result = array.toApiRequest();
+   * // result = ["1", "2", "3"]
+   * ```
+   */
+  public toApiRequest(): string[] {
+    return addCompiledFlag(this.content.flatMap((element) => element.toApiRequest()));
+  }
+
+  /**
+   * Read the array back as the plain values a caller reads.
+   * @param {AllowArray<CairoTypeStrategy>} strategyDecompose how to read each element back
+   * @returns {any[]} the elements' values, in order
+   * @throws {Error} when no strategy can read an element back
+   * @example
+   * ```typescript
+   * const array = new CairoTypeFixedArray([1, 2, 3], '[core::integer::u8; 3]', cairoTypeStrategy);
+   * const result = array.decompose(cairoTypeStrategy);
+   * // result = [1n, 2n, 3n]
+   * ```
+   */
+  public decompose(strategyDecompose: AllowArray<CairoTypeStrategy>): any[] {
+    const strategies = Array.isArray(strategyDecompose) ? strategyDecompose : [strategyDecompose];
+    const elementType = CairoTypeFixedArray.getFixedArrayType(this.arrayType);
+
+    return this.content.map((element) => {
+      const parserName =
+        'dynamicSelector' in element
+          ? (element as { dynamicSelector: string }).dynamicSelector
+          : elementType;
+      const read = findResponseParser(strategies, parserName);
+      if (!read) {
+        throw new Error(
+          `No response parser found for element type: ${parserName} in parsing strategy`
+        );
+      }
+      return read(element, strategies);
+    });
+  }
+}

--- a/src/utils/cairoDataTypes/cairoTypeOption.ts
+++ b/src/utils/cairoDataTypes/cairoTypeOption.ts
@@ -1,0 +1,419 @@
+import type { AllowArray } from '../../types';
+import assert from '../assert';
+import { isTypeOption } from '../calldata/cairo';
+import { CairoOption, CairoOptionVariant } from '../calldata/enum';
+import type { CairoTypeStrategy, VariantType } from '../calldata/parser/cairoTypeStrategy.type';
+import { addCompiledFlag } from '../helpers';
+import { getNext } from '../num';
+import { isUndefined } from '../typed';
+import { isCairoType, type CairoType } from './cairoType.interface';
+import { findConstructor, findResponseParser } from './strategyLookup';
+
+/**
+ * A Cairo `core::option::Option::<T>` : either a value, or nothing.
+ *
+ * On the wire it is an enum with two branches — `0` then the value for `Some`, `1` alone for
+ * `None`. Which branch is meant cannot be read off the value, since `Some(0)` and `None` would
+ * look alike, so building one from raw data asks for the variant.
+ *
+ * This is the internal shape. What a caller writes and reads back is {@link CairoOption}, and
+ * handing one of those here says the variant by itself.
+ * @example
+ * ```typescript
+ * const type = 'core::option::Option::<core::integer::u8>';
+ * new CairoTypeOption(7, type, cairoTypeStrategy, CairoOptionVariant.Some).toApiRequest();
+ * // ["0", "7"]
+ * new CairoTypeOption(undefined, type, cairoTypeStrategy, CairoOptionVariant.None).toApiRequest();
+ * // ["1"]
+ * ```
+ */
+export class CairoTypeOption {
+  /**
+   * The name this class is registered under in a strategy's `dynamicSelectors`.
+   * @example
+   * ```typescript
+   * const result = CairoTypeOption.dynamicSelector;
+   * // result = "CairoTypeOption"
+   * ```
+   */
+  static dynamicSelector = 'CairoTypeOption' as const;
+
+  /**
+   * The selector on the instance, which is how a composite holding it knows what built it.
+   * @example
+   * ```typescript
+   * const type = 'core::option::Option::<core::integer::u8>';
+   * const result = new CairoTypeOption(7, type, cairoTypeStrategy, CairoOptionVariant.Some)
+   *   .dynamicSelector;
+   * // result = "CairoTypeOption"
+   * ```
+   */
+  public readonly dynamicSelector = CairoTypeOption.dynamicSelector;
+
+  /**
+   * The value this option carries, or nothing at all when it is `None`.
+   * @example
+   * ```typescript
+   * const type = 'core::option::Option::<core::integer::u8>';
+   * const result = new CairoTypeOption(undefined, type, cairoTypeStrategy, CairoOptionVariant.None)
+   *   .content;
+   * // result = undefined
+   * ```
+   */
+  public readonly content: CairoType | undefined;
+
+  /**
+   * The abi type this option was built for.
+   * @example
+   * ```typescript
+   * const type = 'core::option::Option::<core::integer::u8>';
+   * const result = new CairoTypeOption(7, type, cairoTypeStrategy, CairoOptionVariant.Some)
+   *   .optionCairoType;
+   * // result = "core::option::Option::<core::integer::u8>"
+   * ```
+   */
+  public readonly optionCairoType: string;
+
+  /**
+   * Which of the two branches this option is on.
+   * @example
+   * ```typescript
+   * const type = 'core::option::Option::<core::integer::u8>';
+   * const result = new CairoTypeOption(7, type, cairoTypeStrategy, CairoOptionVariant.Some)
+   *   .isVariantSome;
+   * // result = true
+   * ```
+   */
+  public readonly isVariantSome: boolean;
+
+  /**
+   * Build an option, from a value a caller passed or from the felts of a response.
+   *
+   * A {@link CairoOption} says its own branch, so `variant` is not given with one — nor with the
+   * response iterator, which reads the branch off the wire. Anywhere else it is required.
+   *
+   * `subType` is what makes an option of options work. Handed a `CairoOption`, this constructor
+   * unwraps it and calls itself with what was inside, which for a nested option is another
+   * `CairoOption`; the flag stops that second call from unwrapping again and losing a level, and
+   * sends it to the strategy instead, where the inner type is what gets built.
+   * @param {unknown} content the value, a `CairoOption`, an instance already built, or the
+   * response iterator
+   * @param {string} optionCairoType the abi type, `core::option::Option::<T>`
+   * @param {AllowArray<CairoTypeStrategy>} parsingStrategy how to build the value
+   * @param {CairoOptionVariant | number} [variant] which branch, when the content does not say.
+   * Must be omitted when `content` is the response iterator.
+   * @param {boolean} [subType=false] true when called from the unwrapping of a nested
+   * `CairoOption`, which is the only caller that should set it
+   * @throws {Error} when the type is not an option, when the variant is missing, absurd, or
+   * contradicts the content
+   * @example
+   * ```typescript
+   * const type = 'core::option::Option::<core::integer::u8>';
+   * new CairoTypeOption(7, type, cairoTypeStrategy, CairoOptionVariant.Some).toApiRequest();
+   * // ["0", "7"]
+   * new CairoTypeOption(new CairoOption(CairoOptionVariant.Some, 7), type, cairoTypeStrategy).toApiRequest();
+   * // ["0", "7"]     the CairoOption says the branch
+   * new CairoTypeOption(['0x0', '0x20'].values(), type, cairoTypeStrategy).toApiRequest();
+   * // ["0", "32"]    read off a response
+   * ```
+   */
+  constructor(
+    content: unknown,
+    optionCairoType: string,
+    parsingStrategy: AllowArray<CairoTypeStrategy>,
+    variant?: CairoOptionVariant | number,
+    subType: boolean = false
+  ) {
+    this.optionCairoType = optionCairoType;
+    const strategies = Array.isArray(parsingStrategy) ? parsingStrategy : [parsingStrategy];
+
+    if (variant === CairoOptionVariant.Some && isUndefined(content)) {
+      throw new Error('"content" parameter has to be defined when Some variant is selected');
+    }
+    if (variant === CairoOptionVariant.None && !isUndefined(content)) {
+      throw new Error('"content" parameter has to be NOT defined when None variant is selected');
+    }
+
+    if (content && typeof content === 'object' && 'next' in content) {
+      assert(
+        isUndefined(variant),
+        'when "content" parameter is an iterator, do not define "variant" parameter.'
+      );
+      const variantFromIterator = Number(getNext(content as Iterator<string>));
+      switch (variantFromIterator) {
+        case CairoOptionVariant.Some:
+          this.content = CairoTypeOption.parser(
+            content as Iterator<string>,
+            optionCairoType,
+            strategies
+          );
+          break;
+        case CairoOptionVariant.None:
+          this.content = undefined;
+          break;
+        default:
+          throw new Error('Invalid Option variant in iterator.');
+      }
+      this.isVariantSome = variantFromIterator === CairoOptionVariant.Some;
+      return;
+    }
+
+    if (content instanceof CairoTypeOption) {
+      this.content = content.content;
+      this.isVariantSome = content.isVariantSome;
+      this.optionCairoType = content.optionCairoType;
+      return;
+    }
+
+    CairoTypeOption.validate(content, optionCairoType, variant);
+
+    if (isCairoType(content)) {
+      assert(
+        !isUndefined(variant),
+        '"variant" parameter is mandatory when creating a new Cairo option from a CairoType.'
+      );
+      this.content = content;
+      this.isVariantSome = variant === CairoOptionVariant.Some;
+      return;
+    }
+
+    if (content instanceof CairoOption) {
+      if (!subType) {
+        const option = new CairoTypeOption(
+          content.unwrap(),
+          optionCairoType,
+          strategies,
+          content.isSome() ? CairoOptionVariant.Some : CairoOptionVariant.None,
+          true // recursive sub-type
+        );
+        this.content = option.content;
+        this.isVariantSome = option.isVariantSome;
+        return;
+      }
+      assert(
+        !isUndefined(variant),
+        '"variant" parameter is mandatory when creating a new Cairo custom enum from a CairoOption.'
+      );
+    }
+
+    // not an iterator, not a CairoType -> so it is low level data (BigNumberish, array, object,
+    // Cairo Enum)
+    assert(
+      !isUndefined(variant),
+      '"variant" parameter is mandatory when creating a new Cairo option from a "CairoType" or raw data.'
+    );
+    this.isVariantSome = true;
+    switch (variant) {
+      case CairoOptionVariant.Some: {
+        const elementType = CairoTypeOption.getVariantSomeType(optionCairoType);
+        const build = findConstructor(strategies, elementType);
+        if (!build) {
+          throw new Error(`"${elementType}" is not a valid Cairo type`);
+        }
+        this.content = build(content, strategies, elementType);
+        break;
+      }
+      case CairoOptionVariant.None: {
+        this.isVariantSome = false;
+        this.content = undefined;
+        break;
+      }
+      default:
+        throw new Error('Invalid Option variant.');
+    }
+  }
+
+  /**
+   * Read the value of a `Some` off a response, the branch having already been consumed.
+   * @param {Iterator<string>} responseIterator the response felts, positioned on the value
+   * @param {string} someVariantCairoType the abi type, `core::option::Option::<T>`
+   * @param {CairoTypeStrategy[]} strategies how to build the value
+   * @returns {CairoType} the value that was read
+   * @throws {Error} when the value type is one no strategy knows
+   * @example
+   * ```typescript
+   * // called from the constructor when it is handed an iterator holding a Some
+   * const type = 'core::option::Option::<core::integer::u8>';
+   * new CairoTypeOption(['0x0', '0x20'].values(), type, cairoTypeStrategy).toApiRequest();
+   * // ["0", "32"]
+   * ```
+   */
+  private static parser(
+    responseIterator: Iterator<string>,
+    someVariantCairoType: string,
+    strategies: CairoTypeStrategy[]
+  ): CairoType {
+    const elementType = CairoTypeOption.getVariantSomeType(someVariantCairoType);
+    const build = findConstructor(strategies, elementType);
+    if (!build) {
+      throw new Error(`No parser found for element type: ${elementType} in parsing strategy`);
+    }
+    return build(responseIterator, strategies, elementType);
+  }
+
+  /**
+   * The type a `Some` carries, read out of the option type.
+   * @param {string} type the abi type to read
+   * @returns {string} the type between the angle brackets
+   * @throws {Error} when there is no type between brackets
+   * @example
+   * ```typescript
+   * const result = CairoTypeOption.getVariantSomeType('core::option::Option::<core::integer::u8>');
+   * // result = "core::integer::u8"
+   * ```
+   */
+  static getVariantSomeType(type: string): string {
+    const matchArray = type.match(/(?<=<).+(?=>)/);
+    if (matchArray === null) {
+      throw new Error(`ABI type ${type} do not includes a valid type of data.`);
+    }
+    return matchArray[0];
+  }
+
+  /**
+   * Throw unless this is an option type and this variant is one of its two branches.
+   *
+   * The value is not read here : what it is worth is the business of the type the option carries,
+   * and is checked when that value is built.
+   * @param {unknown} _input the value, which this does not read
+   * @param {string} type the abi type it is meant for
+   * @param {VariantType} variant the branch, when one was given
+   * @throws {Error} when the type is not an option, or the variant is neither 0 nor 1
+   * @example
+   * ```typescript
+   * const type = 'core::option::Option::<core::integer::u16>';
+   * CairoTypeOption.validate(200, type, CairoOptionVariant.Some); // passes
+   * CairoTypeOption.validate(200, type, 3);
+   * // throws Error("In Cairo option, only 0 or 1 variants are authorized.")
+   * ```
+   */
+  static validate(_input: unknown, type: string, variant: VariantType | undefined): void {
+    assert(
+      CairoTypeOption.isAbiType(type),
+      `The type ${type} is not a Cairo option. Needs core::option::Option::<type>.`
+    );
+    if (!isUndefined(variant)) {
+      const numberVariant = Number(variant);
+      assert(
+        [0, 1].includes(numberVariant),
+        'In Cairo option, only 0 or 1 variants are authorized.'
+      );
+    }
+  }
+
+  /**
+   * Can this be read as an option of this type, on this branch?
+   *
+   * The non-throwing form of {@link CairoTypeOption.validate}.
+   * @param {unknown} input the value to test
+   * @param {string} type the abi type it is meant for
+   * @param {VariantType} variant the branch
+   * @returns {boolean} true when the type and the variant both fit
+   * @example
+   * ```typescript
+   * const type = 'core::option::Option::<core::integer::u16>';
+   * const result = CairoTypeOption.is(200, type, CairoOptionVariant.Some);
+   * // result = true
+   * const result2 = CairoTypeOption.is(200, type, 3);
+   * // result2 = false
+   * ```
+   */
+  static is(input: unknown, type: string, variant: VariantType): boolean {
+    try {
+      CairoTypeOption.validate(input, type, variant);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Is this abi type an option?
+   * @param {string} type the abi type to test
+   * @returns {boolean} true for `core::option::Option::<T>`
+   * @example
+   * ```typescript
+   * const result = CairoTypeOption.isAbiType('core::option::Option::<core::integer::u16>');
+   * // result = true
+   * const result2 = CairoTypeOption.isAbiType('core::integer::u16');
+   * // result2 = false
+   * ```
+   */
+  static isAbiType(type: string): boolean {
+    return isTypeOption(type);
+  }
+
+  /**
+   * Serialize to the felts a contract call carries.
+   *
+   * The branch comes first, and the value only follows it on `Some` — a `None` is one felt, and
+   * that is the whole of it.
+   * @returns {string[]} the branch then the value, flagged as compiled
+   * @example
+   * ```typescript
+   * const type = 'core::option::Option::<core::integer::u8>';
+   * new CairoTypeOption(8, type, cairoTypeStrategy, CairoOptionVariant.Some).toApiRequest();
+   * // ["0", "8"]
+   * new CairoTypeOption(undefined, type, cairoTypeStrategy, CairoOptionVariant.None).toApiRequest();
+   * // ["1"]
+   * ```
+   */
+  public toApiRequest(): string[] {
+    const result: string[] = [this.isVariantSome ? '0' : '1'];
+    if (this.isVariantSome) {
+      result.push(...this.content!.toApiRequest());
+    }
+    return addCompiledFlag(result.flat());
+  }
+
+  /**
+   * Read the value of a `Some` back as the plain value a caller reads.
+   * @param {AllowArray<CairoTypeStrategy>} strategyDecompose how to read the value back
+   * @returns {any} the value the option carries
+   * @throws {Error} when no strategy can read it back
+   * @example
+   * ```typescript
+   * // called from decompose, and only on a Some
+   * const type = 'core::option::Option::<core::integer::u8>';
+   * const option = new CairoTypeOption(3, type, cairoTypeStrategy, CairoOptionVariant.Some);
+   * option.decompose(cairoTypeStrategy).unwrap();
+   * // 3n
+   * ```
+   */
+  private decomposeSome(strategyDecompose: AllowArray<CairoTypeStrategy>): any {
+    const content = this.content as CairoType;
+    const strategies = Array.isArray(strategyDecompose) ? strategyDecompose : [strategyDecompose];
+    const elementType = CairoTypeOption.getVariantSomeType(this.optionCairoType);
+    const parserName =
+      'dynamicSelector' in content
+        ? (content as { dynamicSelector: string }).dynamicSelector
+        : elementType;
+    const read = findResponseParser(strategies, parserName);
+    if (!read) {
+      throw new Error(
+        `No response parser found for element type: ${elementType} in parsing strategy`
+      );
+    }
+    return read(content, strategies);
+  }
+
+  /**
+   * Read the option back as the {@link CairoOption} a caller reads.
+   * @param {AllowArray<CairoTypeStrategy>} strategyDecompose how to read the value back
+   * @returns {CairoOption<any>} the option, on the branch it was built with
+   * @throws {Error} when no strategy can read the value back
+   * @example
+   * ```typescript
+   * const type = 'core::option::Option::<core::integer::u8>';
+   * const option = new CairoTypeOption(3, type, cairoTypeStrategy, CairoOptionVariant.Some);
+   * const result = option.decompose(cairoTypeStrategy).unwrap();
+   * // result = 3n
+   * ```
+   */
+  public decompose(strategyDecompose: AllowArray<CairoTypeStrategy>): CairoOption<any> {
+    if (this.isVariantSome) {
+      return new CairoOption<any>(CairoOptionVariant.Some, this.decomposeSome(strategyDecompose));
+    }
+    return new CairoOption<any>(CairoOptionVariant.None);
+  }
+}

--- a/src/utils/cairoDataTypes/cairoTypeResult.ts
+++ b/src/utils/cairoDataTypes/cairoTypeResult.ts
@@ -1,0 +1,392 @@
+import type { AllowArray } from '../../types';
+import assert from '../assert';
+import { isTypeResult } from '../calldata/cairo';
+import { CairoResult, CairoResultVariant } from '../calldata/enum';
+import type { CairoTypeStrategy, VariantType } from '../calldata/parser/cairoTypeStrategy.type';
+import { addCompiledFlag } from '../helpers';
+import { getNext } from '../num';
+import { isUndefined } from '../typed';
+import { isCairoType, type CairoType } from './cairoType.interface';
+import { findConstructor, findResponseParser } from './strategyLookup';
+import { CairoTuple } from './tuple';
+
+/**
+ * A Cairo `core::result::Result::<T, E>` : either an outcome or an error, each with its own type.
+ *
+ * On the wire it is an enum with two branches — `0` then the `Ok` value, `1` then the `Err` value.
+ * Unlike an option, both branches carry something, so a Result always has content; what cannot be
+ * guessed is which of the two types that content is, which is why building one from raw data asks
+ * for the variant.
+ *
+ * This is the internal shape. What a caller writes and reads back is {@link CairoResult}, and
+ * handing one here says the branch by itself.
+ * @example
+ * ```typescript
+ * const type = 'core::result::Result::<core::integer::u8, core::integer::u16>';
+ * new CairoTypeResult(8, type, cairoTypeStrategy, CairoResultVariant.Ok).toApiRequest();
+ * // ["0", "8"]
+ * new CairoTypeResult(8, type, cairoTypeStrategy, CairoResultVariant.Err).toApiRequest();
+ * // ["1", "8"]
+ * ```
+ */
+export class CairoTypeResult {
+  /**
+   * The name this class is registered under in a strategy's `dynamicSelectors`.
+   * @example
+   * ```typescript
+   * const result = CairoTypeResult.dynamicSelector;
+   * // result = "CairoTypeResult"
+   * ```
+   */
+  static dynamicSelector = 'CairoTypeResult' as const;
+
+  /**
+   * The selector on the instance, which is how a composite holding it knows what built it.
+   * @example
+   * ```typescript
+   * const type = 'core::result::Result::<core::integer::u8, core::integer::u16>';
+   * const result = new CairoTypeResult(8, type, cairoTypeStrategy, CairoResultVariant.Ok)
+   *   .dynamicSelector;
+   * // result = "CairoTypeResult"
+   * ```
+   */
+  public readonly dynamicSelector = CairoTypeResult.dynamicSelector;
+
+  /**
+   * The value this result carries, on whichever branch it is.
+   * @example
+   * ```typescript
+   * const type = 'core::result::Result::<core::integer::u8, core::integer::u16>';
+   * const result = new CairoTypeResult(8, type, cairoTypeStrategy, CairoResultVariant.Ok)
+   *   .content.toApiRequest();
+   * // result = ["8"]
+   * ```
+   */
+  public readonly content: CairoType;
+
+  /**
+   * The abi type this result was built for.
+   * @example
+   * ```typescript
+   * const type = 'core::result::Result::<core::integer::u8, core::integer::u16>';
+   * const result = new CairoTypeResult(8, type, cairoTypeStrategy, CairoResultVariant.Ok)
+   *   .resultCairoType;
+   * // result = "core::result::Result::<core::integer::u8, core::integer::u16>"
+   * ```
+   */
+  public readonly resultCairoType: string;
+
+  /**
+   * Which of the two branches this result is on.
+   * @example
+   * ```typescript
+   * const type = 'core::result::Result::<core::integer::u8, core::integer::u16>';
+   * const result = new CairoTypeResult(8, type, cairoTypeStrategy, CairoResultVariant.Err)
+   *   .isVariantOk;
+   * // result = false
+   * ```
+   */
+  public readonly isVariantOk: boolean;
+
+  /**
+   * Build a result, from a value a caller passed or from the felts of a response.
+   *
+   * A {@link CairoResult} says its own branch, so `variant` must be left out with one — as with
+   * the response iterator, and as with a `CairoTypeResult` being copied. Anywhere else it is
+   * required, since the two branches carry different types and the value alone does not say which.
+   *
+   * `subType` is what makes a result of results work. Handed a `CairoResult`, this constructor
+   * unwraps it and calls itself with what was inside, which for a nested result is another
+   * `CairoResult`; the flag stops that second call from unwrapping again and losing a level.
+   * @param {unknown} content the value, a `CairoResult`, an instance already built, or the
+   * response iterator. Never undefined : both branches carry something.
+   * @param {string} resultCairoType the abi type, `core::result::Result::<T, E>`
+   * @param {AllowArray<CairoTypeStrategy>} parsingStrategy how to build the value
+   * @param {CairoResultVariant | number} [variant] which branch, when the content does not say
+   * @param {boolean} [subType=false] true when called from the unwrapping of a nested
+   * `CairoResult`, which is the only caller that should set it
+   * @throws {Error} when the content is missing, the type is not a result, or the variant is
+   * missing, absurd, or given where the content already says it
+   * @example
+   * ```typescript
+   * const type = 'core::result::Result::<core::integer::u8, core::integer::u16>';
+   * new CairoTypeResult(8, type, cairoTypeStrategy, CairoResultVariant.Ok).toApiRequest();
+   * // ["0", "8"]
+   * new CairoTypeResult(new CairoResult(CairoResultVariant.Err, 8), type, cairoTypeStrategy).toApiRequest();
+   * // ["1", "8"]     the CairoResult says the branch
+   * new CairoTypeResult(['0x0', '0x64'].values(), type, cairoTypeStrategy).toApiRequest();
+   * // ["0", "100"]   read off a response
+   * ```
+   */
+  constructor(
+    content: unknown,
+    resultCairoType: string,
+    parsingStrategy: AllowArray<CairoTypeStrategy>,
+    variant?: CairoResultVariant | number,
+    subType: boolean = false
+  ) {
+    this.resultCairoType = resultCairoType;
+    const strategies = Array.isArray(parsingStrategy) ? parsingStrategy : [parsingStrategy];
+    assert(!isUndefined(content), '"content" parameter has to be defined.');
+    assert(content !== null, '"content" parameter has to be defined.');
+
+    if (typeof content === 'object' && 'next' in content) {
+      assert(
+        isUndefined(variant),
+        'when "content" parameter is an iterator, do not define "variant" parameter.'
+      );
+      const variantFromIterator = Number(getNext(content as Iterator<string>));
+      const activeVariantType =
+        CairoTypeResult.getVariantTypes(resultCairoType)[variantFromIterator];
+      this.content = CairoTypeResult.parser(
+        content as Iterator<string>,
+        activeVariantType,
+        strategies
+      );
+      this.isVariantOk = variantFromIterator === CairoResultVariant.Ok;
+      return;
+    }
+
+    if (content instanceof CairoTypeResult) {
+      assert(
+        isUndefined(variant),
+        'when "content" parameter is a CairoTypeResult, do not define "variant" parameter.'
+      );
+      this.content = content.content;
+      this.isVariantOk = content.isVariantOk;
+      this.resultCairoType = content.resultCairoType;
+      return;
+    }
+
+    CairoTypeResult.validate(content, resultCairoType, variant);
+
+    if (isCairoType(content)) {
+      assert(
+        !isUndefined(variant),
+        '"variant" parameter is mandatory when creating a new Cairo Result from a CairoType.'
+      );
+      this.content = content;
+      this.isVariantOk = variant === CairoResultVariant.Ok;
+      return;
+    }
+
+    if (content instanceof CairoResult && !subType) {
+      assert(
+        isUndefined(variant),
+        'when "content" parameter is a CairoResult and subType is false, do not define "variant" parameter.'
+      );
+      const variantForResult = content.isOk() ? CairoResultVariant.Ok : CairoResultVariant.Err;
+      const result = new CairoTypeResult(
+        content.unwrap(),
+        resultCairoType,
+        strategies,
+        variantForResult,
+        true // recursive sub-type
+      );
+      this.content = result.content;
+      this.isVariantOk = content.isOk();
+      return;
+    }
+
+    // not an iterator, not a CairoType -> so it is low level data (BigNumberish, array, object,
+    // Cairo Enum)
+    assert(
+      !isUndefined(variant),
+      '"variant" parameter is mandatory when creating a new Cairo Result from a Cairo Enum or raw data.'
+    );
+    this.isVariantOk = variant === CairoResultVariant.Ok;
+    const elementType = CairoTypeResult.getVariantTypes(resultCairoType)[variant];
+    const build = findConstructor(strategies, elementType);
+    if (!build) {
+      throw new Error(`"${elementType}" is not a valid Cairo type`);
+    }
+    this.content = build(content, strategies, elementType);
+  }
+
+  /**
+   * Read the value of the active branch off a response, the branch having already been consumed.
+   * @param {Iterator<string>} responseIterator the response felts, positioned on the value
+   * @param {string} elementType the type of the branch that was read
+   * @param {CairoTypeStrategy[]} strategies how to build the value
+   * @returns {CairoType} the value that was read
+   * @throws {Error} when the branch type is one no strategy knows
+   * @example
+   * ```typescript
+   * // called from the constructor when it is handed an iterator
+   * const type = 'core::result::Result::<core::integer::u8, core::integer::u16>';
+   * new CairoTypeResult(['0x0', '0x64'].values(), type, cairoTypeStrategy).toApiRequest();
+   * // ["0", "100"]
+   * ```
+   */
+  private static parser(
+    responseIterator: Iterator<string>,
+    elementType: string,
+    strategies: CairoTypeStrategy[]
+  ): CairoType {
+    const build = findConstructor(strategies, elementType);
+    if (!build) {
+      throw new Error(`No parser found for element type: ${elementType} in parsing strategy`);
+    }
+    return build(responseIterator, strategies, elementType);
+  }
+
+  /**
+   * The two types a result declares, in the order `[Ok, Err]`.
+   *
+   * The two are separated by a comma inside the angle brackets, which is exactly how a tuple
+   * writes its members — so the tuple splitter reads them, wrapped in parentheses for the
+   * occasion, rather than a second comma-scanner being written here.
+   * @param {string} type the abi type to read
+   * @returns {string[]} the `Ok` type then the `Err` type
+   * @throws {Error} when the type carries no bracketed pair, or does not hold exactly two types
+   * @example
+   * ```typescript
+   * const result = CairoTypeResult.getVariantTypes(
+   *   'core::result::Result::<core::integer::u8, core::integer::u16>'
+   * );
+   * // result = ["core::integer::u8", "core::integer::u16"]
+   * ```
+   */
+  static getVariantTypes(type: string): string[] {
+    const matchArray = type.match(/(?<=<).+(?=>)/);
+    if (matchArray === null) {
+      throw new Error(`ABI type ${type} do not includes 2 types enclosed in <>.`);
+    }
+    const subTypes = CairoTuple.getTupleElementTypes(`(${matchArray[0]})`).map((member) =>
+      typeof member === 'string' ? member : member.type
+    );
+    assert(
+      subTypes.length === 2,
+      `ABI type ${type} is not including 2 sub types. Found ${subTypes.length}.`
+    );
+    return subTypes;
+  }
+
+  /**
+   * Throw unless this is a result type and this variant is one of its two branches.
+   *
+   * The value is not read here : what it is worth is the business of the branch type, and is
+   * checked when that value is built.
+   * @param {unknown} _input the value, which this does not read
+   * @param {string} type the abi type it is meant for
+   * @param {VariantType} variant the branch, when one was given
+   * @throws {Error} when the type is not a result, or the variant is neither 0 nor 1
+   * @example
+   * ```typescript
+   * const type = 'core::result::Result::<core::integer::u8, core::integer::u16>';
+   * CairoTypeResult.validate(200, type, CairoResultVariant.Err); // passes
+   * CairoTypeResult.validate(200, type, 3);
+   * // throws Error("In Cairo Result, only 0 or 1 variants are authorized.")
+   * ```
+   */
+  static validate(_input: unknown, type: string, variant: VariantType | undefined): void {
+    assert(
+      CairoTypeResult.isAbiType(type),
+      `The type ${type} is not a Cairo Result. Needs core::result::Result::<type1, type2>.`
+    );
+    if (!isUndefined(variant)) {
+      const numberVariant = Number(variant);
+      assert(
+        [0, 1].includes(numberVariant),
+        'In Cairo Result, only 0 or 1 variants are authorized.'
+      );
+    }
+  }
+
+  /**
+   * Can this be read as a result of this type, on this branch?
+   *
+   * The non-throwing form of {@link CairoTypeResult.validate}.
+   * @param {unknown} input the value to test
+   * @param {string} type the abi type it is meant for
+   * @param {VariantType} variant the branch
+   * @returns {boolean} true when the type and the variant both fit
+   * @example
+   * ```typescript
+   * const type = 'core::result::Result::<core::integer::u8, core::integer::u16>';
+   * const result = CairoTypeResult.is(200, type, CairoResultVariant.Ok);
+   * // result = true
+   * const result2 = CairoTypeResult.is(200, 'wrong', 3);
+   * // result2 = false
+   * ```
+   */
+  static is(input: unknown, type: string, variant: VariantType): boolean {
+    try {
+      CairoTypeResult.validate(input, type, variant);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Is this abi type a result?
+   * @param {string} type the abi type to test
+   * @returns {boolean} true for `core::result::Result::<T, E>`
+   * @example
+   * ```typescript
+   * const result = CairoTypeResult.isAbiType(
+   *   'core::result::Result::<core::integer::u8, core::integer::u16>'
+   * );
+   * // result = true
+   * const result2 = CairoTypeResult.isAbiType('core::integer::u16');
+   * // result2 = false
+   * ```
+   */
+  static isAbiType(type: string): boolean {
+    return isTypeResult(type);
+  }
+
+  /**
+   * Serialize to the felts a contract call carries.
+   *
+   * The branch comes first, then the value — always, since both branches carry one.
+   * @returns {string[]} the branch then the value, flagged as compiled
+   * @example
+   * ```typescript
+   * const type = 'core::result::Result::<core::integer::u8, core::integer::u16>';
+   * new CairoTypeResult(8, type, cairoTypeStrategy, CairoResultVariant.Err).toApiRequest();
+   * // ["1", "8"]
+   * ```
+   */
+  public toApiRequest(): string[] {
+    const result: string[] = [this.isVariantOk ? '0' : '1'];
+    result.push(...this.content.toApiRequest());
+    return addCompiledFlag(result.flat());
+  }
+
+  /**
+   * Read the result back as the {@link CairoResult} a caller reads.
+   * @param {AllowArray<CairoTypeStrategy>} strategyDecompose how to read the value back
+   * @returns {CairoResult<any, any>} the result, on the branch it was built with
+   * @throws {Error} when no strategy can read the value back
+   * @example
+   * ```typescript
+   * const type = 'core::result::Result::<core::integer::u8, core::integer::u16>';
+   * const result = new CairoTypeResult(3, type, cairoTypeStrategy, CairoResultVariant.Ok);
+   * const value = result.decompose(cairoTypeStrategy).unwrap();
+   * // value = 3n
+   * ```
+   */
+  public decompose(strategyDecompose: AllowArray<CairoTypeStrategy>): CairoResult<any, any> {
+    const { content } = this;
+    const strategies = Array.isArray(strategyDecompose) ? strategyDecompose : [strategyDecompose];
+    const elementType = CairoTypeResult.getVariantTypes(this.resultCairoType)[
+      this.isVariantOk ? CairoResultVariant.Ok : CairoResultVariant.Err
+    ];
+    const parserName =
+      'dynamicSelector' in content
+        ? (content as { dynamicSelector: string }).dynamicSelector
+        : elementType;
+    const read = findResponseParser(strategies, parserName);
+    if (!read) {
+      throw new Error(
+        `No response parser found for element type: ${elementType} in parsing strategy`
+      );
+    }
+    return new CairoResult<any, any>(
+      this.isVariantOk ? CairoResultVariant.Ok : CairoResultVariant.Err,
+      read(content, strategies)
+    );
+  }
+}

--- a/src/utils/cairoDataTypes/classHash.ts
+++ b/src/utils/cairoDataTypes/classHash.ts
@@ -1,0 +1,182 @@
+import { BigNumberish, Literal } from '../../types';
+import { addHexPrefix } from '../encode';
+import { getNext } from '../num';
+import { isText } from '../shortString';
+import assert from '../assert';
+import { addCompiledFlag } from '../helpers';
+import { CairoFelt252 } from './felt';
+
+/**
+ * A Cairo `core::starknet::class_hash::ClassHash` : the hash identifying a declared class.
+ *
+ * On the wire it is a field element like any other, so what this class adds over
+ * {@link CairoFelt252} is the bound the RPC spec sets on it — 252 bits. That is wider than a
+ * felt252 is, so the two bounds each refuse values the other allows, and neither stands in for
+ * the other.
+ *
+ * A number, a bigint, a decimal string and a hexadecimal string are all read as the same number.
+ * Text is **not** an accepted input : a class hash spelled as words is a mistake, not a value.
+ * @example
+ * ```typescript
+ * // the same hash, reached three ways
+ * new CairoClassHash('0x1234').toBigInt(); // 4660n
+ * new CairoClassHash(4660).toBigInt(); //    4660n
+ * new CairoClassHash('4660').toBigInt(); //  4660n
+ * ```
+ */
+export class CairoClassHash {
+  /**
+   * The hash, always as a bigint.
+   * @example
+   * ```typescript
+   * const result = new CairoClassHash('0x1234').data;
+   * // result = 4660n
+   * ```
+   */
+  data: bigint;
+
+  /**
+   * The abi type this class serializes.
+   * @example
+   * ```typescript
+   * const result = CairoClassHash.abiSelector;
+   * // result = "core::starknet::class_hash::ClassHash"
+   * ```
+   */
+  static abiSelector = Literal.ClassHash;
+
+  /**
+   * Build from a number or a numeric string, refusing text and anything wider than 252 bits.
+   * @param {BigNumberish | boolean} data the hash to carry, within [0, 2^252 - 1]
+   * @throws {Error} when the value is text, is not a felt252 input, or is out of the ClassHash range
+   * @example
+   * ```typescript
+   * const result = new CairoClassHash('0x1234').toApiRequest();
+   * // result = ["4660"]
+   * ```
+   */
+  constructor(data: BigNumberish | boolean | unknown) {
+    CairoClassHash.validate(data);
+    this.data = new CairoFelt252(data).toBigInt();
+  }
+
+  /**
+   * Serialize to the single felt a contract call carries.
+   * @returns {string[]} one decimal-string felt, flagged as compiled
+   * @example
+   * ```typescript
+   * const result = new CairoClassHash('0x1234').toApiRequest();
+   * // result = ["4660"]
+   * ```
+   */
+  toApiRequest(): string[] {
+    return addCompiledFlag([this.toBigInt().toString()]);
+  }
+
+  /**
+   * The hash as a number.
+   * @returns {bigint} the number this hash holds
+   * @example
+   * ```typescript
+   * const result = new CairoClassHash('0x1234').toBigInt();
+   * // result = 4660n
+   * ```
+   */
+  toBigInt(): bigint {
+    return this.data;
+  }
+
+  /**
+   * The hash in hexadecimal, without padding.
+   *
+   * The 64 hex digits a class hash is usually written with are not restored here : leading zeros
+   * are dropped, as they are everywhere else in the library.
+   * @returns {string} the hash as a 0x-prefixed hex string
+   * @example
+   * ```typescript
+   * const result = new CairoClassHash(4660).toHexString();
+   * // result = "0x1234"
+   * const result2 = new CairoClassHash('0x0034').toHexString();
+   * // result2 = "0x34"     (four digits in, two out)
+   * ```
+   */
+  toHexString(): string {
+    return addHexPrefix(this.toBigInt().toString(16));
+  }
+
+  /**
+   * Throw unless the value can be carried by a ClassHash.
+   *
+   * Text is refused first, then the value is read as a felt252 — which is what refuses a null, an
+   * object or an unsupported type, and what bounds the value. There is no narrower bound to add:
+   * a class hash is a hash output, so any field element is one.
+   * @param {BigNumberish | boolean} data the value to check
+   * @throws {Error} when the value is text, is not a felt252 input, or is outside the field
+   * @example
+   * ```typescript
+   * CairoClassHash.validate('0x1234'); // passes
+   * CairoClassHash.validate('abc');
+   * // throws Error("Invalid input: a ClassHash cannot be built from text")
+   * ```
+   */
+  static validate(data: BigNumberish | boolean | unknown): void {
+    assert(!isText(data), 'Invalid input: a ClassHash cannot be built from text');
+    // the field is the only bound a class hash has, so a felt252's own check is the whole of it
+    CairoFelt252.validate(data);
+  }
+
+  /**
+   * Can this value be carried by a ClassHash?
+   *
+   * The non-throwing form of {@link CairoClassHash.validate}, so it answers false for every input
+   * that one refuses, whatever the reason.
+   * @param {BigNumberish | boolean} data the value to test
+   * @returns {boolean} true when the value fits in a ClassHash
+   * @example
+   * ```typescript
+   * const result = CairoClassHash.is('0x1234');
+   * // result = true
+   * const result2 = CairoClassHash.is('abc');
+   * // result2 = false     (text, not a number)
+   * ```
+   */
+  static is(data: BigNumberish | boolean | unknown): boolean {
+    try {
+      CairoClassHash.validate(data);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Is this abi type the one this class serializes?
+   * @param {string} abiType the abi type to test
+   * @returns {boolean} true for `core::starknet::class_hash::ClassHash`
+   * @example
+   * ```typescript
+   * const result = CairoClassHash.isAbiType('core::starknet::class_hash::ClassHash');
+   * // result = true
+   * const result2 = CairoClassHash.isAbiType('core::felt252');
+   * // result2 = false
+   * ```
+   */
+  static isAbiType(abiType: string): boolean {
+    return abiType === CairoClassHash.abiSelector;
+  }
+
+  /**
+   * Read one ClassHash off a contract response, advancing the iterator past it.
+   * @param {Iterator<string>} responseIterator the response felts, positioned on this hash
+   * @returns {CairoClassHash} the hash that was read
+   * @example
+   * ```typescript
+   * const response = ['0x1234'];
+   * const result = CairoClassHash.factoryFromApiResponse(response.values()).toBigInt();
+   * // result = 4660n
+   * ```
+   */
+  static factoryFromApiResponse(responseIterator: Iterator<string>): CairoClassHash {
+    return new CairoClassHash(getNext(responseIterator));
+  }
+}

--- a/src/utils/cairoDataTypes/contractAddress.ts
+++ b/src/utils/cairoDataTypes/contractAddress.ts
@@ -1,0 +1,191 @@
+import { BigNumberish, Literal } from '../../types';
+import { RANGE_CONTRACT_ADDRESS } from '../../global/constants';
+import { addHexPrefix } from '../encode';
+import { getNext } from '../num';
+import { isText } from '../shortString';
+import assert from '../assert';
+import { addCompiledFlag } from '../helpers';
+import { CairoFelt252 } from './felt';
+
+/**
+ * A Cairo `core::starknet::contract_address::ContractAddress` : the address of a deployed contract.
+ *
+ * On the wire it is a field element like any other, so what this class adds over
+ * {@link CairoFelt252} is the narrower bound an address has : `ADDR_BOUND`, which is what an
+ * address is computed modulo and what `validateAndParseAddress` already refuses to exceed. The
+ * 252 bits the RPC spec states are looser than both, and never what binds.
+ *
+ * A number, a bigint, a decimal string and a hexadecimal string are all read as the same number.
+ * Text is **not** an accepted input : an address spelled as words is a mistake, not a value.
+ * @example
+ * ```typescript
+ * // the same address, reached three ways
+ * new CairoContractAddress('0x1234').toBigInt(); // 4660n
+ * new CairoContractAddress(4660).toBigInt(); //    4660n
+ * new CairoContractAddress('4660').toBigInt(); //  4660n
+ * ```
+ */
+export class CairoContractAddress {
+  /**
+   * The address, always as a bigint.
+   * @example
+   * ```typescript
+   * const result = new CairoContractAddress('0x1234').data;
+   * // result = 4660n
+   * ```
+   */
+  data: bigint;
+
+  /**
+   * The abi type this class serializes.
+   * @example
+   * ```typescript
+   * const result = CairoContractAddress.abiSelector;
+   * // result = "core::starknet::contract_address::ContractAddress"
+   * ```
+   */
+  static abiSelector = Literal.ContractAddress;
+
+  /**
+   * Build from a number or a numeric string, refusing text and anything wider than 252 bits.
+   * @param {BigNumberish | boolean} data the address to carry, within [0, 2^252 - 1]
+   * @throws {Error} when the value is text, is not a felt252 input, or is out of range
+   * @example
+   * ```typescript
+   * const result = new CairoContractAddress('0x1234').toApiRequest();
+   * // result = ["4660"]
+   * ```
+   */
+  constructor(data: BigNumberish | boolean | unknown) {
+    CairoContractAddress.validate(data);
+    this.data = new CairoFelt252(data).toBigInt();
+  }
+
+  /**
+   * Serialize to the single felt a contract call carries.
+   * @returns {string[]} one decimal-string felt, flagged as compiled
+   * @example
+   * ```typescript
+   * const result = new CairoContractAddress('0x1234').toApiRequest();
+   * // result = ["4660"]
+   * ```
+   */
+  toApiRequest(): string[] {
+    return addCompiledFlag([this.toBigInt().toString()]);
+  }
+
+  /**
+   * The address as a number.
+   * @returns {bigint} the number this address holds
+   * @example
+   * ```typescript
+   * const result = new CairoContractAddress('0x1234').toBigInt();
+   * // result = 4660n
+   * ```
+   */
+  toBigInt(): bigint {
+    return this.data;
+  }
+
+  /**
+   * The address in hexadecimal, without padding.
+   *
+   * The 64 hex digits an address is usually written with are not restored here : leading zeros
+   * are dropped, as they are everywhere else in the library.
+   * @returns {string} the address as a 0x-prefixed hex string
+   * @example
+   * ```typescript
+   * const result = new CairoContractAddress(4660).toHexString();
+   * // result = "0x1234"
+   * const result2 = new CairoContractAddress('0x0034').toHexString();
+   * // result2 = "0x34"     (four digits in, two out)
+   * ```
+   */
+  toHexString(): string {
+    return addHexPrefix(this.toBigInt().toString(16));
+  }
+
+  /**
+   * Throw unless the value can be carried by a ContractAddress.
+   *
+   * Text is refused first, then the value is read as a felt252 — which is what refuses a null, an
+   * object or an unsupported type — and finally checked against the bound an address has, which
+   * is narrower than the field.
+   * @param {BigNumberish | boolean} data the value to check
+   * @throws {Error} when the value is text, is not a felt252 input, or is out of range
+   * @example
+   * ```typescript
+   * CairoContractAddress.validate('0x1234'); // passes
+   * CairoContractAddress.validate('abc');
+   * // throws Error("Invalid input: a ContractAddress cannot be built from text")
+   * CairoContractAddress.validate(2n ** 251n);
+   * // throws Error("Value is out of ContractAddress range [0, 3618502788666131106986593281521497120414687020801267626233049500247285300991]")
+   * ```
+   */
+  static validate(data: BigNumberish | boolean | unknown): void {
+    assert(!isText(data), 'Invalid input: a ContractAddress cannot be built from text');
+
+    const value = new CairoFelt252(data).toBigInt();
+    assert(
+      value >= RANGE_CONTRACT_ADDRESS.min && value <= RANGE_CONTRACT_ADDRESS.max,
+      `Value is out of ContractAddress range [${RANGE_CONTRACT_ADDRESS.min}, ${RANGE_CONTRACT_ADDRESS.max}]`
+    );
+  }
+
+  /**
+   * Can this value be carried by a ContractAddress?
+   *
+   * The non-throwing form of {@link CairoContractAddress.validate}, so it answers false for every
+   * input that one refuses, whatever the reason.
+   * @param {BigNumberish | boolean} data the value to test
+   * @returns {boolean} true when the value fits in a ContractAddress
+   * @example
+   * ```typescript
+   * const result = CairoContractAddress.is('0x1234');
+   * // result = true
+   * const result2 = CairoContractAddress.is('abc');
+   * // result2 = false     (text, not a number)
+   * ```
+   */
+  static is(data: BigNumberish | boolean | unknown): boolean {
+    try {
+      CairoContractAddress.validate(data);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Is this abi type the one this class serializes?
+   * @param {string} abiType the abi type to test
+   * @returns {boolean} true for `core::starknet::contract_address::ContractAddress`
+   * @example
+   * ```typescript
+   * const result = CairoContractAddress.isAbiType(
+   *   'core::starknet::contract_address::ContractAddress'
+   * );
+   * // result = true
+   * const result2 = CairoContractAddress.isAbiType('core::felt252');
+   * // result2 = false
+   * ```
+   */
+  static isAbiType(abiType: string): boolean {
+    return abiType === CairoContractAddress.abiSelector;
+  }
+
+  /**
+   * Read one ContractAddress off a contract response, advancing the iterator past it.
+   * @param {Iterator<string>} responseIterator the response felts, positioned on this address
+   * @returns {CairoContractAddress} the address that was read
+   * @example
+   * ```typescript
+   * const response = ['0x1234'];
+   * const result = CairoContractAddress.factoryFromApiResponse(response.values()).toBigInt();
+   * // result = 4660n
+   * ```
+   */
+  static factoryFromApiResponse(responseIterator: Iterator<string>): CairoContractAddress {
+    return new CairoContractAddress(getNext(responseIterator));
+  }
+}

--- a/src/utils/cairoDataTypes/index.ts
+++ b/src/utils/cairoDataTypes/index.ts
@@ -18,3 +18,5 @@ export * from './uint32';
 export * from './bool';
 export * from './ethAddress';
 export * from './secp256k1Point';
+export * from './classHash';
+export * from './contractAddress';

--- a/src/utils/cairoDataTypes/nonZero.ts
+++ b/src/utils/cairoDataTypes/nonZero.ts
@@ -1,0 +1,330 @@
+import type { AllowArray } from '../../types';
+import assert from '../assert';
+import { getArrayType, isTypeFelt, isTypeNonZero, isTypeUint } from '../calldata/cairo';
+import type { CairoTypeStrategy } from '../calldata/parser/cairoTypeStrategy.type';
+import { addCompiledFlag } from '../helpers';
+import { CairoFelt252 } from './felt';
+import { CairoUint8 } from './uint8';
+import { CairoUint16 } from './uint16';
+import { CairoUint32 } from './uint32';
+import { CairoUint64 } from './uint64';
+import { CairoUint96 } from './uint96';
+import { CairoUint128 } from './uint128';
+import { CairoUint256 } from './uint256';
+import { CairoUint512 } from './uint512';
+import { isCairoType, type CairoType } from './cairoType.interface';
+import { findConstructor, findResponseParser } from './strategyLookup';
+
+/**
+ * The classes a NonZero may hold, which are the ones that carry a number it can compare to zero.
+ *
+ * Cairo restricts `NonZero` to the purely numeric types and to `EcPoint`; the latter carries no
+ * `Serde` implementation, so it never appears in an abi. `u512` is left out because Cairo does not
+ * support it here, and the signed integers because `NonZero::<i*>` did not work in Cairo 2.6.3.
+ */
+const NON_ZERO_TYPES = [
+  CairoUint8,
+  CairoUint16,
+  CairoUint32,
+  CairoUint64,
+  CairoUint96,
+  CairoUint128,
+  CairoUint256,
+  CairoFelt252,
+] as const;
+
+/**
+ * A Cairo `core::zeroable::NonZero::<T>` : a value of type `T` that is guaranteed not to be zero.
+ *
+ * It adds nothing to the wire — a `NonZero<u8>` is the felt a `u8` is. Its whole job is the check
+ * it performs while being built, which is why a contract can then divide by it without a guard.
+ *
+ * Only the types Cairo allows are accepted : the unsigned integers up to `u256`, and `felt252`.
+ * @example
+ * ```typescript
+ * const nonZero = new CairoNonZero(2, 'core::zeroable::NonZero::<core::integer::u8>', cairoTypeStrategy);
+ * nonZero.toApiRequest(); //                  ["2"]     no wrapper felt
+ * nonZero.decompose(cairoTypeStrategy); //    2n
+ * ```
+ */
+export class CairoNonZero {
+  /**
+   * The name this class is registered under in a strategy's `dynamicSelectors`.
+   * @example
+   * ```typescript
+   * const result = CairoNonZero.dynamicSelector;
+   * // result = "CairoNonZero"
+   * ```
+   */
+  static dynamicSelector = 'CairoNonZero' as const;
+
+  /**
+   * The selector on the instance, which is how a composite holding it knows what built it.
+   * @example
+   * ```typescript
+   * const type = 'core::zeroable::NonZero::<core::integer::u8>';
+   * const result = new CairoNonZero(2, type, cairoTypeStrategy).dynamicSelector;
+   * // result = "CairoNonZero"
+   * ```
+   */
+  public readonly dynamicSelector = CairoNonZero.dynamicSelector;
+
+  /**
+   * The value, built as the type the `NonZero` wraps.
+   * @example
+   * ```typescript
+   * const type = 'core::zeroable::NonZero::<core::integer::u8>';
+   * const result = new CairoNonZero(2, type, cairoTypeStrategy).content.toApiRequest();
+   * // result = ["2"]
+   * ```
+   */
+  public readonly content: CairoType;
+
+  /**
+   * The abi type this value was built for, brackets included.
+   * @example
+   * ```typescript
+   * const type = 'core::zeroable::NonZero::<core::integer::u8>';
+   * const result = new CairoNonZero(2, type, cairoTypeStrategy).contentType;
+   * // result = "core::zeroable::NonZero::<core::integer::u8>"
+   * ```
+   */
+  public readonly contentType: string;
+
+  /**
+   * Build a non-zero value, from what a caller passed or from the felts of a response.
+   *
+   * A value given raw is built as the wrapped type and then checked against zero. A value already
+   * built is taken as it stands, and a response is read as the wrapped type would be — in neither
+   * case is zero rejected, since what a node answers is not the caller's mistake to catch.
+   * @param {unknown} content the value, an instance already built, or the response iterator
+   * @param {string} type the abi type, `core::zeroable::NonZero::<T>`
+   * @param {AllowArray<CairoTypeStrategy>} parsingStrategy how to build the value
+   * @throws {Error} when the type is not a NonZero, when the wrapped type is one Cairo does not
+   * allow there, or when a value given raw is zero
+   * @example
+   * ```typescript
+   * const type = 'core::zeroable::NonZero::<core::integer::u8>';
+   * new CairoNonZero(2, type, cairoTypeStrategy).toApiRequest(); //  ["2"]
+   * new CairoNonZero(['0x9'].values(), type, cairoTypeStrategy).toApiRequest(); //  ["9"]
+   * ```
+   */
+  constructor(content: unknown, type: string, parsingStrategy: AllowArray<CairoTypeStrategy>) {
+    this.contentType = type;
+    const strategies = Array.isArray(parsingStrategy) ? parsingStrategy : [parsingStrategy];
+
+    if (content && typeof content === 'object' && 'next' in content) {
+      this.content = CairoNonZero.parser(content as Iterator<string>, type, strategies);
+      return;
+    }
+    if (content instanceof CairoNonZero) {
+      this.content = content.content;
+      this.contentType = content.contentType;
+      return;
+    }
+
+    CairoNonZero.validate(content, type);
+    const contentType = CairoNonZero.getNonZeroType(type);
+
+    if (isCairoType(content)) {
+      this.content = content;
+      return;
+    }
+
+    const build = findConstructor(strategies, contentType);
+    if (!build) {
+      throw new Error(`"${contentType}" is not a valid Cairo type`);
+    }
+    const cairoInstance = build(content, strategies, contentType);
+    this.validateValue(cairoInstance);
+    this.content = cairoInstance;
+  }
+
+  /**
+   * Read the wrapped value off a response.
+   *
+   * A NonZero adds no felt of its own, so this reads exactly what the wrapped type reads.
+   * @param {Iterator<string>} responseIterator the response felts, positioned on the value
+   * @param {string} nonZeroType the abi type, `core::zeroable::NonZero::<T>`
+   * @param {CairoTypeStrategy[]} strategies how to build the value
+   * @returns {CairoType} the value that was read
+   * @throws {Error} when the wrapped type is one no strategy knows
+   * @example
+   * ```typescript
+   * // called from the constructor when it is handed an iterator
+   * const type = 'core::zeroable::NonZero::<core::integer::u8>';
+   * new CairoNonZero(['0x9'].values(), type, cairoTypeStrategy).toApiRequest();
+   * // ["9"]
+   * ```
+   */
+  private static parser(
+    responseIterator: Iterator<string>,
+    nonZeroType: string,
+    strategies: CairoTypeStrategy[]
+  ): CairoType {
+    const elementType = CairoNonZero.getNonZeroType(nonZeroType);
+    const build = findConstructor(strategies, elementType);
+    if (!build) {
+      throw new Error(`No parser found for element type: ${elementType} in parsing strategy`);
+    }
+    return build(responseIterator, strategies, elementType);
+  }
+
+  /**
+   * The type a NonZero wraps.
+   * @param {string} type the abi type to read
+   * @returns {string} the type between the angle brackets
+   * @example
+   * ```typescript
+   * const result = CairoNonZero.getNonZeroType('core::zeroable::NonZero::<core::integer::u8>');
+   * // result = "core::integer::u8"
+   * ```
+   */
+  static getNonZeroType(type: string): string {
+    return getArrayType(type);
+  }
+
+  /**
+   * Throw unless this is a NonZero of a type Cairo allows there.
+   *
+   * The value is not read here : whether it is zero is checked once it has been built, since that
+   * is what turns `'0x0'` and `0` into the same thing.
+   * @param {unknown} input the value, which this does not read
+   * @param {string} type the abi type it is meant for
+   * @throws {Error} when the type is not a NonZero, or wraps a type Cairo does not allow
+   * @example
+   * ```typescript
+   * CairoNonZero.validate(1, 'core::zeroable::NonZero::<core::integer::u8>'); // passes
+   * CairoNonZero.validate(1, 'core::zeroable::NonZero::<core::integer::u512>');
+   * // throws Error("Validate: core::integer::u512 type is not authorized for NonZero type.")
+   * ```
+   */
+  static validate(input: unknown, type: string): void {
+    assert(
+      CairoNonZero.isAbiType(type),
+      `The type ${type} is not a Cairo Non Zero. Needs core::zeroable::NonZero::<T>.`
+    );
+    // "NonZero is only supported for purely numeric types (u*, i* and felt252) and EcPoint."
+    // Ori Ziv, 8 April 2024 — https://t.me/sncorestars/11902/45433
+    // EcPoint carries no Serde, so it never appears in an abi; u512 is not compatible; and
+    // core::zeroable::NonZero::<i*> did not work in Cairo 2.6.3. What is left is u8 to u256 and
+    // felt252.
+    const baseType = CairoNonZero.getNonZeroType(type);
+    assert(
+      (isTypeUint(baseType) && baseType !== CairoUint512.abiSelector) || isTypeFelt(baseType),
+      `Validate: ${baseType} type is not authorized for NonZero type.`
+    );
+  }
+
+  /**
+   * Throw unless this built value is one a NonZero may hold, and is not zero.
+   *
+   * Only a value given raw goes through here : one already built is taken as it stands, and a
+   * response is read as it comes.
+   * @param {CairoType} cairoInstance the value that was just built
+   * @throws {Error} when the value is zero, or of a class a NonZero may not hold
+   * @example
+   * ```typescript
+   * // called from the constructor
+   * const type = 'core::zeroable::NonZero::<core::integer::u8>';
+   * new CairoNonZero(0, type, cairoTypeStrategy);
+   * // throws Error("ValidateValue: value 0 is not authorized in NonZero type.")
+   * ```
+   */
+  validateValue(cairoInstance: CairoType): void {
+    const isNumeric = NON_ZERO_TYPES.some((cairoType) => cairoInstance instanceof cairoType);
+    if (!isNumeric) {
+      throw new Error(`ValidateValue: ${cairoInstance} is not authorized for NonZero type.`);
+    }
+    assert(
+      (cairoInstance as CairoType & { toBigInt: Function }).toBigInt() > 0n,
+      'ValidateValue: value 0 is not authorized in NonZero type.'
+    );
+  }
+
+  /**
+   * Can this be read as a NonZero of this type?
+   *
+   * The non-throwing form of {@link CairoNonZero.validate}, so it says nothing about whether the
+   * value is zero.
+   * @param {unknown} input the value to test
+   * @param {string} type the abi type it is meant for
+   * @returns {boolean} true when the type is a NonZero of an allowed type
+   * @example
+   * ```typescript
+   * const result = CairoNonZero.is(1, 'core::zeroable::NonZero::<core::integer::u8>');
+   * // result = true
+   * const result2 = CairoNonZero.is(1, 'core::integer::u8');
+   * // result2 = false
+   * ```
+   */
+  static is(input: unknown, type: string): boolean {
+    try {
+      CairoNonZero.validate(input, type);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Is this abi type a NonZero?
+   * @param {string} type the abi type to test
+   * @returns {boolean} true for `core::zeroable::NonZero::<T>`
+   * @example
+   * ```typescript
+   * const result = CairoNonZero.isAbiType('core::zeroable::NonZero::<core::integer::u8>');
+   * // result = true
+   * const result2 = CairoNonZero.isAbiType('core::integer::u8');
+   * // result2 = false
+   * ```
+   */
+  static isAbiType(type: string): boolean {
+    return isTypeNonZero(type);
+  }
+
+  /**
+   * Serialize to the felts a contract call carries.
+   *
+   * Exactly the felts of the wrapped value : a NonZero is a promise about a value, not a shape
+   * around it.
+   * @returns {string[]} the wrapped value's felts, flagged as compiled
+   * @example
+   * ```typescript
+   * const type = 'core::zeroable::NonZero::<core::integer::u8>';
+   * const result = new CairoNonZero(2, type, cairoTypeStrategy).toApiRequest();
+   * // result = ["2"]
+   * ```
+   */
+  public toApiRequest(): string[] {
+    return addCompiledFlag(this.content.toApiRequest());
+  }
+
+  /**
+   * Read the wrapped value back as the plain value a caller reads.
+   * @param {AllowArray<CairoTypeStrategy>} strategyDecompose how to read the value back
+   * @returns {any} the value the NonZero wraps
+   * @throws {Error} when no strategy can read it back
+   * @example
+   * ```typescript
+   * const type = 'core::zeroable::NonZero::<core::integer::u8>';
+   * const result = new CairoNonZero(2, type, cairoTypeStrategy).decompose(cairoTypeStrategy);
+   * // result = 2n
+   * ```
+   */
+  public decompose(strategyDecompose: AllowArray<CairoTypeStrategy>): any {
+    const strategies = Array.isArray(strategyDecompose) ? strategyDecompose : [strategyDecompose];
+    const elementType = CairoNonZero.getNonZeroType(this.contentType);
+    const parserName =
+      'dynamicSelector' in this.content
+        ? (this.content as { dynamicSelector: string }).dynamicSelector
+        : elementType;
+    const read = findResponseParser(strategies, parserName);
+    if (!read) {
+      throw new Error(
+        `No response parser found for element type: ${elementType} in parsing strategy`
+      );
+    }
+    return read(this.content, strategies);
+  }
+}

--- a/src/utils/cairoDataTypes/strategyLookup.ts
+++ b/src/utils/cairoDataTypes/strategyLookup.ts
@@ -1,0 +1,66 @@
+import type { CairoTypeStrategy } from '../calldata/parser/cairoTypeStrategy.type';
+
+/**
+ * Find what builds a given abi type, among the strategies given, or nothing.
+ *
+ * A type is looked up twice : first among the constructors keyed by an exact abi type, which is
+ * how every leaf is registered, then among the dynamic selectors, which recognize the composite
+ * shapes no single string can key — an array, a tuple, an option all write their element type
+ * into their own name.
+ *
+ * Every composite needs this, and needs it identically, which is why it lives here rather than in
+ * each of them.
+ * @param {CairoTypeStrategy[]} strategies the strategies to search, in order
+ * @param {string} type the abi type to build
+ * @returns {Function | undefined} the constructor, or undefined when no strategy knows the type
+ * @example
+ * ```typescript
+ * const build = findConstructor([cairoTypeStrategy], 'core::integer::u8');
+ * build?.(44, [cairoTypeStrategy]).toApiRequest();
+ * // ["44"]
+ * const missing = findConstructor([cairoTypeStrategy], 'core::foo::Bar');
+ * // missing = undefined
+ * ```
+ */
+export function findConstructor(
+  strategies: CairoTypeStrategy[],
+  type: string
+): CairoTypeStrategy['constructors'][string] | undefined {
+  const direct = strategies.find((strategy) => strategy.constructors[type]);
+  if (direct) {
+    return direct.constructors[type];
+  }
+  const dynamic = strategies
+    .flatMap((strategy) =>
+      Object.entries(strategy.dynamicSelectors).map(([name, matches]) => ({
+        strategy,
+        name,
+        matches,
+      }))
+    )
+    .find((entry) => entry.matches(type) && entry.strategy.constructors[entry.name]);
+  return dynamic ? dynamic.strategy.constructors[dynamic.name] : undefined;
+}
+
+/**
+ * Find what reads a built Cairo type back, among the strategies given, or nothing.
+ *
+ * The lookup is by one name only, and the caller decides which : the abi type for a leaf, and
+ * what built it — its `dynamicSelector` — for a composite, since that is what knows how to walk
+ * the elements it holds.
+ * @param {CairoTypeStrategy[]} strategies the strategies to search, in order
+ * @param {string} parserName the abi type, or the dynamic selector of a composite
+ * @returns {Function | undefined} the response parser, or undefined when no strategy has one
+ * @example
+ * ```typescript
+ * const read = findResponseParser([cairoTypeStrategy], 'core::integer::u8');
+ * read?.(new CairoUint8(44), [cairoTypeStrategy]);
+ * // 44n
+ * ```
+ */
+export function findResponseParser(
+  strategies: CairoTypeStrategy[],
+  parserName: string
+): CairoTypeStrategy['response'][string] | undefined {
+  return strategies.find((strategy) => strategy.response[parserName])?.response[parserName];
+}

--- a/src/utils/cairoDataTypes/tuple.ts
+++ b/src/utils/cairoDataTypes/tuple.ts
@@ -1,0 +1,426 @@
+import type { AllowArray } from '../../types';
+import assert from '../assert';
+import { isCairo1Type, isTypeTuple } from '../calldata/cairo';
+import extractTupleMemberTypes from '../calldata/tuple';
+import type { CairoTypeStrategy } from '../calldata/parser/cairoTypeStrategy.type';
+import { addCompiledFlag } from '../helpers';
+import { CairoFelt252 } from './felt';
+import { isCairoType, type CairoType } from './cairoType.interface';
+import { findConstructor, findResponseParser } from './strategyLookup';
+
+/** One member of a tuple type: a bare type, or a name and a type for a Cairo 0 named tuple. */
+type TupleMember = string | { name: string; type: string };
+
+/** The type a member stands for, whether or not it carries a name. */
+const memberType = (member: TupleMember): string =>
+  typeof member === 'string' ? member : member.type;
+
+/**
+ * A Cairo tuple : a fixed sequence of values, each of its own type.
+ *
+ * Its abi type is written `(type1, type2)`, and Cairo 0 also allows naming the members,
+ * `(x: felt, y: felt)`. On the wire a tuple is just its members one after the other — unlike an
+ * array it carries no length, because its shape is entirely in its type.
+ *
+ * A tuple holds its members as {@link CairoType} instances rather than as raw values, so a tuple
+ * of tuples serializes in one pass : each member is asked for its own felts.
+ * @example
+ * ```typescript
+ * const tuple = new CairoTuple([1, 2], '(core::integer::u8, core::integer::u32)', cairoTypeStrategy);
+ * tuple.toApiRequest(); //                  ["1", "2"]     no length prefix
+ * tuple.decompose(cairoTypeStrategy); //    { '0': 1n, '1': 2n }
+ * ```
+ */
+export class CairoTuple {
+  /**
+   * The name this class is registered under in a strategy's `dynamicSelectors`.
+   *
+   * A tuple type is a shape rather than one string, so it cannot be a key of `constructors` the
+   * way `core::integer::u8` is : the selector recognizes the shape, and this names what to build.
+   * @example
+   * ```typescript
+   * const result = CairoTuple.dynamicSelector;
+   * // result = "CairoTuple"
+   * ```
+   */
+  static dynamicSelector = 'CairoTuple' as const;
+
+  /**
+   * The selector on the instance, which is how a composite holding it knows what built it.
+   * @example
+   * ```typescript
+   * const tuple = new CairoTuple([1], '(core::integer::u8)', cairoTypeStrategy);
+   * const result = tuple.dynamicSelector;
+   * // result = "CairoTuple"
+   * ```
+   */
+  public readonly dynamicSelector = CairoTuple.dynamicSelector;
+
+  /**
+   * The members, each already built as the Cairo type its position declares.
+   * @example
+   * ```typescript
+   * const tuple = new CairoTuple([1, 2], '(core::integer::u8, core::integer::u32)', cairoTypeStrategy);
+   * const result = tuple.content.length;
+   * // result = 2
+   * ```
+   */
+  public readonly content: CairoType[];
+
+  /**
+   * The abi type this tuple was built for.
+   * @example
+   * ```typescript
+   * const tuple = new CairoTuple([1, 2], '(core::integer::u8, core::integer::u32)', cairoTypeStrategy);
+   * const result = tuple.tupleType;
+   * // result = "(core::integer::u8, core::integer::u32)"
+   * ```
+   */
+  public readonly tupleType: string;
+
+  /**
+   * Build a tuple, from values a caller passed or from the felts of a response.
+   *
+   * The three inputs a member can take are all accepted : a raw value, which the strategy turns
+   * into the type its position declares; an instance already built, which is taken as it stands;
+   * and the response iterator, which is read member by member.
+   *
+   * A named Cairo 0 tuple also accepts an object keyed by those names, and any tuple accepts one
+   * keyed by position — `{ 0: 1, 1: 2 }` says what `[1, 2]` says.
+   * @param {unknown} content the members, as an array, an object, or the response iterator
+   * @param {string} tupleType the abi type, `(type1, type2)`
+   * @param {AllowArray<CairoTypeStrategy>} parsingStrategy how to build each member
+   * @throws {Error} when the type is not a tuple, when the member count does not match, or when a
+   * member type no strategy knows is met
+   * @example
+   * ```typescript
+   * const fromArray = new CairoTuple([1, 2], '(core::integer::u8, core::integer::u32)', cairoTypeStrategy);
+   * fromArray.toApiRequest(); // ["1", "2"]
+   *
+   * const fromResponse = new CairoTuple(
+   *   ['0x1', '0x2'].values(),
+   *   '(core::integer::u8, core::integer::u32)',
+   *   cairoTypeStrategy
+   * );
+   * fromResponse.toApiRequest(); // ["1", "2"]
+   * ```
+   */
+  constructor(content: unknown, tupleType: string, parsingStrategy: AllowArray<CairoTypeStrategy>) {
+    this.tupleType = tupleType;
+    const strategies = Array.isArray(parsingStrategy) ? parsingStrategy : [parsingStrategy];
+
+    if (content && typeof content === 'object' && 'next' in content) {
+      this.content = CairoTuple.parser(content as Iterator<string>, tupleType, strategies);
+      return;
+    }
+    if (content instanceof CairoTuple) {
+      this.content = content.content;
+      this.tupleType = content.tupleType;
+      return;
+    }
+
+    CairoTuple.validate(content, tupleType);
+    const memberTypes = CairoTuple.getTupleElementTypes(tupleType).map(memberType);
+    const values = CairoTuple.extractValuesArray(content, tupleType);
+    assert(
+      values.length === memberTypes.length,
+      `ABI type ${tupleType}: expected ${memberTypes.length} items, got ${values.length} items.`
+    );
+
+    this.content = values.map((value, index) => {
+      if (isCairoType(value)) {
+        return value;
+      }
+      const build = findConstructor(strategies, memberTypes[index]);
+      if (!build) {
+        throw new Error(`"${memberTypes[index]}" is not a valid Cairo type`);
+      }
+      return build(value, strategies, memberTypes[index]);
+    });
+  }
+
+  /**
+   * Read a tuple off a response, one member after another.
+   *
+   * Nothing marks where a tuple ends on the wire, so the type is what says how many felts to
+   * take : each member consumes what it needs and leaves the iterator on the next one. A member
+   * type no strategy knows is read as a felt252 rather than guessed at.
+   * @param {Iterator<string>} responseIterator the response felts, positioned on this tuple
+   * @param {string} tupleType the abi type, `(type1, type2)`
+   * @param {CairoTypeStrategy[]} strategies how to build each member
+   * @returns {CairoType[]} the members that were read
+   * @example
+   * ```typescript
+   * // called from the constructor when it is handed an iterator
+   * const tuple = new CairoTuple(
+   *   ['0x1', '0x2'].values(),
+   *   '(core::integer::u8, core::integer::u32)',
+   *   cairoTypeStrategy
+   * );
+   * tuple.toApiRequest();
+   * // ["1", "2"]
+   * ```
+   */
+  private static parser(
+    responseIterator: Iterator<string>,
+    tupleType: string,
+    strategies: CairoTypeStrategy[]
+  ): CairoType[] {
+    return CairoTuple.getTupleElementTypes(tupleType)
+      .map(memberType)
+      .map((type) => {
+        const build =
+          findConstructor(strategies, type) ??
+          findConstructor(strategies, CairoFelt252.abiSelector);
+        if (!build) {
+          throw new Error(`No parser found for element type: ${type} in parsing strategy`);
+        }
+        return build(responseIterator, strategies, type);
+      });
+  }
+
+  /**
+   * Line the members up in the order the type declares, whatever shape the input took.
+   *
+   * An array is already in order. An object is read by the member names for a named tuple, and by
+   * position otherwise — `{ 0: 1, 1: 2 }` and `{ a: 1, b: 2 }` both give `[1, 2]`, the second one
+   * relying on the insertion order JavaScript keeps for string keys.
+   * @param {unknown} input the members, as an array or an object
+   * @param {string} tupleType the abi type, which names the members of a Cairo 0 named tuple
+   * @returns {any[]} the members in the order the type declares
+   * @example
+   * ```typescript
+   * // called from the constructor
+   * const byPosition = new CairoTuple({ 0: 1, 1: 2 }, '(core::integer::u8, core::integer::u32)', cairoTypeStrategy);
+   * byPosition.toApiRequest();
+   * // ["1", "2"]
+   * ```
+   */
+  private static extractValuesArray(input: unknown, tupleType: string): any[] {
+    if (Array.isArray(input)) {
+      return input;
+    }
+    const inputObject = input as Record<string, any>;
+    const members = CairoTuple.getTupleElementTypes(tupleType);
+
+    const named = members.filter((member) => typeof member === 'object') as {
+      name: string;
+      type: string;
+    }[];
+    if (named.length === members.length && named.every((member) => member.name in inputObject)) {
+      return named.map((member) => inputObject[member.name]);
+    }
+
+    const keys = Object.keys(inputObject);
+    if (keys.length > 0 && keys.every((key) => /^\d+$/.test(key))) {
+      return keys
+        .sort((left, right) => Number(left) - Number(right))
+        .map((key) => inputObject[key]);
+    }
+    return Object.values(inputObject);
+  }
+
+  /**
+   * Split a tuple type into its members.
+   *
+   * The reading itself is done by the tuple parser the request and response parsers already
+   * share, so both worlds see the same members. Only the empty tuple is handled here : that
+   * parser answers `['']` for `()` in the Cairo 0 form, which would stand for one member rather
+   * than none.
+   * @param {string} tupleType the abi type to split
+   * @returns {TupleMember[]} the members, named ones as `{ name, type }`
+   * A Cairo 1 type is also checked for having survived the split : the members are put back
+   * together and compared to what came in. That parser walks the string assuming members are
+   * separated by `', '`, so a comma without its space makes it eat the next character and hand
+   * back a member type that does not exist — silently. Recomposing catches exactly that, and
+   * nothing else : a nested `Result::<u8,u8>` is read by bracket matching rather than by commas,
+   * comes back whole, and is left alone.
+   *
+   * Cairo 0 has no such check, and needs none : every space is stripped before that type is
+   * split, so there is nothing to compare against.
+   * @param {string} tupleType the abi type to split
+   * @returns {TupleMember[]} the members, named ones as `{ name, type }`
+   * @throws {Error} when a Cairo 1 tuple type does not survive being split and put back together
+   * @example
+   * ```typescript
+   * const result = CairoTuple.getTupleElementTypes('(core::integer::u8, core::integer::u32)');
+   * // result = ["core::integer::u8", "core::integer::u32"]
+   * const result2 = CairoTuple.getTupleElementTypes('(x:felt, y:felt)');
+   * // result2 = [{ name: "x", type: "felt" }, { name: "y", type: "felt" }]
+   * const result3 = CairoTuple.getTupleElementTypes('()');
+   * // result3 = []
+   * CairoTuple.getTupleElementTypes('(core::integer::u8,core::integer::u32)');
+   * // throws Error('"(core::integer::u8,core::integer::u32)" is not a valid Cairo type
+   * //              (its members do not recompose it, usually a missing space after a comma)')
+   * ```
+   */
+  static getTupleElementTypes(tupleType: string): TupleMember[] {
+    if (tupleType.replace(/\s/g, '') === '()') {
+      return [];
+    }
+    const members = extractTupleMemberTypes(tupleType) as TupleMember[];
+    if (isCairo1Type(tupleType) && `(${members.join(', ')})` !== tupleType) {
+      throw new Error(
+        `"${tupleType}" is not a valid Cairo type (its members do not recompose it, usually a missing space after a comma)`
+      );
+    }
+    return members;
+  }
+
+  /**
+   * The names of the members, or their positions when the tuple does not name them.
+   * @param {string} type the abi type to read
+   * @returns {string[]} one name per member
+   * @example
+   * ```typescript
+   * const result = CairoTuple.extractTupleMembersNames('(core::integer::u8, core::integer::u32)');
+   * // result = ["0", "1"]
+   * const result2 = CairoTuple.extractTupleMembersNames('(x:felt, y:felt)');
+   * // result2 = ["x", "y"]
+   * ```
+   */
+  static extractTupleMembersNames(type: string): string[] {
+    return CairoTuple.getTupleElementTypes(type).map((member, index) =>
+      typeof member === 'string' ? index.toString() : member.name
+    );
+  }
+
+  /**
+   * Throw unless this input can be read as a tuple of this type.
+   *
+   * Only the shape is checked here — a tuple type, and members given as a list or an object. What
+   * each member is worth is the business of the class its position declares, and is checked when
+   * that member is built.
+   * @param {unknown} input the members to check
+   * @param {string} tupleType the abi type they are meant for
+   * @throws {Error} when the type is not a tuple, or the input is neither an array nor an object
+   * @example
+   * ```typescript
+   * CairoTuple.validate([1, 2], '(core::integer::u8, core::integer::u32)'); // passes
+   * CairoTuple.validate([1, 2], 'core::integer::u8');
+   * // throws Error("The type core::integer::u8 is not a Cairo tuple. Expected format: (type1, type2, ...)")
+   * ```
+   */
+  static validate(input: unknown, tupleType: string): void {
+    assert(
+      CairoTuple.isAbiType(tupleType),
+      `The type ${tupleType} is not a Cairo tuple. Expected format: (type1, type2, ...)`
+    );
+    assert(
+      Array.isArray(input) || (typeof input === 'object' && input !== null),
+      `Invalid input: expected Array or Object, got ${typeof input}`
+    );
+  }
+
+  /**
+   * Can this input be read as a tuple of this type?
+   *
+   * The non-throwing form of {@link CairoTuple.validate}.
+   * @param {unknown} input the members to test
+   * @param {string} tupleType the abi type they are meant for
+   * @returns {boolean} true when the shape fits
+   * @example
+   * ```typescript
+   * const result = CairoTuple.is([1, 2], '(core::integer::u8, core::integer::u32)');
+   * // result = true
+   * const result2 = CairoTuple.is('nope', '(core::integer::u8, core::integer::u32)');
+   * // result2 = false
+   * ```
+   */
+  static is(input: unknown, tupleType: string): boolean {
+    try {
+      CairoTuple.validate(input, tupleType);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Is this abi type a tuple?
+   * @param {string} type the abi type to test
+   * @returns {boolean} true for `(type1, type2)`, named or not, nested or not
+   * @example
+   * ```typescript
+   * const result = CairoTuple.isAbiType('(core::integer::u8, core::integer::u32)');
+   * // result = true
+   * const result2 = CairoTuple.isAbiType('core::integer::u32');
+   * // result2 = false
+   * ```
+   */
+  static isAbiType(type: string): boolean {
+    return isTypeTuple(type);
+  }
+
+  /**
+   * Serialize to the felts a contract call carries.
+   *
+   * The members follow one another with nothing in front : a tuple carries no length, since its
+   * type already says how many members it has and what each of them is.
+   * @returns {string[]} the members' felts, in order, flagged as compiled
+   * @example
+   * ```typescript
+   * const tuple = new CairoTuple([1, 2], '(core::integer::u8, core::integer::u32)', cairoTypeStrategy);
+   * const result = tuple.toApiRequest();
+   * // result = ["1", "2"]
+   * ```
+   */
+  public toApiRequest(): string[] {
+    return addCompiledFlag(this.content.flatMap((member) => member.toApiRequest()));
+  }
+
+  /**
+   * Turn a list into the object `CallData.compile` reads a tuple from.
+   * @param {Array<any>} input the members, in order
+   * @returns {Object} the members keyed by position
+   * @example
+   * ```typescript
+   * const result = CairoTuple.compile([10, 20, 30]);
+   * // result = { '0': 10, '1': 20, '2': 30 }
+   * ```
+   */
+  static compile(input: Array<any>): Object {
+    return input.reduce((acc: any, item: any, index: number) => {
+      acc[index] = item;
+      return acc;
+    }, {});
+  }
+
+  /**
+   * Read the tuple back as the plain values a caller reads.
+   *
+   * Each member is handed to the strategy entry for its type — or for what built it, when that is
+   * a composite, which is what its `dynamicSelector` says. The result is keyed by member name for
+   * a Cairo 0 named tuple, and by position otherwise.
+   * @param {AllowArray<CairoTypeStrategy>} strategyDecompose how to read each member back
+   * @returns {Object} the members' values, keyed by name or by position
+   * @throws {Error} when no strategy can read a member back
+   * @example
+   * ```typescript
+   * const tuple = new CairoTuple([1, 2], '(core::integer::u8, core::integer::u32)', cairoTypeStrategy);
+   * const result = tuple.decompose(cairoTypeStrategy);
+   * // result = { '0': 1n, '1': 2n }
+   * ```
+   */
+  public decompose(strategyDecompose: AllowArray<CairoTypeStrategy>): Object {
+    const strategies = Array.isArray(strategyDecompose) ? strategyDecompose : [strategyDecompose];
+    const members = CairoTuple.getTupleElementTypes(this.tupleType);
+    const names = CairoTuple.extractTupleMembersNames(this.tupleType);
+
+    const values = this.content.map((member, index) => {
+      const parserName =
+        'dynamicSelector' in member
+          ? (member as { dynamicSelector: string }).dynamicSelector
+          : memberType(members[index]);
+      const read = findResponseParser(strategies, parserName);
+      if (!read) {
+        throw new Error(
+          `No response parser found for element type: ${parserName} in parsing strategy`
+        );
+      }
+      return read(member, strategies);
+    });
+
+    return Object.fromEntries(names.map((name, index) => [name, values[index]]));
+  }
+}

--- a/src/utils/calldata/parser/cairoTypeStrategy.ts
+++ b/src/utils/calldata/parser/cairoTypeStrategy.ts
@@ -1,0 +1,317 @@
+import { CairoBool } from '../../cairoDataTypes/bool';
+import { CairoByteArray } from '../../cairoDataTypes/byteArray';
+import { CairoBytes31 } from '../../cairoDataTypes/bytes31';
+import { CairoClassHash } from '../../cairoDataTypes/classHash';
+import { CairoContractAddress } from '../../cairoDataTypes/contractAddress';
+import { CairoEthAddress } from '../../cairoDataTypes/ethAddress';
+import { CairoFelt252 } from '../../cairoDataTypes/felt';
+import { CairoInt8 } from '../../cairoDataTypes/int8';
+import { CairoInt16 } from '../../cairoDataTypes/int16';
+import { CairoInt32 } from '../../cairoDataTypes/int32';
+import { CairoInt64 } from '../../cairoDataTypes/int64';
+import { CairoInt128 } from '../../cairoDataTypes/int128';
+import { CairoSecp256k1Point } from '../../cairoDataTypes/secp256k1Point';
+import { CairoUint8 } from '../../cairoDataTypes/uint8';
+import { CairoUint16 } from '../../cairoDataTypes/uint16';
+import { CairoUint32 } from '../../cairoDataTypes/uint32';
+import { CairoUint64 } from '../../cairoDataTypes/uint64';
+import { CairoUint96 } from '../../cairoDataTypes/uint96';
+import { CairoUint128 } from '../../cairoDataTypes/uint128';
+import { CairoUint256 } from '../../cairoDataTypes/uint256';
+import { CairoUint512 } from '../../cairoDataTypes/uint512';
+import { CairoArray } from '../../cairoDataTypes/array';
+import { CairoStruct } from '../../cairoDataTypes/cairoStruct';
+import { CairoTypeCustomEnum } from '../../cairoDataTypes/cairoTypeCustomEnum';
+import { CairoTypeFixedArray } from '../../cairoDataTypes/cairoTypeFixedArray';
+import { CairoTypeOption } from '../../cairoDataTypes/cairoTypeOption';
+import { CairoTypeResult } from '../../cairoDataTypes/cairoTypeResult';
+import { CairoNonZero } from '../../cairoDataTypes/nonZero';
+import { CairoTuple } from '../../cairoDataTypes/tuple';
+import type { AbiEnum, AbiStruct, AllowArray } from '../../../types';
+import type { CairoType } from '../../cairoDataTypes/cairoType.interface';
+import type { CairoTypeStrategy, VariantType } from './cairoTypeStrategy.type';
+import assert from '../../assert';
+
+/**
+ * Is this the response iterator rather than a value a caller passed?
+ *
+ * The two directions share one entry per type, so each constructor has to tell them apart. An
+ * iterator is the only input carrying a `next`, and no Cairo value is built from one.
+ * @param {unknown} input the value handed to a constructor
+ * @returns {boolean} true when the input is the felts of a response
+ * @example
+ * ```typescript
+ * const result = isResponseIterator(['0x1'].values());
+ * // result = true
+ * const result2 = isResponseIterator(44);
+ * // result2 = false
+ * ```
+ */
+function isResponseIterator(input: unknown): input is Iterator<string> {
+  return typeof input === 'object' && input !== null && 'next' in input;
+}
+
+/**
+ * Build one entry of the map from a Cairo type class.
+ *
+ * Every leaf answers the two directions the same way — its constructor for a value, its
+ * `factoryFromApiResponse` for the felts of a response — so the entry is the same shape each
+ * time and is written once here rather than nineteen times below.
+ * @param {object} cairoType the class to wrap
+ * @returns {Function} the constructor entry for that class
+ * @example
+ * ```typescript
+ * const entry = leafConstructor(CairoUint8);
+ * const result = entry(44).toApiRequest();
+ * // result = ["44"]
+ * const result2 = entry(['0x2c'].values()).toApiRequest();
+ * // result2 = ["44"]
+ * ```
+ */
+function leafConstructor(cairoType: {
+  new (input: any): CairoType;
+  factoryFromApiResponse(responseIterator: Iterator<string>): CairoType;
+}): (input: Iterator<string> | unknown) => CairoType {
+  return (input) =>
+    isResponseIterator(input)
+      ? cairoType.factoryFromApiResponse(input)
+      : // eslint-disable-next-line new-cap
+        new cairoType(input);
+}
+
+/**
+ * The Cairo types that occupy a known number of felts and are built from a value of their own.
+ *
+ * Listed together because the entry is identical for each: the class knows how to read itself in
+ * both directions, and nothing here needs the strategy back — only a composite does, to build the
+ * elements it holds.
+ */
+const LEAF_TYPES = [
+  CairoFelt252,
+  CairoBool,
+  CairoEthAddress,
+  CairoClassHash,
+  CairoContractAddress,
+  CairoBytes31,
+  CairoByteArray,
+  CairoSecp256k1Point,
+  CairoUint8,
+  CairoUint16,
+  CairoUint32,
+  CairoUint64,
+  CairoUint96,
+  CairoUint128,
+  CairoUint256,
+  CairoUint512,
+  CairoInt8,
+  CairoInt16,
+  CairoInt32,
+  CairoInt64,
+  CairoInt128,
+] as const;
+
+/**
+ * The strategy the composite classes drive.
+ *
+ * It carries the leaf types only for now : a composite adds itself to `dynamicSelectors` as it is
+ * written, because its abi type is a family rather than one string. Nothing in the library reads
+ * this map yet — the parsers still run on {@link hdParsingStrategy}, and moving them over is the
+ * next step, not this one.
+ * @example
+ * ```typescript
+ * const felts = cairoTypeStrategy.constructors['core::integer::u8'](44, cairoTypeStrategy)
+ *   .toApiRequest();
+ * // felts = ["44"]
+ * ```
+ */
+export const cairoTypeStrategy: CairoTypeStrategy = {
+  constructors: {
+    ...Object.fromEntries(
+      LEAF_TYPES.map((cairoType) => [cairoType.abiSelector, leafConstructor(cairoType)])
+    ),
+    // A composite is keyed by its selector name rather than by an abi type, and needs the type
+    // back : the selector matched a family, and only the caller knows which member of it.
+    [CairoTuple.dynamicSelector]: (input, strategy, type) => {
+      assert(type !== undefined, 'A CairoTuple cannot be built without the abi type it stands for');
+      return new CairoTuple(input, type, strategy);
+    },
+    [CairoArray.dynamicSelector]: (input, strategy, type) => {
+      assert(type !== undefined, 'A CairoArray cannot be built without the abi type it stands for');
+      return new CairoArray(input, type, strategy);
+    },
+    // the one entry that forwards the fourth argument: which branch of the enum is meant cannot
+    // be read off the value, so whoever knows it has to say so
+    [CairoTypeOption.dynamicSelector]: (input, strategy, type, variant) => {
+      assert(
+        type !== undefined,
+        'A CairoTypeOption cannot be built without the abi type it stands for'
+      );
+      return new CairoTypeOption(input, type, strategy, variant as number | undefined);
+    },
+    [CairoTypeResult.dynamicSelector]: (input, strategy, type, variant) => {
+      assert(
+        type !== undefined,
+        'A CairoTypeResult cannot be built without the abi type it stands for'
+      );
+      return new CairoTypeResult(input, type, strategy, variant as number | undefined);
+    },
+    [CairoNonZero.dynamicSelector]: (input, strategy, type) => {
+      assert(
+        type !== undefined,
+        'A CairoNonZero cannot be built without the abi type it stands for'
+      );
+      return new CairoNonZero(input, type, strategy);
+    },
+    [CairoTypeFixedArray.dynamicSelector]: (input, strategy, type) => {
+      assert(
+        type !== undefined,
+        'A CairoTypeFixedArray cannot be built without the abi type it stands for'
+      );
+      return new CairoTypeFixedArray(input, type, strategy);
+    },
+  },
+  response: {
+    [CairoFelt252.abiSelector]: (instance) => (instance as CairoFelt252).toBigInt(),
+    [CairoBool.abiSelector]: (instance) => (instance as CairoBool).toBoolean(),
+    [CairoEthAddress.abiSelector]: (instance) => (instance as CairoEthAddress).toBigInt(),
+    [CairoClassHash.abiSelector]: (instance) => (instance as CairoClassHash).toBigInt(),
+    [CairoContractAddress.abiSelector]: (instance) => (instance as CairoContractAddress).toBigInt(),
+    [CairoBytes31.abiSelector]: (instance) => (instance as CairoBytes31).decodeUtf8(),
+    [CairoByteArray.abiSelector]: (instance) => (instance as CairoByteArray).decodeUtf8(),
+    [CairoSecp256k1Point.abiSelector]: (instance) => (instance as CairoSecp256k1Point).toBigInt(),
+    [CairoUint8.abiSelector]: (instance) => (instance as CairoUint8).toBigInt(),
+    [CairoUint16.abiSelector]: (instance) => (instance as CairoUint16).toBigInt(),
+    [CairoUint32.abiSelector]: (instance) => (instance as CairoUint32).toBigInt(),
+    [CairoUint64.abiSelector]: (instance) => (instance as CairoUint64).toBigInt(),
+    [CairoUint96.abiSelector]: (instance) => (instance as CairoUint96).toBigInt(),
+    [CairoUint128.abiSelector]: (instance) => (instance as CairoUint128).toBigInt(),
+    [CairoUint256.abiSelector]: (instance) => (instance as CairoUint256).toBigInt(),
+    [CairoUint512.abiSelector]: (instance) => (instance as CairoUint512).toBigInt(),
+    [CairoInt8.abiSelector]: (instance) => (instance as CairoInt8).toBigInt(),
+    [CairoInt16.abiSelector]: (instance) => (instance as CairoInt16).toBigInt(),
+    [CairoInt32.abiSelector]: (instance) => (instance as CairoInt32).toBigInt(),
+    [CairoInt64.abiSelector]: (instance) => (instance as CairoInt64).toBigInt(),
+    [CairoInt128.abiSelector]: (instance) => (instance as CairoInt128).toBigInt(),
+    // A composite reads itself back by decomposing, which is what walks the members it holds.
+    [CairoTuple.dynamicSelector]: (instance, strategy) =>
+      (instance as CairoTuple).decompose(strategy),
+    [CairoArray.dynamicSelector]: (instance, strategy) =>
+      (instance as CairoArray).decompose(strategy),
+    [CairoTypeOption.dynamicSelector]: (instance, strategy) =>
+      (instance as CairoTypeOption).decompose(strategy),
+    [CairoTypeResult.dynamicSelector]: (instance, strategy) =>
+      (instance as CairoTypeResult).decompose(strategy),
+    [CairoNonZero.dynamicSelector]: (instance, strategy) =>
+      (instance as CairoNonZero).decompose(strategy),
+    [CairoTypeFixedArray.dynamicSelector]: (instance, strategy) =>
+      (instance as CairoTypeFixedArray).decompose(strategy),
+  },
+  dynamicSelectors: {
+    [CairoTuple.dynamicSelector]: (type) => CairoTuple.isAbiType(type),
+    [CairoArray.dynamicSelector]: (type) => CairoArray.isAbiType(type),
+    [CairoTypeOption.dynamicSelector]: (type) => CairoTypeOption.isAbiType(type),
+    [CairoTypeResult.dynamicSelector]: (type) => CairoTypeResult.isAbiType(type),
+    [CairoNonZero.dynamicSelector]: (type) => CairoNonZero.isAbiType(type),
+    [CairoTypeFixedArray.dynamicSelector]: (type) => CairoTypeFixedArray.isAbiType(type),
+  },
+};
+
+/**
+ * The strategy for the structs an abi declares, to be used beside {@link cairoTypeStrategy}.
+ *
+ * A struct is the one Cairo type with no shape to recognize : its abi type is the name the
+ * contract chose, which looks like any other. So it cannot be a dynamic selector — one that
+ * matched by name would have to know every name in advance, and one that matched anything would
+ * shadow every other type. Instead each struct becomes an ordinary entry keyed by its own name,
+ * which is what a lookup tries first.
+ *
+ * That is what the second argument of every composite is for : the strategies are searched in
+ * order, so a call passes `[cairoTypeStrategy, structStrategy(structs)]` and gets the language's
+ * types from the first and the contract's from the second.
+ * @param {AbiStruct[]} structs the struct definitions an abi declares
+ * @returns {CairoTypeStrategy} a strategy carrying one entry per struct
+ * @example
+ * ```typescript
+ * const point: AbiStruct = {
+ *   type: 'struct',
+ *   name: 'test::Point',
+ *   members: [
+ *     { name: 'x', type: 'core::integer::u8' },
+ *     { name: 'y', type: 'core::integer::u32' },
+ *   ],
+ * };
+ * const strategies = [cairoTypeStrategy, structStrategy([point])];
+ * const felts = strategies[1].constructors['test::Point']({ x: 1, y: 2 }, strategies)
+ *   .toApiRequest();
+ * // felts = ["1", "2"]
+ * ```
+ */
+/**
+ * The strategy for the custom enums an abi declares, to be used beside {@link cairoTypeStrategy}.
+ *
+ * Built exactly like {@link structStrategy}, and for the same reason : a custom enum's abi type is
+ * the name the contract chose, so it is keyed by that name rather than recognized by a pattern.
+ *
+ * Its constructors forward the variant, which for an enum is the index of the active branch — the
+ * one thing a raw value cannot say about itself.
+ * @param {AbiEnum[]} enums the enum definitions an abi declares
+ * @returns {CairoTypeStrategy} a strategy carrying one entry per enum
+ * @example
+ * ```typescript
+ * const abiEnum: AbiEnum = {
+ *   type: 'enum',
+ *   name: 'test::MyEnum',
+ *   variants: [
+ *     { name: 'Empty', type: '()' },
+ *     { name: 'Number', type: 'core::integer::u8' },
+ *   ],
+ * };
+ * const strategies = [cairoTypeStrategy, enumStrategy([abiEnum])];
+ * const felts = strategies[1].constructors['test::MyEnum'](7, strategies, 'test::MyEnum', 1)
+ *   .toApiRequest();
+ * // felts = ["1", "7"]
+ * ```
+ */
+export function enumStrategy(enums: AbiEnum[]): CairoTypeStrategy {
+  return {
+    constructors: Object.fromEntries(
+      enums.map((abiEnum) => [
+        abiEnum.name,
+        (
+          input: Iterator<string> | unknown,
+          strategy: AllowArray<CairoTypeStrategy>,
+          _type?: string,
+          variant?: VariantType
+        ) => new CairoTypeCustomEnum(input, abiEnum, strategy, variant as number | undefined),
+      ])
+    ),
+    response: Object.fromEntries(
+      enums.map((abiEnum) => [
+        abiEnum.name,
+        (instance: CairoType, strategy: AllowArray<CairoTypeStrategy>) =>
+          (instance as CairoTypeCustomEnum).decompose(strategy),
+      ])
+    ),
+    dynamicSelectors: {},
+  };
+}
+
+export function structStrategy(structs: AbiStruct[]): CairoTypeStrategy {
+  return {
+    constructors: Object.fromEntries(
+      structs.map((abiStruct) => [
+        abiStruct.name,
+        (input: Iterator<string> | unknown, strategy: AllowArray<CairoTypeStrategy>) =>
+          new CairoStruct(input, abiStruct, strategy),
+      ])
+    ),
+    response: Object.fromEntries(
+      structs.map((abiStruct) => [
+        abiStruct.name,
+        (instance: CairoType, strategy: AllowArray<CairoTypeStrategy>) =>
+          (instance as CairoStruct).decompose(strategy),
+      ])
+    ),
+    dynamicSelectors: {},
+  };
+}

--- a/src/utils/calldata/parser/cairoTypeStrategy.type.ts
+++ b/src/utils/calldata/parser/cairoTypeStrategy.type.ts
@@ -1,0 +1,77 @@
+import type { AbiEntryType, AllowArray } from '../../../types';
+import type { CairoType } from '../../cairoDataTypes/cairoType.interface';
+import type { CairoOptionVariant, CairoResultVariant } from '../enum';
+
+/**
+ * Which branch of an enum a value stands for.
+ *
+ * `Option` and `Result` have their own named variants; a custom enum names its own, and a bare
+ * index is accepted for the abi order.
+ */
+export type VariantType = CairoOptionVariant | CairoResultVariant | string | number;
+
+/**
+ * How to build a Cairo type from an abi type, and how to read one back.
+ *
+ * This is the shape the composite classes drive : unlike `ParsingStrategy`, whose entries go
+ * straight from a value to its felts, a constructor here returns a {@link CairoType} **instance**.
+ * That is what lets a composite hold its elements as a tree and serialize the whole of it at once,
+ * rather than each level having to flatten what it contains.
+ *
+ * Every constructor receives the strategy back, because building a composite means building its
+ * children : an array of tuples of u8 has to reach this map three times.
+ * @example
+ * ```typescript
+ * const strategy: CairoTypeStrategy = {
+ *   constructors: {
+ *     [CairoUint8.abiSelector]: (input) => new CairoUint8(input),
+ *   },
+ *   response: {
+ *     [CairoUint8.abiSelector]: (instance) => (instance as CairoUint8).toBigInt(),
+ *   },
+ *   dynamicSelectors: {},
+ * };
+ * const felts = strategy.constructors['core::integer::u8'](44, strategy).toApiRequest();
+ * // felts = ["44"]
+ * ```
+ */
+export type CairoTypeStrategy = {
+  /**
+   * Build a Cairo type, from raw data on the way out or from response felts on the way in.
+   *
+   * The two directions share one entry because they build the same thing : `input` is whatever a
+   * caller passed for a request, and the iterator positioned on this value for a response. `type`
+   * and `variant` are given only where the abi key is not enough to know what to build — a
+   * dynamic selector matches a family of types, and an enum has to be told which branch it holds.
+   */
+  constructors: Record<
+    AbiEntryType,
+    (
+      input: Iterator<string> | unknown,
+      strategy: AllowArray<CairoTypeStrategy>,
+      type?: string,
+      variant?: VariantType
+    ) => CairoType
+  >;
+
+  /**
+   * Turn a built Cairo type back into the plain JS value a caller reads.
+   *
+   * The strategy comes along for the same reason as above : decomposing a composite means
+   * decomposing its elements.
+   */
+  response: Record<
+    AbiEntryType,
+    (instance: CairoType, strategy: AllowArray<CairoTypeStrategy>) => any
+  >;
+
+  /**
+   * Recognize the types whose abi string is not a fixed key.
+   *
+   * An array, a tuple, a fixed array, an `Option` or a `NonZero` write their element type into
+   * their own name, so there is no one string to key them by. Each entry here is a predicate on
+   * the abi type, and its key names the constructor to use — which is why a composite class
+   * carries a `dynamicSelector` telling which one built it.
+   */
+  dynamicSelectors: Record<string, (type: string) => boolean>;
+};


### PR DESCRIPTION
## Motivation and Resolution

The closed PR #1484 built an object model for the Cairo types — one class per type,
each able to serialize itself and read itself back — and was closed along with its
integration branch #1496. What `beta` kept of it is the leaf types; the composites
never landed, and `src/utils/calldata/parser/parsingStrategy.ts` still carries the
`TODO: extend for complex types like structs, tuples, enums, arrays`.

This takes the work up again, in two phases:

1. **This PR** — the classes land, are exercised on their own, and nothing in the
   current encoding or decoding path moves.
2. **Later** — the request and response parsers are rewritten to drive them, and
   `requestParser.ts`, `responseParser.ts` and `validate.ts` disappear.

The split is deliberate. The rewrite touches every calldata path, and its risk is
not a broken API — the composites are internal — but a silent decoding regression:
a `u8` coming back as the wrong type, a named tuple whose key order shifts. None of
that fails a build. Landing the classes first lets them be reviewed and tested
against the behaviour the original PR established, before anything that users
depend on is asked to move.

### RPC version (if applicable)

N/A

## Usage related changes

- New exported class `CairoClassHash`, for `core::starknet::class_hash::ClassHash`.
- New exported class `CairoContractAddress`, for
  `core::starknet::contract_address::ContractAddress`.
- New exported constant `RANGE_CONTRACT_ADDRESS`.

Nothing else reaches the public surface, and no existing behaviour changes. The
eight composite classes are deliberately kept out of the barrel: their constructors
take the parsing strategy, whose shape phase 2 will change, and exporting them now
would freeze an API before it has been used once. Their tests import them by path.

One thing worth flagging for phase 2 rather than for users: `validate.ts` bounds a
`ContractAddress` at 2^252-1, which the RPC spec states but which is looser than the
field. `CairoContractAddress` uses `ADDR_BOUND` instead — an address is computed
modulo it, and `validateAndParseAddress` already refuses to exceed it. The new class
is therefore stricter than the path in use, which is left untouched.

## Development related changes

Fourteen source files and nine test files, plus two lines in `global/constants.ts`
and two exports in the `cairoDataTypes` barrel.

**What is added**

```
composites  CairoTuple · CairoArray · CairoStruct · CairoTypeOption
            CairoTypeResult · CairoTypeCustomEnum · CairoNonZero
            CairoTypeFixedArray
leaves      CairoClassHash · CairoContractAddress
socle       CairoType (interface) · findConstructor / findResponseParser
            cairoTypeStrategy · structStrategy · enumStrategy
```

**`CairoType` is an interface, not the abstract class of #1484.** TypeScript matches
it structurally, so the eighteen existing classes satisfy it without being touched,
where a base class would have had to be added to each of them — and any that forgot
would not have raised: an `instanceof` check would simply have answered false and
sent the value down the wrong branch. The eight `instanceof CairoType` guards of the
original were redundant wrappers around an `in` check, and collapse to it.

**A struct and a custom enum have no shape to recognise**, their abi type being the
name the contract chose. They are keyed by that exact name in a strategy built from
the abi, which is what `structStrategy` and `enumStrategy` do — and what the
`AllowArray<CairoTypeStrategy>` in every composite signature exists for.

**Three defects of the original are fixed**: a strategy argument passed in the
type's place in `CairoTuple`'s parser; a fixed-base `parseInt` that read a decimal
array length as hexadecimal (a length of 10 became 16); and a raw string cast to
`CairoType` where the felts could not be parsed, which lied about its own type and
was caught later by a `typeof === 'string'` guard.

**A guard is added where `CairoTuple` splits a type.** The shared tuple parser walks
the string assuming `', '`, so a comma without its space makes it eat the next
character and hand back a member type that does not exist — silently. The guard
compares the members put back together to what came in, which catches exactly that
and leaves a nested `Result::<u8,u8>` alone.

**The enum classes are ported faithfully**, `subType` flag included. It is what makes
an option of options work, and the tests now pin that down at depths one to five, in
both directions, with `None` at every level.

**What is not covered, by decision**: Cairo 0 stays on the current path. The strategy
registers Cairo 1 type names only, and a Cairo 0 named tuple is read but cannot be
built by it — asserted as such in the tests.

**301 tests**, bringing the offline suite to 1994 across 78 suites. Beyond each class
on its own, they cover every composite inside every other: an array of structs, a
struct holding an array and a tuple, `Option<Array<Option<u8>>>`, `Array<Result>`, an
enum holding an option, a result and a fixed array. `CairoContractAddress` is
asserted to agree with `validateAndParseAddress` on the boundary values.

## Checklist:

- [x] Performed a self-review of the code
- [x] Documented the changes in code (API docs will be generated automatically)
- [x] Updated the tests
- [x] All tests are passing
