### PR TITLE
test: adapt the suite to devnet 0.10.0 (Starknet 0.14.4)

### DIFF
--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -33,7 +33,7 @@ jobs:
     services:
       devnet:
         # 0.9.2 or later: the WebSocket run needs JSON-RPC batches on the `/ws` endpoint.
-        image: ${{ (inputs.use-devnet) && 'shardlabs/starknet-devnet-rs:0.9.2' || '' }}
+        image: ${{ (inputs.use-devnet) && 'shardlabs/starknet-devnet-rs:0.10.0' || '' }}
         ports:
           - 5050:5050
 

--- a/__tests__/utils/ethSigner.test.ts
+++ b/__tests__/utils/ethSigner.test.ts
@@ -152,7 +152,9 @@ describe('Ethereum signer', () => {
         entrypoint: 'transfer',
         calldata: {
           recipient: contractETHAccountAddress,
-          amount: cairo.uint256(2n * 10n ** 18n), // 2 STRK of fees
+          // Hard spending cap for this test. The node checks the balance against the ceiling of
+          // the bounds sent below — 400x the estimate, i.e. 2.03 STRK under Starknet 0.14.4.
+          amount: cairo.uint256(3n * 10n ** 18n), // 3 STRK of fees
         },
       });
       await account.provider.waitForTransaction(transaction_hash);


### PR DESCRIPTION
## Motivation and Resolution

starknet-devnet 0.10.0 ships Starknet 0.14.4, and two tests stop passing against it:
`ETH account transaction V3` and `ETH account declaration V3`. Both fail in the same
`beforeAll`, on the `deployAccount` call, with
`Account balance is smaller than the transaction's maximal fee`.

The L2 gas cost of a `deploy_account` grew from 3,310,440 to 3,375,000 (+2%) between
Starknet 0.14.3 and 0.14.4 — measured by running the same test file against a devnet 0.9.0
and a devnet 0.10.0 side by side. The gas prices themselves did not move (1 Gwei-fri for all
three resources on both). That deployment deliberately over-provisions its bounds, multiplying
the estimate by 20 on the amount *and* on the price, and the node checks the account balance
against the resulting ceiling — the sum, over every resource, of its limit times its max price.
The ceiling went from 1.9868 STRK to 2.0256 STRK, while the test funds the account with a
hard-coded 2 STRK. The remaining margin had been 0.66%.

The funding constant is raised to 3 STRK, the smallest integer covering the new ceiling. It
stays a hard-coded constant on purpose: a spending limit derived from a value the node returns
has no bound of its own should the node ever answer something unreasonable.

### RPC version (if applicable)

Unchanged. devnet 0.9.x and 0.10.0 both serve RPC spec 0.10.2, and the spec version detected by
the test setup is the same before and after.

## Usage related changes

- None. This PR touches the test suite and CI only; no library code is modified.

## Development related changes

- `__tests__/utils/ethSigner.test.ts`: the ETH account is funded with 3 STRK instead of 2 before
  its deployment, with a comment recording what sets that floor so the next gas-cost drift is
  diagnosable without redoing the investigation.
- CI runs against `shardlabs/starknet-devnet-rs:0.10.0` instead of `0.9.2`. The comment above the
  image documents the 0.9.2 *floor* (JSON-RPC batches over `/ws`) and is left as is — it is a
  minimum, not the tested version.
- `AGENTS.md` keeps stating "0.9.2 or later" as the devnet minimum, which remains accurate: the
  corrected test also passes on devnet 0.9.0.
- Full suite against devnet 0.10.0: 2866 passed, 0 failed, 4 suites skipped — against 2862 passed
  and 4 failed before the fix.

## Checklist:

- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Documented the changes in code (API docs will be generated automatically)
- [x] Updated the tests
- [x] All tests are passing
