### PR TITLE
fix(security): harden code scanning findings

### DIFF
--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -31,6 +31,8 @@ jobs:
   test:
     name: Run tests
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     # TODO - periodically check if conditional services are supported; https://github.com/actions/runner/issues/822
     services:

--- a/.github/workflows/manual-docs-deploy-pages.yml
+++ b/.github/workflows/manual-docs-deploy-pages.yml
@@ -14,6 +14,8 @@ jobs:
   build:
     name: Documentation build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     environment: github-pages
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/manual-docs-version-pr.yml
+++ b/.github/workflows/manual-docs-version-pr.yml
@@ -10,6 +10,9 @@ jobs:
   build_docs:
     name: Documentation build
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v5

--- a/.github/workflows/manual-npm-dist-tag.yml
+++ b/.github/workflows/manual-npm-dist-tag.yml
@@ -13,6 +13,7 @@ on:
 jobs:
   promote:
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - uses: actions/setup-node@v5
         with:

--- a/.github/workflows/manual-tests-devnet.yml
+++ b/.github/workflows/manual-tests-devnet.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   tests:
     name: Run test on rpc-devnet
+    permissions:
+      contents: read
 
     uses: ./.github/workflows/_test.yml
     with:

--- a/.github/workflows/manual-tests-testnet.yml
+++ b/.github/workflows/manual-tests-testnet.yml
@@ -45,6 +45,7 @@ jobs:
   prepare-matrix:
     name: Prepare matrix
     runs-on: ubuntu-latest
+    permissions: {}
     outputs:
       matrix: ${{ steps.process-inputs.outputs.result }}
     steps:
@@ -71,6 +72,8 @@ jobs:
   tests:
     name: Run test on ${{ matrix.node }} ${{ matrix.protocol }} ${{ matrix.version }}
     needs: [prepare-matrix]
+    permissions:
+      contents: read
     strategy:
       max-parallel: 1
       fail-fast: ${{ inputs.fail-fast }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,11 @@ on:
       - 'ts*'
       - '!www/**'
 
+# Default every read-only job to the minimum token scope. Release jobs override
+# this with the additional write permissions they need below.
+permissions:
+  contents: read
+
 # Cancel redundant in-progress runs for the same ref (replaces the
 # `cancel_others` behaviour of the now-unmaintained skip-duplicate-actions).
 # Scoped to pull_request only: a push to a release branch is never cancelled,

--- a/__tests__/utils/logger.test.ts
+++ b/__tests__/utils/logger.test.ts
@@ -150,6 +150,12 @@ describe('Logger', () => {
       expect(gInfo).toHaveBeenCalledWith(expectedMessage);
     });
 
+    it('should remove line breaks from messages', () => {
+      logger.info('first\r\nsecond\nthird\rfourth');
+
+      expect(gInfo).toHaveBeenCalledWith('[2024-01-01T00:00:00.000Z] INFO: firstsecondthirdfourth');
+    });
+
     it('should use appropriate console methods', () => {
       logger.setLogLevel('DEBUG');
       logger.debug('Debug');

--- a/src/global/logger.ts
+++ b/src/global/logger.ts
@@ -38,7 +38,7 @@ class Logger {
 
   private formatMessage(logMessage: LogMessage): string {
     const { level, message, timestamp, data } = logMessage;
-    const sanitizedMessage = message.replace(/[\r\n]/g, '');
+    const sanitizedMessage = String(message).replace(/[\r\n]/g, '');
     let formattedMessage = `[${timestamp}] ${level}: ${sanitizedMessage}`;
 
     if (data) {

--- a/src/global/logger.ts
+++ b/src/global/logger.ts
@@ -38,13 +38,15 @@ class Logger {
 
   private formatMessage(logMessage: LogMessage): string {
     const { level, message, timestamp, data } = logMessage;
-    let formattedMessage = `[${timestamp}] ${level}: ${message}`;
+    const sanitizedMessage = message.replace(/[\r\n]/g, '');
+    let formattedMessage = `[${timestamp}] ${level}: ${sanitizedMessage}`;
 
     if (data) {
       try {
         formattedMessage += `\n${JSON.stringify(data, null, 2)}`;
       } catch (error) {
-        formattedMessage += `\n[JSON.stringify Error/Circular]: ${error}`;
+        const sanitizedError = String(error).replace(/[\r\n]/g, '');
+        formattedMessage += `\n[JSON.stringify Error/Circular]: ${sanitizedError}`;
       }
     }
 


### PR DESCRIPTION
## Summary
- scope GitHub Actions tokens to the minimum permissions each job needs
- remove CR/LF characters from logger messages and serialization errors before console output
- cover newline sanitization in the logger unit tests

## Testing
- npm run test:unit -- __tests__/utils/logger.test.ts
- npx prettier --check (changed files)