### PR TITLE
Fix 4 advisories about  paymaster

### DIFF
--- a/__tests__/accountPaymaster.test.ts
+++ b/__tests__/accountPaymaster.test.ts
@@ -2,6 +2,7 @@ import type { OutsideCallV2, OutsideExecutionTypedDataV2 } from '../src/types/ap
 import {
   Account,
   OutsideExecutionVersion,
+  constants,
   logger,
   hash,
   type Call,
@@ -20,6 +21,7 @@ describe('Account - Paymaster integration', () => {
   const mockMaliciousBuildTransactionAddedCalls = jest.fn();
   const mockExecuteTransaction = jest.fn();
   const mockGetSnip9Version = jest.fn();
+  const mockGetChainId = jest.fn();
   const mockSignMessage = jest.fn();
 
   const fakeSignature: Signature = ['0x1', '0x2'];
@@ -37,7 +39,7 @@ describe('Account - Paymaster integration', () => {
 
   const typedData: OutsideExecutionTypedDataV2 = {
     types: {},
-    domain: {},
+    domain: { chainId: constants.StarknetChainId.SN_SEPOLIA },
     primaryType: '',
     message: {
       Caller: '0xcaller',
@@ -134,6 +136,18 @@ describe('Account - Paymaster integration', () => {
     typed_data: maliciousTypedDataAddedCalls,
   };
 
+  const maliciousTypedDataWrongChain: OutsideExecutionTypedDataV2 = {
+    ...typedData,
+    domain: { chainId: constants.StarknetChainId.SN_MAIN },
+  };
+
+  const maliciousPaymasterResponseWrongChain = {
+    ...paymasterResponse,
+    typed_data: maliciousTypedDataWrongChain,
+  };
+
+  const mockMaliciousBuildTransactionWrongChain = jest.fn();
+
   const getAccount = () => {
     if (!account) {
       account = new Account({
@@ -151,18 +165,21 @@ describe('Account - Paymaster integration', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     jest.spyOn(getAccount(), 'getSnip9Version').mockImplementation(mockGetSnip9Version);
+    jest.spyOn(getAccount().provider, 'getChainId').mockImplementation(mockGetChainId);
     mockBuildTransaction.mockResolvedValue(paymasterResponse);
     mockMaliciousBuildTransactionChangeToken.mockResolvedValue(
       maliciousPaymasterResponseChangeToken
     );
     mockMaliciousBuildTransactionChangeFees.mockResolvedValue(maliciousPaymasterResponseChangeFees);
     mockMaliciousBuildTransactionAddedCalls.mockResolvedValue(maliciousPaymasterResponseAddedCalls);
+    mockMaliciousBuildTransactionWrongChain.mockResolvedValue(maliciousPaymasterResponseWrongChain);
     mockExecuteTransaction.mockResolvedValue({ transaction_hash: '0x123' });
     mockGetSnip9Version.mockResolvedValue(OutsideExecutionVersion.V2);
+    mockGetChainId.mockResolvedValue(constants.StarknetChainId.SN_SEPOLIA);
   });
 
   describe('estimatePaymasterTransactionFee', () => {
-    it('should return estimated transaction fee from paymaster', async () => {
+    test('should return estimated transaction fee from paymaster', async () => {
       const result = await getAccount().estimatePaymasterTransactionFee(originalCalls, {
         feeMode: { mode: 'default', gasToken: '0x456' },
       });
@@ -184,7 +201,7 @@ describe('Account - Paymaster integration', () => {
   });
 
   describe('executePaymasterTransaction', () => {
-    it('should sign and execute transaction via paymaster without checking gas fees', async () => {
+    test('should sign and execute transaction via paymaster without checking gas fees', async () => {
       const details: PaymasterDetails = {
         feeMode: { mode: 'default', gasToken: '0x456' },
       };
@@ -211,7 +228,7 @@ describe('Account - Paymaster integration', () => {
       expect(result).toEqual({ transaction_hash: '0x123' });
     });
 
-    it('should sign and execute transaction via paymaster', async () => {
+    test('should sign and execute transaction via paymaster', async () => {
       const details: PaymasterDetails = {
         feeMode: { mode: 'default', gasToken: '0x456' },
       };
@@ -224,7 +241,7 @@ describe('Account - Paymaster integration', () => {
       expect(result).toEqual({ transaction_hash: '0x123' });
     });
 
-    it('should not throw if token price exceeds maxPriceInGasToken but transaction is sponsored', async () => {
+    test('should not throw if token price exceeds maxPriceInGasToken but transaction is sponsored', async () => {
       const details: PaymasterDetails = {
         feeMode: { mode: 'sponsored' },
       };
@@ -238,7 +255,7 @@ describe('Account - Paymaster integration', () => {
       });
     });
 
-    it('should throw if token price exceeds maxPriceInGasToken', async () => {
+    test('should throw if token price exceeds maxPriceInGasToken', async () => {
       const details: PaymasterDetails = {
         feeMode: { mode: 'default', gasToken: '0x456' },
       };
@@ -248,7 +265,7 @@ describe('Account - Paymaster integration', () => {
       ).rejects.toThrow('Gas token price is too high');
     });
 
-    it('should throw if Gas token value is not equal to the provided gas fees', async () => {
+    test('should throw if Gas token value is not equal to the provided gas fees', async () => {
       const details: PaymasterDetails = {
         feeMode: { mode: 'default', gasToken: '0x456' },
       };
@@ -258,7 +275,7 @@ describe('Account - Paymaster integration', () => {
       ).rejects.toThrow('Gas token value is not equal to the provided gas fees');
     });
 
-    it('should throw if Gas token address is not equal to the provided gas token', async () => {
+    test('should throw if Gas token address is not equal to the provided gas token', async () => {
       const details: PaymasterDetails = {
         feeMode: { mode: 'default', gasToken: '0x456' },
       };
@@ -268,7 +285,7 @@ describe('Account - Paymaster integration', () => {
       ).rejects.toThrow('Gas token address is not equal to the provided gas token');
     });
 
-    it('should throw if provided calls are not strictly equal to the returned calls', async () => {
+    test('should throw if provided calls are not strictly equal to the returned calls', async () => {
       const details: PaymasterDetails = {
         feeMode: { mode: 'default', gasToken: '0x456' },
       };
@@ -277,6 +294,19 @@ describe('Account - Paymaster integration', () => {
       await expect(
         getAccount().executePaymasterTransaction(originalCalls, details, '0x123456')
       ).rejects.toThrow('Provided calls are not strictly equal to the returned calls');
+    });
+
+    test('should throw if paymaster typed data domain chainId does not match the provider chain', async () => {
+      const details: PaymasterDetails = {
+        feeMode: { mode: 'default', gasToken: '0x456' },
+      };
+      getAccount().paymaster.buildTransaction = mockMaliciousBuildTransactionWrongChain;
+
+      await expect(
+        getAccount().executePaymasterTransaction(originalCalls, details)
+      ).rejects.toThrow(
+        "Paymaster typed data domain chainId does not match the account's provider chain"
+      );
     });
   });
 });

--- a/__tests__/accountPaymaster.test.ts
+++ b/__tests__/accountPaymaster.test.ts
@@ -170,6 +170,50 @@ describe('Account - Paymaster integration', () => {
 
   const mockMaliciousBuildTransactionDualCallsField = jest.fn();
 
+  const maliciousTypedDataApproveInsteadOfTransfer: OutsideExecutionTypedDataV2 = {
+    ...typedData,
+    message: {
+      ...typedData.message,
+      Calls: [
+        ...originalCallsAsOutsideCalls,
+        {
+          To: '0x456',
+          Selector: hash.getSelectorFromName('approve'),
+          Calldata: ['0xcaller', '1200', '0'],
+        },
+      ],
+    },
+  };
+
+  const maliciousPaymasterResponseApproveInsteadOfTransfer = {
+    ...paymasterResponse,
+    typed_data: maliciousTypedDataApproveInsteadOfTransfer,
+  };
+
+  const mockMaliciousBuildTransactionApproveInsteadOfTransfer = jest.fn();
+
+  const maliciousTypedDataShortCalldata: OutsideExecutionTypedDataV2 = {
+    ...typedData,
+    message: {
+      ...typedData.message,
+      Calls: [
+        ...originalCallsAsOutsideCalls,
+        {
+          To: '0x456',
+          Selector: hash.getSelectorFromName('transfer'),
+          Calldata: ['0xcaller', '1200'], // missing the u256 high limb
+        },
+      ],
+    },
+  };
+
+  const maliciousPaymasterResponseShortCalldata = {
+    ...paymasterResponse,
+    typed_data: maliciousTypedDataShortCalldata,
+  };
+
+  const mockMaliciousBuildTransactionShortCalldata = jest.fn();
+
   const getAccount = () => {
     if (!account) {
       account = new Account({
@@ -197,6 +241,12 @@ describe('Account - Paymaster integration', () => {
     mockMaliciousBuildTransactionWrongChain.mockResolvedValue(maliciousPaymasterResponseWrongChain);
     mockMaliciousBuildTransactionDualCallsField.mockResolvedValue(
       maliciousPaymasterResponseDualCallsField
+    );
+    mockMaliciousBuildTransactionApproveInsteadOfTransfer.mockResolvedValue(
+      maliciousPaymasterResponseApproveInsteadOfTransfer
+    );
+    mockMaliciousBuildTransactionShortCalldata.mockResolvedValue(
+      maliciousPaymasterResponseShortCalldata
     );
     mockExecuteTransaction.mockResolvedValue({ transaction_hash: '0x123' });
     mockGetSnip9Version.mockResolvedValue(OutsideExecutionVersion.V2);
@@ -344,6 +394,31 @@ describe('Account - Paymaster integration', () => {
         getAccount().executePaymasterTransaction(originalCalls, details)
       ).rejects.toThrow(
         'Paymaster typed data must declare exactly one of "calls" (SNIP-9 V1) or "Calls" (SNIP-9 V2)'
+      );
+    });
+
+    test('should throw if the gas-token call selector is not a transfer', async () => {
+      const details: PaymasterDetails = {
+        feeMode: { mode: 'default', gasToken: '0x456' },
+      };
+      getAccount().paymaster.buildTransaction =
+        mockMaliciousBuildTransactionApproveInsteadOfTransfer;
+
+      await expect(
+        getAccount().executePaymasterTransaction(originalCalls, details)
+      ).rejects.toThrow('Gas token call selector is not a transfer');
+    });
+
+    test('should throw if the gas-token call calldata does not have the expected shape', async () => {
+      const details: PaymasterDetails = {
+        feeMode: { mode: 'default', gasToken: '0x456' },
+      };
+      getAccount().paymaster.buildTransaction = mockMaliciousBuildTransactionShortCalldata;
+
+      await expect(
+        getAccount().executePaymasterTransaction(originalCalls, details)
+      ).rejects.toThrow(
+        'Gas token transfer calldata does not match the expected recipient/amount shape'
       );
     });
   });

--- a/__tests__/accountPaymaster.test.ts
+++ b/__tests__/accountPaymaster.test.ts
@@ -1,4 +1,8 @@
-import type { OutsideCallV2, OutsideExecutionTypedDataV2 } from '../src/types/api';
+import type {
+  OutsideCallV2,
+  OutsideExecutionMessageV2,
+  OutsideExecutionTypedDataV2,
+} from '../src/types/api';
 import {
   Account,
   OutsideExecutionVersion,
@@ -148,6 +152,24 @@ describe('Account - Paymaster integration', () => {
 
   const mockMaliciousBuildTransactionWrongChain = jest.fn();
 
+  const maliciousTypedDataDualCallsField: OutsideExecutionTypedDataV2 = {
+    ...typedData,
+    message: {
+      ...typedData.message,
+      // Undeclared lowercase field, added on top of the real `Calls`. It mirrors a fully
+      // valid response (original call + fee call), so it passes every existing check when
+      // read instead of `Calls`.
+      calls: typedData.message.Calls,
+    } as OutsideExecutionMessageV2,
+  };
+
+  const maliciousPaymasterResponseDualCallsField = {
+    ...paymasterResponse,
+    typed_data: maliciousTypedDataDualCallsField,
+  };
+
+  const mockMaliciousBuildTransactionDualCallsField = jest.fn();
+
   const getAccount = () => {
     if (!account) {
       account = new Account({
@@ -173,6 +195,9 @@ describe('Account - Paymaster integration', () => {
     mockMaliciousBuildTransactionChangeFees.mockResolvedValue(maliciousPaymasterResponseChangeFees);
     mockMaliciousBuildTransactionAddedCalls.mockResolvedValue(maliciousPaymasterResponseAddedCalls);
     mockMaliciousBuildTransactionWrongChain.mockResolvedValue(maliciousPaymasterResponseWrongChain);
+    mockMaliciousBuildTransactionDualCallsField.mockResolvedValue(
+      maliciousPaymasterResponseDualCallsField
+    );
     mockExecuteTransaction.mockResolvedValue({ transaction_hash: '0x123' });
     mockGetSnip9Version.mockResolvedValue(OutsideExecutionVersion.V2);
     mockGetChainId.mockResolvedValue(constants.StarknetChainId.SN_SEPOLIA);
@@ -306,6 +331,19 @@ describe('Account - Paymaster integration', () => {
         getAccount().executePaymasterTransaction(originalCalls, details)
       ).rejects.toThrow(
         "Paymaster typed data domain chainId does not match the account's provider chain"
+      );
+    });
+
+    test('should throw if paymaster typed data declares both "calls" and "Calls"', async () => {
+      const details: PaymasterDetails = {
+        feeMode: { mode: 'default', gasToken: '0x456' },
+      };
+      getAccount().paymaster.buildTransaction = mockMaliciousBuildTransactionDualCallsField;
+
+      await expect(
+        getAccount().executePaymasterTransaction(originalCalls, details)
+      ).rejects.toThrow(
+        'Paymaster typed data must declare exactly one of "calls" (SNIP-9 V1) or "Calls" (SNIP-9 V2)'
       );
     });
   });

--- a/__tests__/accountPaymaster.test.ts
+++ b/__tests__/accountPaymaster.test.ts
@@ -238,6 +238,42 @@ describe('Account - Paymaster integration', () => {
 
   const mockMaliciousBuildTransactionHighLimbDrain = jest.fn();
 
+  const sponsoredTypedData: OutsideExecutionTypedDataV2 = {
+    ...typedData,
+    message: {
+      ...typedData.message,
+      Calls: originalCallsAsOutsideCalls, // sponsored: no appended fee-transfer call
+    },
+  };
+
+  const sponsoredPaymasterResponse = {
+    ...paymasterResponse,
+    typed_data: sponsoredTypedData,
+  };
+
+  const mockSponsoredBuildTransaction = jest.fn();
+
+  const maliciousTypedDataSponsoredSubstitutedCalls: OutsideExecutionTypedDataV2 = {
+    ...typedData,
+    message: {
+      ...typedData.message,
+      Calls: [
+        {
+          To: '0x999',
+          Selector: hash.getSelectorFromName('transfer'),
+          Calldata: ['0xattacker', '999999', '0'],
+        },
+      ], // a call the user never requested; still no fee call since this is "sponsored"
+    },
+  };
+
+  const maliciousPaymasterResponseSponsoredSubstitutedCalls = {
+    ...paymasterResponse,
+    typed_data: maliciousTypedDataSponsoredSubstitutedCalls,
+  };
+
+  const mockMaliciousBuildTransactionSponsoredSubstitutedCalls = jest.fn();
+
   const getAccount = () => {
     if (!account) {
       account = new Account({
@@ -256,6 +292,10 @@ describe('Account - Paymaster integration', () => {
     jest.clearAllMocks();
     jest.spyOn(getAccount(), 'getSnip9Version').mockImplementation(mockGetSnip9Version);
     jest.spyOn(getAccount().provider, 'getChainId').mockImplementation(mockGetChainId);
+    // Reset to the default mock: individual tests below override this when they need a
+    // specific (malicious or sponsored) response, but the account object is a shared
+    // singleton, so without this reset an override from one test would leak into the next.
+    getAccount().paymaster.buildTransaction = mockBuildTransaction;
     mockBuildTransaction.mockResolvedValue(paymasterResponse);
     mockMaliciousBuildTransactionChangeToken.mockResolvedValue(
       maliciousPaymasterResponseChangeToken
@@ -274,6 +314,10 @@ describe('Account - Paymaster integration', () => {
     );
     mockMaliciousBuildTransactionHighLimbDrain.mockResolvedValue(
       maliciousPaymasterResponseHighLimbDrain
+    );
+    mockSponsoredBuildTransaction.mockResolvedValue(sponsoredPaymasterResponse);
+    mockMaliciousBuildTransactionSponsoredSubstitutedCalls.mockResolvedValue(
+      maliciousPaymasterResponseSponsoredSubstitutedCalls
     );
     mockExecuteTransaction.mockResolvedValue({ transaction_hash: '0x123' });
     mockGetSnip9Version.mockResolvedValue(OutsideExecutionVersion.V2);
@@ -347,6 +391,7 @@ describe('Account - Paymaster integration', () => {
       const details: PaymasterDetails = {
         feeMode: { mode: 'sponsored' },
       };
+      getAccount().paymaster.buildTransaction = mockSponsoredBuildTransaction;
       const result = await getAccount().executePaymasterTransaction(
         originalCalls,
         details,
@@ -458,6 +503,18 @@ describe('Account - Paymaster integration', () => {
       await expect(
         getAccount().executePaymasterTransaction(originalCalls, details)
       ).rejects.toThrow('Gas token value is not equal to the provided gas fees');
+    });
+
+    test('should throw if a sponsored transaction substitutes different calls', async () => {
+      const details: PaymasterDetails = {
+        feeMode: { mode: 'sponsored' },
+      };
+      getAccount().paymaster.buildTransaction =
+        mockMaliciousBuildTransactionSponsoredSubstitutedCalls;
+
+      await expect(
+        getAccount().executePaymasterTransaction(originalCalls, details)
+      ).rejects.toThrow('Provided calls are not strictly equal to the returned calls');
     });
   });
 });

--- a/__tests__/accountPaymaster.test.ts
+++ b/__tests__/accountPaymaster.test.ts
@@ -214,6 +214,30 @@ describe('Account - Paymaster integration', () => {
 
   const mockMaliciousBuildTransactionShortCalldata = jest.fn();
 
+  const maliciousTypedDataHighLimbDrain: OutsideExecutionTypedDataV2 = {
+    ...typedData,
+    message: {
+      ...typedData.message,
+      Calls: [
+        ...originalCallsAsOutsideCalls,
+        {
+          To: '0x456',
+          Selector: hash.getSelectorFromName('transfer'),
+          // low limb (1200) matches the suggested fee exactly; the high limb (2^128 - 1) is
+          // where the actual drain happens once both limbs are combined on-chain.
+          Calldata: ['0xcaller', '1200', '340282366920938463463374607431768211455'],
+        },
+      ],
+    },
+  };
+
+  const maliciousPaymasterResponseHighLimbDrain = {
+    ...paymasterResponse,
+    typed_data: maliciousTypedDataHighLimbDrain,
+  };
+
+  const mockMaliciousBuildTransactionHighLimbDrain = jest.fn();
+
   const getAccount = () => {
     if (!account) {
       account = new Account({
@@ -247,6 +271,9 @@ describe('Account - Paymaster integration', () => {
     );
     mockMaliciousBuildTransactionShortCalldata.mockResolvedValue(
       maliciousPaymasterResponseShortCalldata
+    );
+    mockMaliciousBuildTransactionHighLimbDrain.mockResolvedValue(
+      maliciousPaymasterResponseHighLimbDrain
     );
     mockExecuteTransaction.mockResolvedValue({ transaction_hash: '0x123' });
     mockGetSnip9Version.mockResolvedValue(OutsideExecutionVersion.V2);
@@ -420,6 +447,17 @@ describe('Account - Paymaster integration', () => {
       ).rejects.toThrow(
         'Gas token transfer calldata does not match the expected recipient/amount shape'
       );
+    });
+
+    test('should throw if the gas-token transfer high limb inflates the amount, even without an explicit maxFeeInGasToken', async () => {
+      const details: PaymasterDetails = {
+        feeMode: { mode: 'default', gasToken: '0x456' },
+      };
+      getAccount().paymaster.buildTransaction = mockMaliciousBuildTransactionHighLimbDrain;
+
+      await expect(
+        getAccount().executePaymasterTransaction(originalCalls, details)
+      ).rejects.toThrow('Gas token value is not equal to the provided gas fees');
     });
   });
 });

--- a/__tests__/accountPaymaster.test.ts
+++ b/__tests__/accountPaymaster.test.ts
@@ -274,6 +274,20 @@ describe('Account - Paymaster integration', () => {
 
   const mockMaliciousBuildTransactionSponsoredSubstitutedCalls = jest.fn();
 
+  // SNIP-29's own typed-data examples show domain.chainId as an already-encoded hex felt, but
+  // some paymasters (e.g. AVNU) return the raw shortstring instead. Both hash to the same felt.
+  const typedDataChainIdAsShortstring: OutsideExecutionTypedDataV2 = {
+    ...typedData,
+    domain: { chainId: 'SN_SEPOLIA' },
+  };
+
+  const paymasterResponseChainIdAsShortstring = {
+    ...paymasterResponse,
+    typed_data: typedDataChainIdAsShortstring,
+  };
+
+  const mockBuildTransactionChainIdAsShortstring = jest.fn();
+
   const getAccount = () => {
     if (!account) {
       account = new Account({
@@ -318,6 +332,9 @@ describe('Account - Paymaster integration', () => {
     mockSponsoredBuildTransaction.mockResolvedValue(sponsoredPaymasterResponse);
     mockMaliciousBuildTransactionSponsoredSubstitutedCalls.mockResolvedValue(
       maliciousPaymasterResponseSponsoredSubstitutedCalls
+    );
+    mockBuildTransactionChainIdAsShortstring.mockResolvedValue(
+      paymasterResponseChainIdAsShortstring
     );
     mockExecuteTransaction.mockResolvedValue({ transaction_hash: '0x123' });
     mockGetSnip9Version.mockResolvedValue(OutsideExecutionVersion.V2);
@@ -515,6 +532,17 @@ describe('Account - Paymaster integration', () => {
       await expect(
         getAccount().executePaymasterTransaction(originalCalls, details)
       ).rejects.toThrow('Provided calls are not strictly equal to the returned calls');
+    });
+
+    test('should not throw if the domain chainId is a raw shortstring instead of an encoded felt', async () => {
+      const details: PaymasterDetails = {
+        feeMode: { mode: 'default', gasToken: '0x456' },
+      };
+      getAccount().paymaster.buildTransaction = mockBuildTransactionChainIdAsShortstring;
+
+      const result = await getAccount().executePaymasterTransaction(originalCalls, details);
+
+      expect(result).toEqual({ transaction_hash: '0x123' });
     });
   });
 });

--- a/src/account/default.ts
+++ b/src/account/default.ts
@@ -1138,12 +1138,13 @@ export class Account implements AccountInterface {
     const preparedTransaction = await this.buildPaymasterTransaction(calls, paymasterDetails);
 
     // Check the transaction is safe
-    // Check gas fee value & gas token address
+    // Check chain binding, gas fee value & gas token address
     // Check that provided calls and builded calls are strictly equal
     assertPaymasterTransactionSafety(
       preparedTransaction,
       calls,
       paymasterDetails,
+      await this.provider.getChainId(),
       maxFeeInGasToken
     );
 

--- a/src/utils/paymaster.ts
+++ b/src/utils/paymaster.ts
@@ -6,7 +6,13 @@ import { CallData } from './calldata';
 import { toOutsideCallV2 } from './outsideExecution';
 import { getSelectorFromName } from './hash';
 import { toBigInt } from './num';
-import type { OutsideCallV1, OutsideCallV2, OutsideExecutionTypedData } from '../types/api';
+import type {
+  OutsideCallV1,
+  OutsideCallV2,
+  OutsideExecutionMessageV1,
+  OutsideExecutionMessageV2,
+  OutsideExecutionTypedData,
+} from '../types/api';
 
 /**
  * Return randomly select available public paymaster node url
@@ -191,11 +197,19 @@ export const assertPaymasterTransactionSafety = (
 
     // A sponsored transaction has no appended gas-token call: nothing left to verify below.
     if (paymasterDetails.feeMode.mode !== 'sponsored') {
-      // extract unsafe calls to verify
-      const unsafeCalls: (OutsideCallV1 | OutsideCallV2)[] =
-        'calls' in preparedTransaction.typed_data.message
-          ? (preparedTransaction.typed_data.message as any).calls
-          : (preparedTransaction.typed_data.message as any).Calls;
+      // extract unsafe calls to verify: the message must declare exactly one of the two
+      // SNIP-9 shapes, never both — otherwise a paymaster could present a benign array to
+      // this check while a different, attacker-chosen array is the one actually signed.
+      const { message } = preparedTransaction.typed_data;
+      const hasV1Calls = 'calls' in message;
+      const hasV2Calls = 'Calls' in message;
+      assert(
+        hasV1Calls !== hasV2Calls,
+        'Paymaster typed data must declare exactly one of "calls" (SNIP-9 V1) or "Calls" (SNIP-9 V2)'
+      );
+      const unsafeCalls: (OutsideCallV1 | OutsideCallV2)[] = hasV1Calls
+        ? (message as OutsideExecutionMessageV1).calls
+        : (message as OutsideExecutionMessageV2).Calls;
 
       // Assert calls provided and unsafe calls are strictly equal
       assertCallsAreStrictlyEqual(calls, unsafeCalls);

--- a/src/utils/paymaster.ts
+++ b/src/utils/paymaster.ts
@@ -85,18 +85,28 @@ const assertGasTokenFromUnsafeCalls = (
  * Asserts that the given calls are strictly equal, otherwise throws an error.
  * @param {Call[]} originalCalls - The original calls.
  * @param {Call[]} unsafeCalls - The unsafe calls.
+ * @param {boolean} [isSponsored] - Whether the transaction is sponsored. A sponsored
+ * transaction appends no gas-token fee-transfer call; a non-sponsored one appends exactly
+ * one. Defaults to `false` for backward compatibility.
  * @throws {Error} Throws an error if the calls are not strictly equal.
+ * @example
+ * ```typescript
+ * paymaster.assertCallsAreStrictlyEqual(originalCalls, unsafeCalls, true); // sponsored: no fee call
+ * ```
  */
 export function assertCallsAreStrictlyEqual(
   originalCalls: Call[],
-  unsafeCalls: (OutsideCallV1 | OutsideCallV2)[]
+  unsafeCalls: (OutsideCallV1 | OutsideCallV2)[],
+  isSponsored: boolean = false
 ) {
   const baseError = 'Provided calls are not strictly equal to the returned calls';
 
-  // Unsafe calls always include one additional call (gas token transfer)
+  // A sponsored transaction appends no gas-token fee-transfer call; a non-sponsored one
+  // appends exactly one.
+  const expectedExtraCalls = isSponsored ? 0 : 1;
   assert(
-    unsafeCalls.length - 1 === originalCalls.length,
-    `${baseError}: Expected ${originalCalls.length + 1} calls, got ${unsafeCalls.length}`
+    unsafeCalls.length - expectedExtraCalls === originalCalls.length,
+    `${baseError}: Expected ${originalCalls.length + expectedExtraCalls} calls, got ${unsafeCalls.length}`
   );
 
   // Compare each original call with the corresponding unsafe call
@@ -212,25 +222,28 @@ export const assertPaymasterTransactionSafety = (
     // regardless of fee mode: a cross-chain signature is dangerous even when sponsored.
     assertChainIdFromTypedData(preparedTransaction.typed_data, chainId);
 
+    // extract unsafe calls to verify: the message must declare exactly one of the two
+    // SNIP-9 shapes, never both — otherwise a paymaster could present a benign array to
+    // this check while a different, attacker-chosen array is the one actually signed.
+    // This runs for every fee mode: a sponsored transaction still executes whatever calls
+    // are in this array, so it needs the same protection.
+    const { message } = preparedTransaction.typed_data;
+    const hasV1Calls = 'calls' in message;
+    const hasV2Calls = 'Calls' in message;
+    assert(
+      hasV1Calls !== hasV2Calls,
+      'Paymaster typed data must declare exactly one of "calls" (SNIP-9 V1) or "Calls" (SNIP-9 V2)'
+    );
+    const unsafeCalls: (OutsideCallV1 | OutsideCallV2)[] = hasV1Calls
+      ? (message as OutsideExecutionMessageV1).calls
+      : (message as OutsideExecutionMessageV2).Calls;
+
+    // A sponsored transaction appends no gas-token call, so the calls array should match the
+    // user's request 1:1; a non-sponsored one appends exactly one (the fee transfer).
+    assertCallsAreStrictlyEqual(calls, unsafeCalls, paymasterDetails.feeMode.mode === 'sponsored');
+
     // A sponsored transaction has no appended gas-token call: nothing left to verify below.
     if (paymasterDetails.feeMode.mode !== 'sponsored') {
-      // extract unsafe calls to verify: the message must declare exactly one of the two
-      // SNIP-9 shapes, never both — otherwise a paymaster could present a benign array to
-      // this check while a different, attacker-chosen array is the one actually signed.
-      const { message } = preparedTransaction.typed_data;
-      const hasV1Calls = 'calls' in message;
-      const hasV2Calls = 'Calls' in message;
-      assert(
-        hasV1Calls !== hasV2Calls,
-        'Paymaster typed data must declare exactly one of "calls" (SNIP-9 V1) or "Calls" (SNIP-9 V2)'
-      );
-      const unsafeCalls: (OutsideCallV1 | OutsideCallV2)[] = hasV1Calls
-        ? (message as OutsideExecutionMessageV1).calls
-        : (message as OutsideExecutionMessageV2).Calls;
-
-      // Assert calls provided and unsafe calls are strictly equal
-      assertCallsAreStrictlyEqual(calls, unsafeCalls);
-
       // Assert gas token address from unsafe calls is equal to the provided gas token
       assertGasTokenFromUnsafeCalls(unsafeCalls, paymasterDetails.feeMode.gasToken);
 

--- a/src/utils/paymaster.ts
+++ b/src/utils/paymaster.ts
@@ -57,10 +57,20 @@ const assertGasTokenFromUnsafeCalls = (
   gasToken: string
 ) => {
   const unsafeCall = toOutsideCallV2(unsafeCalls[unsafeCalls.length - 1]);
-  // Assert gas token to signed is stricly equal to the provided gas fees
+  // Assert gas token to signed is stricly equal to the provided gas token
   assert(
     BigInt(unsafeCall.To) === BigInt(gasToken),
     'Gas token address is not equal to the provided gas token'
+  );
+  // Assert the appended call is a plain ERC-20 `transfer`, not e.g. an `approve`
+  assert(
+    unsafeCall.Selector === getSelectorFromName('transfer'),
+    'Gas token call selector is not a transfer'
+  );
+  // Assert the calldata shape matches transfer(recipient, amount: Uint256) -> 3 felts
+  assert(
+    CallData.toCalldata(unsafeCall.Calldata).length === 3,
+    'Gas token transfer calldata does not match the expected recipient/amount shape'
   );
 };
 

--- a/src/utils/paymaster.ts
+++ b/src/utils/paymaster.ts
@@ -6,6 +6,7 @@ import { CallData } from './calldata';
 import { toOutsideCallV2 } from './outsideExecution';
 import { getSelectorFromName } from './hash';
 import { toBigInt } from './num';
+import { encodeShortString } from './shortString';
 import { uint256ToBN } from './uint256';
 import type {
   OutsideCallV1,
@@ -164,6 +165,30 @@ export function assertCallsAreStrictlyEqual(
 }
 
 /**
+ * Normalizes a SNIP-12 domain field declared `shortstring` (e.g. `domain.chainId`) to a felt.
+ * SNIP-29's own typed-data examples always show `chainId` as an already-encoded hex felt
+ * (e.g. `"0x534e5f4d41494e"`), but some paymasters do not follow that and return the raw
+ * shortstring instead (e.g. `"SN_SEPOLIA"`). Both hash to the same felt once encoded, so this
+ * mirrors the same tolerant fallback `src/utils/typedData.ts`'s own hash computation already
+ * uses for `shortstring`/`felt` fields, rather than rejecting a non-compliant but harmless
+ * paymaster response.
+ * @param {string | number} value - The raw domain field value.
+ * @returns {bigint} The felt value of the domain field.
+ * @example
+ * ```typescript
+ * domainFieldToFelt('SN_SEPOLIA'); // 1536727068981429685321n
+ * domainFieldToFelt('0x534e5f5345504f4c4941'); // 1536727068981429685321n
+ * ```
+ */
+const domainFieldToFelt = (value: string | number): bigint => {
+  try {
+    return toBigInt(value);
+  } catch {
+    return toBigInt(encodeShortString(String(value)));
+  }
+};
+
+/**
  * Asserts that the typed-data domain returned by the paymaster is bound to the account's own
  * provider chain, so a malicious or mismatched paymaster cannot obtain a signature that is
  * valid on a different chain than the one the user intended.
@@ -173,7 +198,7 @@ export function assertCallsAreStrictlyEqual(
  * @example
  * ```typescript
  * assertChainIdFromTypedData(
- *   { domain: { chainId: '0x534e5f5345504f4c4941' }, message: {}, primaryType: '', types: {} },
+ *   { domain: { chainId: 'SN_SEPOLIA' }, message: {}, primaryType: '', types: {} },
  *   constants.StarknetChainId.SN_SEPOLIA
  * );
  * // does not throw
@@ -184,7 +209,8 @@ const assertChainIdFromTypedData = (
   chainId: StarknetChainId
 ) => {
   assert(
-    typedData.domain.chainId !== undefined && BigInt(typedData.domain.chainId) === BigInt(chainId),
+    typedData.domain.chainId !== undefined &&
+      domainFieldToFelt(typedData.domain.chainId) === BigInt(chainId),
     "Paymaster typed data domain chainId does not match the account's provider chain"
   );
 };

--- a/src/utils/paymaster.ts
+++ b/src/utils/paymaster.ts
@@ -6,6 +6,7 @@ import { CallData } from './calldata';
 import { toOutsideCallV2 } from './outsideExecution';
 import { getSelectorFromName } from './hash';
 import { toBigInt } from './num';
+import { uint256ToBN } from './uint256';
 import type {
   OutsideCallV1,
   OutsideCallV2,
@@ -44,10 +45,16 @@ const assertGasFeeFromUnsafeCalls = (
 ) => {
   const unsafeCall = toOutsideCallV2(unsafeCalls[unsafeCalls.length - 1]);
   const unsafeGasTokenCalldata = CallData.toCalldata(unsafeCall.Calldata);
-  const unsafeGasTokenValue = unsafeGasTokenCalldata[1];
+  // The transfer amount is a Uint256: low limb at index 1, high limb at index 2. Reading only
+  // the low limb lets a malicious paymaster inflate the signed amount via the high limb while
+  // this check still sees a match.
+  const unsafeGasTokenValue = uint256ToBN({
+    low: unsafeGasTokenCalldata[1],
+    high: unsafeGasTokenCalldata[2],
+  });
   // Assert gas token to signed is stricly equal to the provided gas fees
   assert(
-    BigInt(unsafeGasTokenValue) === BigInt(fees),
+    unsafeGasTokenValue === BigInt(fees),
     'Gas token value is not equal to the provided gas fees'
   );
 };
@@ -227,18 +234,18 @@ export const assertPaymasterTransactionSafety = (
       // Assert gas token address from unsafe calls is equal to the provided gas token
       assertGasTokenFromUnsafeCalls(unsafeCalls, paymasterDetails.feeMode.gasToken);
 
-      // If maxFeeInGasToken is provided, do all safety checks
+      // Assert the signed gas-token amount matches the fee displayed to the user, whether or
+      // not the caller supplied an explicit ceiling below
+      assertGasFeeFromUnsafeCalls(
+        unsafeCalls,
+        preparedTransaction.fee.suggested_max_fee_in_gas_token
+      );
+
+      // If maxFeeInGasToken is provided, also enforce the user-approved ceiling
       if (maxFeeInGasToken) {
-        // Check if the gas token price is too high
         assert(
           preparedTransaction.fee.suggested_max_fee_in_gas_token <= maxFeeInGasToken,
           'Gas token price is too high'
-        );
-
-        // Assert gas fee from unsafe calls is equal to the provided gas fees(the value used to display the gas fee to the user)
-        assertGasFeeFromUnsafeCalls(
-          unsafeCalls,
-          preparedTransaction.fee.suggested_max_fee_in_gas_token
         );
       }
     }

--- a/src/utils/paymaster.ts
+++ b/src/utils/paymaster.ts
@@ -1,4 +1,4 @@
-import { NetworkName, PAYMASTER_RPC_NODES } from '../global/constants';
+import { NetworkName, PAYMASTER_RPC_NODES, StarknetChainId } from '../global/constants';
 import { logger } from '../global/logger';
 import { BigNumberish, PaymasterDetails, PreparedTransaction, Call } from '../types';
 import assert from './assert';
@@ -6,7 +6,7 @@ import { CallData } from './calldata';
 import { toOutsideCallV2 } from './outsideExecution';
 import { getSelectorFromName } from './hash';
 import { toBigInt } from './num';
-import type { OutsideCallV1, OutsideCallV2 } from '../types/api';
+import type { OutsideCallV1, OutsideCallV2, OutsideExecutionTypedData } from '../types/api';
 
 /**
  * Return randomly select available public paymaster node url
@@ -130,16 +130,67 @@ export function assertCallsAreStrictlyEqual(
   }
 }
 
+/**
+ * Asserts that the typed-data domain returned by the paymaster is bound to the account's own
+ * provider chain, so a malicious or mismatched paymaster cannot obtain a signature that is
+ * valid on a different chain than the one the user intended.
+ * @param {OutsideExecutionTypedData} typedData - The typed data returned by the paymaster.
+ * @param {StarknetChainId} chainId - The chain id of the account's own provider.
+ * @throws {Error} Throws an error if the domain chainId does not match the provider chain.
+ * @example
+ * ```typescript
+ * assertChainIdFromTypedData(
+ *   { domain: { chainId: '0x534e5f5345504f4c4941' }, message: {}, primaryType: '', types: {} },
+ *   constants.StarknetChainId.SN_SEPOLIA
+ * );
+ * // does not throw
+ * ```
+ */
+const assertChainIdFromTypedData = (
+  typedData: OutsideExecutionTypedData,
+  chainId: StarknetChainId
+) => {
+  assert(
+    typedData.domain.chainId !== undefined && BigInt(typedData.domain.chainId) === BigInt(chainId),
+    "Paymaster typed data domain chainId does not match the account's provider chain"
+  );
+};
+
+/**
+ * Asserts that a paymaster-prepared transaction is safe to sign: the typed-data domain is
+ * bound to the account's own chain, and — for non-sponsored transactions — the calls and the
+ * appended gas-token transfer match what the user actually requested.
+ * @param {PreparedTransaction} preparedTransaction - The transaction returned by the paymaster.
+ * @param {Call[]} calls - The calls originally requested by the user.
+ * @param {PaymasterDetails} paymasterDetails - The fee mode and related paymaster details.
+ * @param {StarknetChainId} chainId - The chain id of the account's own provider.
+ * @param {BigNumberish} [maxFeeInGasToken] - Optional user-approved ceiling on the gas-token fee.
+ * @throws {Error} Throws an error if any of the above safety properties do not hold.
+ * @example
+ * ```typescript
+ * assertPaymasterTransactionSafety(
+ *   preparedTransaction,
+ *   calls,
+ *   { feeMode: { mode: 'default', gasToken: strkAddress } },
+ *   constants.StarknetChainId.SN_SEPOLIA
+ * );
+ * // does not throw if preparedTransaction is exactly what was requested
+ * ```
+ */
 export const assertPaymasterTransactionSafety = (
   preparedTransaction: PreparedTransaction,
   calls: Call[],
   paymasterDetails: PaymasterDetails,
+  chainId: StarknetChainId,
   maxFeeInGasToken?: BigNumberish
 ) => {
-  // If tx is not sponsored, we can skip safety checks
-  if (paymasterDetails.feeMode.mode !== 'sponsored') {
-    // We only check the calls if user effectively has to pay something
-    if (preparedTransaction.type === 'invoke' || preparedTransaction.type === 'deploy_and_invoke') {
+  if (preparedTransaction.type === 'invoke' || preparedTransaction.type === 'deploy_and_invoke') {
+    // The typed-data domain must always be bound to the account's own provider chain,
+    // regardless of fee mode: a cross-chain signature is dangerous even when sponsored.
+    assertChainIdFromTypedData(preparedTransaction.typed_data, chainId);
+
+    // A sponsored transaction has no appended gas-token call: nothing left to verify below.
+    if (paymasterDetails.feeMode.mode !== 'sponsored') {
       // extract unsafe calls to verify
       const unsafeCalls: (OutsideCallV1 | OutsideCallV2)[] =
         'calls' in preparedTransaction.typed_data.message


### PR DESCRIPTION
## Motivation and Resolution

Hardens the SNIP-29 paymaster safety check (`assertPaymasterTransactionSafety()` and its helpers in `src/utils/paymaster.ts`), which is the only client-side guard preventing a malicious or misbehaving paymaster from getting the account to sign something other than what the user requested.

Closes four confirmed security advisories, plus one additional gap found while reviewing this code, plus one real-world compatibility issue found by exercising the fix against a live paymaster and a test dApp:

- **Cross-chain domain binding** — the typed-data domain's `chainId` was never compared against the account's own provider chain, so a mismatched/malicious paymaster could obtain a signature valid on a different chain than intended.
- **Dual `calls`/`Calls` field** — a paymaster could return typed data declaring both the SNIP-9 V1 `calls` field and the V2 `Calls` field; the safety check validated whichever was present by key lookup, while the hash/signature is bound only to `Calls`, letting a benign decoy pass validation while a different array gets signed.
- **Unvalidated appended fee call** — the gas-token transfer call appended by the paymaster was checked only on its destination address; its selector and calldata shape were never verified, so it could be swapped for e.g. an unlimited `approve` without detection.
- **Truncated fee amount (critical)** — the appended transfer's amount is a `u256` (two felts); only the low limb was compared, and only when the caller passed an explicit `maxFeeInGasToken`. A malicious paymaster could match the low limb while inflating the high limb, draining far more than displayed, and callers who omitted the ceiling got no amount check at all.
- **Sponsored transactions skipped calls verification entirely** (not tied to a reported advisory) — the whole safety check was gated behind `feeMode.mode !== 'sponsored'`, so a sponsored paymaster response could substitute arbitrary calls with zero verification.
- **Real-world compatibility** — SNIP-29's own typed-data examples show `domain.chainId` as an already-encoded hex felt, but at least one paymaster in production returns the raw shortstring instead; the new chain-binding check now tolerates both, matching how `getMessageHash()` already hashes this field.

> [!IMPORTANT]
> This PR closes every gap above that is actually closable from the SDK. One is not: the appended gas-token transfer's recipient (`calldata[0]` / `Fee Receiver`) still cannot be verified against a known-good address, because neither the SNIP-29 RPC surface nor `PaymasterInterface` exposes a canonical "paymaster receiving address" for the client to check against. This is a protocol-level gap, not a client bug — the fix for it already exists in draft form: `OutsideExecution v3` (see [SNIP-29 § Security Considerations](https://github.com/starknet-io/SNIPs/blob/main/SNIPS/snip-29.md#security-considerations)) moves the fee payment into its own typed `Fee` field, with an explicit `Fee Receiver: ContractAddress`, making the recipient part of what is actually signed instead of an opaque call.
>
> @adrienlacombe, would you have some bandwidth to help move SNIP-29 toward ratifying/adopting v3? It would let us close this last piece properly, at the right layer, instead of leaving it as a documented residual risk. Thank you very much in advance.

> [!NOTE]
> NOTA: this PR patches `assertPaymasterTransactionSafety()` because it is, today, the only guard available — not because a JS SDK is the right place for this kind of security property. A check implemented in a library only protects callers who happen to use this exact, unmodified code; it offers no guarantee once forked, bypassed, or reimplemented. Every one of the advisories closed here exists only because this trust boundary currently lives in `starknet.js` instead of being enforced by the protocol/account itself. `OutsideExecution v3` moves that guarantee to where it structurally belongs — a typed, signed field the account contract itself can enforce — which is the right fix rather than another future round of client-side patching.
>
> @adrienlacombe, it would be very much appreciated if SNIP-29 could move forward in that direction. Please let us know if there is anything useful we can help with from the starknet.js side once it does. Thank you for your time and consideration.

### RPC version (if applicable)

Not applicable — this is client-side validation logic with no RPC spec version dependency.

## Usage related changes

- `assertPaymasterTransactionSafety()` (exported via `starknet.paymaster`) has a new required parameter: `chainId: StarknetChainId`, inserted as the 4th argument (`maxFeeInGasToken` moves to 5th). `Account.executePaymasterTransaction()` passes this automatically; only direct callers of the exported helper need to update their call site.
- `assertCallsAreStrictlyEqual()` (also exported) gains an optional `isSponsored: boolean` parameter (default `false`), fully backward compatible.
- Sponsored paymaster transactions are now verified for calls equality, same as non-sponsored ones (previously unverified).
- A paymaster returning `domain.chainId` as a raw shortstring (e.g. `"SN_SEPOLIA"`) instead of an encoded felt is now accepted, not just the SNIP-29-canonical hex form.

## Development related changes

- Extended `__tests__/accountPaymaster.test.ts` with one regression test per fix above (dual-field rejection, selector/calldata-shape validation, full `u256` amount check, cross-chain domain rejection, sponsored-mode call substitution, chainId shortstring tolerance).
- Renamed `it(` to `test(` throughout that file for consistency with the rest of the test suite (84/89 files already used `test`).
- Fixed a pre-existing test-isolation bug exposed by this work: the shared `Account` singleton's `paymaster.buildTransaction` mock was only assigned once at construction, so one test overriding it could silently leak into a later test that never set its own. `beforeEach` now resets it every time.
- Manually verified against a live AVNU Sepolia paymaster (via an external test script) and a test dApp for the full non-sponsored SNIP-29 flow.

## Checklist:

- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Linked the issues which this PR resolves — the four advisories are private GitHub Security Advisories (still in triage), not public issues, so they cannot be linked with `#`; reference by GHSA id in the description above instead.
- [x] Documented the changes in code (API docs will be generated automatically)
- [x] Updated the tests
- [x] All tests are passing
