### PR TITLE
fix(deployer): preserve constructor argument names before ABI ordering

### DIFF
--- a/__tests__/utils/contract.test.ts
+++ b/__tests__/utils/contract.test.ts
@@ -1,4 +1,4 @@
-import type { CompiledSierra } from '../../src';
+import { type CompiledSierra, type Calldata, CallData, Deployer } from '../../src';
 import { isSierra, extractContractHashes } from '../../src/utils/contract';
 import { CONTRACTS } from '../config/fixtures';
 
@@ -79,5 +79,60 @@ describe('extractContractHashes', () => {
       'compiledClassHash',
       '0x51bdb8f4a2ca02c238fc2d700f68d020574949c1c70dff3799b16f3d9757d52'
     );
+  });
+});
+
+describe('Deployer.buildDeployerCall', () => {
+  const erc20Abi = CONTRACTS.Erc20Oz100.sierra.abi;
+  const classHash = '0x1234';
+  const deployerAddress = '0xabc';
+  const salt = '0x1';
+
+  const name = 'Token';
+  const symbol = 'ERC20';
+  const amount = 1000n;
+  const recipient = '0x1111';
+  const owner = '0x2222';
+
+  // An array is always positional, so this call never goes through the object-ordering
+  // logic under test: it is an independent oracle for the expected constructor calldata.
+  const expectedConstructorCalldata = new CallData(erc20Abi).compile('constructor', [
+    name,
+    symbol,
+    amount,
+    recipient,
+    owner,
+  ]);
+
+  test('orders a named constructor object by the abi, not by its key insertion order', () => {
+    const deployer = new Deployer();
+
+    // `Call.calldata` is typed `RawArgs | Calldata` for input flexibility elsewhere; this
+    // function always builds it as a concrete array, so the cast reflects that guarantee.
+    const inAbiOrder = deployer.buildDeployerCall(
+      {
+        classHash,
+        salt,
+        abi: erc20Abi,
+        constructorCalldata: { name, symbol, amount, recipient, owner },
+      },
+      deployerAddress
+    ).calls[0].calldata as Calldata;
+
+    // Same fields and values, only the object's insertion order differs from the abi's:
+    // recipient and amount swap places, as in GHSA-5v3j-x5p9-4grp.
+    const outOfAbiOrder = deployer.buildDeployerCall(
+      {
+        classHash,
+        salt,
+        abi: erc20Abi,
+        constructorCalldata: { name, symbol, recipient, amount, owner },
+      },
+      deployerAddress
+    ).calls[0].calldata as Calldata;
+
+    // calldata layout: [classHash, salt, unique, constructorCalldata.length, ...constructorCalldata]
+    expect(inAbiOrder.slice(4)).toEqual(expectedConstructorCalldata);
+    expect(outOfAbiOrder.slice(4)).toEqual(expectedConstructorCalldata);
   });
 });

--- a/src/deployer/default.ts
+++ b/src/deployer/default.ts
@@ -42,10 +42,14 @@ export class Deployer implements DeployerInterface {
         // compile with abi
         if (abi) {
           const calldataClass = new CallData(abi);
-          // Convert object based raw js arguments to ...args array
-          const rawArgs = Object.values(constructorCalldata);
-          calldataClass.validate(ValidateType.DEPLOY, 'constructor', rawArgs);
-          return calldataClass.compile('constructor', rawArgs);
+          // Array-shaped calldata is already positional: validate its length up front.
+          // Object-shaped calldata must keep its field names until `compile()`, which
+          // orders them by ABI name — flattening here first would make that ordering
+          // depend on JS insertion order instead.
+          if (Array.isArray(constructorCalldata)) {
+            calldataClass.validate(ValidateType.DEPLOY, 'constructor', constructorCalldata);
+          }
+          return calldataClass.compile('constructor', constructorCalldata);
         }
         // compile without abi
         return CallData.compile(constructorCalldata);


### PR DESCRIPTION
## Motivation and Resolution

`Deployer.buildDeployerCall()` compiled a named (object-shaped) constructor
calldata by first flattening it with `Object.values(constructorCalldata)`,
before it ever reached the ABI-aware `CallData` compiler. `Object.values()`
returns fields in JS insertion order, not in the constructor's declared ABI
order. Whenever a caller wrote a valid object whose field order differed
from the ABI (e.g. `{ name, symbol, recipient, amount, owner }` for a
constructor declared as `name, symbol, amount, recipient, owner`), the
deployment produced positionally wrong calldata — fields such as `amount`,
`recipient`, or `owner` silently landed on the wrong constructor parameter,
with no error raised. Since constructor state generally cannot be repaired
after deployment, this could deploy a contract with the wrong owner,
recipient, or amount.

Fix: the constructor-calldata object is now passed unchanged to
`CallData.compile()`, which already knows how to reorder an object's
fields by ABI name (`orderPropsByAbi`) — exactly like every other
calldata-compiling code path in the SDK. Array-shaped calldata, which was
already positional, is unaffected.

Reported by DicksonWu654 as GHSA-5v3j-x5p9-4grp.

### RPC version (if applicable)

N/A — this is a local calldata-encoding fix, independent of RPC spec version.

## Usage related changes

- `Account.deploy()`, `Account.deployContract()`, `Account.declareAndDeploy()`,
  and `Contract.factory()`'s declare-and-deploy branch (all of which funnel
  through `Deployer.buildDeployerCall()`) now correctly reorder a named
  `constructorCalldata` object by the contract's constructor ABI, regardless
  of the key order used when writing that object in JS.
- No API signature change; callers who already write their object in ABI
  order see no change in behavior.

## Development related changes

- Added a unit test in `__tests__/utils/contract.test.ts`
  (`Deployer.buildDeployerCall`) reproducing the exact GHSA-5v3j-x5p9-4grp
  scenario: a named constructor object with fields in and out of ABI order
  must produce identical, ABI-correct calldata.

## Checklist:

- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Linked the issues which this PR resolves
- [x] Documented the changes in code (API docs will be generated automatically)
- [x] Updated the tests
- [x] All tests are passing
