### PR TITLE
fix(typedData): reject caller types that shadow SNIP-12 preset names

### DIFF
--- a/__tests__/utils/typedData.test.ts
+++ b/__tests__/utils/typedData.test.ts
@@ -380,6 +380,43 @@ describe('typedData', () => {
     });
   });
 
+  describe('preset type shadowing (SNIP-12 reserved names)', () => {
+    const shadowedTypedData = (
+      typeName: string,
+      fields: { name: string; type: string }[],
+      amount: any
+    ) => ({
+      ...copyMock(examplePresetTypes),
+      types: {
+        StarknetDomain: examplePresetTypes.types.StarknetDomain,
+        [typeName]: fields,
+        Payload: [{ name: 'amount', type: typeName }],
+      },
+      primaryType: 'Payload',
+      message: { amount },
+    });
+
+    test('rejects a caller-defined "u256" type instead of silently equating distinct schemas', () => {
+      // GHSA-qc84-vrxf-5cqj: schema A and B differ only in which field the caller's own
+      // (reserved) "u256" type declares — SNIP-12 requires the request to be rejected outright,
+      // not resolved by some precedence between the caller's definition and the built-in preset.
+      const schemaA = shadowedTypedData('u256', [{ name: 'low', type: 'u128' }], { low: 1 });
+      const schemaB = shadowedTypedData('u256', [{ name: 'high', type: 'u128' }], { high: 1 });
+
+      expect(() => getMessageHash(schemaA, exampleAddress)).toThrow(/does not match JSON schema/);
+      expect(() => getMessageHash(schemaB, exampleAddress)).toThrow(/does not match JSON schema/);
+    });
+
+    test('a non-reserved type name is unaffected and the two schemas hash differently', () => {
+      const schemaA = shadowedTypedData('Amount', [{ name: 'low', type: 'u128' }], { low: 1 });
+      const schemaB = shadowedTypedData('Amount', [{ name: 'high', type: 'u128' }], { high: 1 });
+
+      expect(getMessageHash(schemaA, exampleAddress)).not.toBe(
+        getMessageHash(schemaB, exampleAddress)
+      );
+    });
+  });
+
   describe('verifyMessage', () => {
     const addr = '0x64b48806902a367c8598f4f95c305e8c1a1acba5f082d294a43793113115691';
     const privK = '0x71d7bb07b9a64f6f78ac4c816aff4da9';

--- a/src/utils/typedData.ts
+++ b/src/utils/typedData.ts
@@ -97,13 +97,21 @@ function getHex(value: BigNumberish): string {
 }
 
 /**
- * Validates that `data` matches the EIP-712 JSON schema.
+ * Validates that `data` matches the EIP-712 JSON schema, and that it does not redefine any
+ * of the active revision's preset type names (SNIP-12 reserves those names and requires such
+ * a request to be rejected).
  */
 export function validateTypedData(data: unknown): data is TypedData {
   const typedData = data as TypedData;
-  return Boolean(
-    typedData.message && typedData.primaryType && typedData.types && identifyRevision(typedData)
-  );
+  if (!(typedData.message && typedData.primaryType && typedData.types)) {
+    return false;
+  }
+  const revision = identifyRevision(typedData);
+  if (!revision) {
+    return false;
+  }
+  const presetNames = Object.keys(revisionConfiguration[revision].presetTypes);
+  return Object.keys(typedData.types).every((name) => !presetNames.includes(name));
 }
 
 /**


### PR DESCRIPTION
## Motivation and Resolution

`validateTypedData()` only checked that `message`/`primaryType`/`types` were
present and that the revision could be identified. It never checked whether
a caller-defined type in `types` reused one of the active revision's
reserved preset names (`u256`, `TokenAmount`, `NftId`).

`encodeType()` and `encodeData()`/`encodeValue()` disagreed on which
definition to use when that happened: `encodeType()` merged presets over
caller types, so the encoded type string always came from the built-in
preset, while `encodeData()`/`encodeValue()` preferred the caller's
definition when reading values. Two schemas that differed only in their own
`"u256"` definition could therefore produce the exact same message hash,
letting a signature over one schema verify against the other.

SNIP-12 already requires this to be rejected outright — a user-defined type
name "can't match preset types like TokenAmount, NftId, u256" (SNIP-12,
[Type identification](https://github.com/starknet-io/SNIPs/blob/main/SNIPS/snip-12.md#type-identification)).
`validateTypedData()` now does exactly that, closing the path for every
caller of `getMessageHash()` — signing (`Signer`, `EthSigner`,
`LedgerSigner`, `Account.hashMessage`) and verification (`verifyMessage`)
alike.

Reported by DicksonWu654 as GHSA-qc84-vrxf-5cqj.

### RPC version (if applicable)

N/A — this is a local typed-data hashing fix, independent of RPC spec version.

## Usage related changes

- Any typed data whose `types` object redefines a reserved preset name
  (`u256`, `TokenAmount`, `NftId` for the active revision) is now rejected
  with `Typed data does not match JSON schema`, instead of being silently
  hashed with an inconsistent type/value encoding.
- Legitimate use of preset types (referencing `u256`/`TokenAmount`/`NftId`
  as a field's `type` without redefining them in `types`) is unaffected.
- No API signature change.

## Development related changes

- Added two tests in `__tests__/utils/typedData.test.ts`
  (`preset type shadowing (SNIP-12 reserved names)`) reproducing
  GHSA-qc84-vrxf-5cqj: two schemas colliding on a redefined `"u256"` type
  are both rejected, while the same schemas under a non-reserved name
  (`"Amount"`) still hash correctly and differently.

## Checklist:

- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Linked the issues which this PR resolves
- [x] Documented the changes in code (API docs will be generated automatically)
- [x] Updated the tests
- [x] All tests are passing
