### PR TITLE
fix(calldata): default to the parsing strategy that decodes

### DIFF
--- a/__tests__/cairo1v2.test.ts
+++ b/__tests__/cairo1v2.test.ts
@@ -694,8 +694,8 @@ describe('Cairo 1', () => {
         { address: 1193046n, is_claimed: true },
         { address: 624485n, is_claimed: false },
       ]);
-      const res4 = c1v2CallData.decodeParameters('core::integer::u8', ['0x123456']);
-      expect(res4).toBe(1193046n);
+      const res4 = c1v2CallData.decodeParameters('core::integer::u8', ['0x42']);
+      expect(res4).toBe(66n);
       const res5 = c1v2CallData.decodeParameters('core::bool', ['0x1']);
       expect(res5).toBe(true);
       const res6 = c1v2CallData.decodeParameters('core::felt252', ['0x123456']);
@@ -704,16 +704,16 @@ describe('Cairo 1', () => {
       expect(num.toHex(res7.toString())).toBe('0x78900000000000000000000000000123456');
       const res8 = c1v2CallData.decodeParameters('core::array::Array::<core::integer::u16>', [
         '2',
-        '0x123456',
+        '0x1234',
         '0x789',
       ]);
-      expect(res8).toEqual([1193046n, 1929n]);
+      expect(res8).toEqual([4660n, 1929n]);
       const res9 = c1v2CallData.decodeParameters('core::array::Span::<core::integer::u16>', [
         '2',
-        '0x123456',
+        '0x1234',
         '0x789',
       ]);
-      expect(res9).toEqual([1193046n, 1929n]);
+      expect(res9).toEqual([4660n, 1929n]);
       const res10 = c1v2CallData.decodeParameters('(core::felt252, core::integer::u16)', [
         '0x123456',
         '0x789',

--- a/__tests__/contract.test.ts
+++ b/__tests__/contract.test.ts
@@ -992,21 +992,21 @@ describe('Complex interaction', () => {
       const res0 = myCallData.decodeParameters('core::felt252', ['474107654995566025798705']);
       expect(res0).toBe(474107654995566025798705n);
       const res1 = myCallData.decodeParameters('echo::StructY', [
-        '474107654995566025798705',
+        '4741076549955660',
         '3534634645645',
       ]);
-      expect(res1).toEqual({ y1: 474107654995566025798705n, y2: 3534634645645n });
+      expect(res1).toEqual({ y1: 4741076549955660n, y2: 3534634645645n });
 
       const res2 = myCallData.decodeParameters('core::integer::u256', ['47410765', '35346645']);
       expect(res2).toBe(12027840023314154934885372750905072692667575885n);
       const res3 = myCallData.decodeParameters('echo::Struct32', [
         '47410765',
-        '35346645',
+        '12345',
         '1',
         '2',
         '3',
       ]);
-      expect(res3).toEqual({ b: 47410765n, c: { '0': 35346645n, '1': 1n, '2': 2n, '3': 3n } });
+      expect(res3).toEqual({ b: 47410765n, c: { '0': 12345n, '1': 1n, '2': 2n, '3': 3n } });
 
       const res4 = myCallData.decodeParameters(
         '(core::felt252, core::felt252, core::felt252, core::felt252)',

--- a/__tests__/utils/calldata/parser/parser-0-1.1.0.test.ts
+++ b/__tests__/utils/calldata/parser/parser-0-1.1.0.test.ts
@@ -1,5 +1,7 @@
 import { AbiParser1 } from '../../../../src/utils/calldata/parser/parser-0-1.1.0';
 import { getFunctionAbi, getInterfaceAbi } from '../../../factories/abi';
+import { PRIME } from '../../../../src/global/constants';
+import { toHex } from '../../../../src/utils/num';
 
 describe('AbiParser1', () => {
   test('should create an instance', () => {
@@ -39,6 +41,15 @@ describe('AbiParser1', () => {
       const abiParser = new AbiParser1([getFunctionAbi('struct'), getInterfaceAbi()]);
       const legacyFormat = abiParser.getLegacyFormat();
       expect(legacyFormat).toStrictEqual(abiParser.abi);
+    });
+  });
+
+  describe('default parsing strategy', () => {
+    test('decodes a negative i8 response without an explicit parsingStrategy (GHSA-mv8m-rfr4-jcq8)', () => {
+      const abiParser = new AbiParser1([getFunctionAbi('struct')]);
+      const responseIterator = [toHex(PRIME - 1n)].values();
+      const parse = abiParser.getResponseParser('core::integer::i8');
+      expect(parse(responseIterator)).toEqual(-1n);
     });
   });
 });

--- a/__tests__/utils/calldata/parser/parser-2.0.0.test.ts
+++ b/__tests__/utils/calldata/parser/parser-2.0.0.test.ts
@@ -1,5 +1,7 @@
 import { AbiParser2 } from '../../../../src/utils/calldata/parser/parser-2.0.0';
 import { getFunctionAbi, getInterfaceAbi } from '../../../factories/abi';
+import { PRIME } from '../../../../src/global/constants';
+import { toHex } from '../../../../src/utils/num';
 
 describe('AbiParser2', () => {
   test('should create an instance', () => {
@@ -40,6 +42,15 @@ describe('AbiParser2', () => {
       const legacyFormat = abiParser.getLegacyFormat();
       const result = [getFunctionAbi('struct'), getFunctionAbi('struct')];
       expect(legacyFormat).toEqual(result);
+    });
+  });
+
+  describe('default parsing strategy', () => {
+    test('decodes a negative i128 response without an explicit parsingStrategy (GHSA-mv8m-rfr4-jcq8)', () => {
+      const abiParser = new AbiParser2([getFunctionAbi('struct')]);
+      const responseIterator = [toHex(PRIME - 1n)].values();
+      const parse = abiParser.getResponseParser('core::integer::i128');
+      expect(parse(responseIterator)).toEqual(-1n);
     });
   });
 });

--- a/src/utils/calldata/parser/parser-0-1.1.0.ts
+++ b/src/utils/calldata/parser/parser-0-1.1.0.ts
@@ -1,7 +1,7 @@
 import { Abi, AbiEntryType, FunctionAbi } from '../../../types';
 import { isLen } from '../cairo';
 import { AbiParserInterface } from './interface';
-import { fastParsingStrategy, ParsingStrategy } from './parsingStrategy';
+import { hdParsingStrategy, ParsingStrategy } from './parsingStrategy';
 
 export class AbiParser1 implements AbiParserInterface {
   abi: Abi;
@@ -10,7 +10,9 @@ export class AbiParser1 implements AbiParserInterface {
 
   constructor(abi: Abi, parsingStrategy?: ParsingStrategy) {
     this.abi = abi;
-    this.parsingStrategy = parsingStrategy || fastParsingStrategy;
+    // hdParsingStrategy is the default: it decodes signed integers correctly (fastParsingStrategy
+    // returns the raw felt for a negative i8..i128 instead of converting it back from PRIME).
+    this.parsingStrategy = parsingStrategy || hdParsingStrategy;
   }
 
   public getRequestParser(abiType: AbiEntryType): (val: unknown) => any {

--- a/src/utils/calldata/parser/parser-2.0.0.ts
+++ b/src/utils/calldata/parser/parser-2.0.0.ts
@@ -8,7 +8,7 @@ import {
   AbiEntryType,
 } from '../../../types';
 import { AbiParserInterface } from './interface';
-import { fastParsingStrategy, ParsingStrategy } from './parsingStrategy';
+import { hdParsingStrategy, ParsingStrategy } from './parsingStrategy';
 
 export class AbiParser2 implements AbiParserInterface {
   abi: Abi;
@@ -17,7 +17,9 @@ export class AbiParser2 implements AbiParserInterface {
 
   constructor(abi: Abi, parsingStrategy?: ParsingStrategy) {
     this.abi = abi;
-    this.parsingStrategy = parsingStrategy || fastParsingStrategy;
+    // hdParsingStrategy is the default: it decodes signed integers correctly (fastParsingStrategy
+    // returns the raw felt for a negative i8..i128 instead of converting it back from PRIME).
+    this.parsingStrategy = parsingStrategy || hdParsingStrategy;
   }
 
   public getRequestParser(abiType: AbiEntryType): (val: unknown) => any {


### PR DESCRIPTION
## Motivation and Resolution

`AbiParser1` and `AbiParser2` both defaulted to `fastParsingStrategy` when a
caller constructed a `Contract` (or `CallData`) without passing
`parsingStrategy` explicitly — the case in every example in the README and
docs. That strategy's response handlers for `i8`/`i16`/`i32`/`i64`/`i128`
return the raw felt (`BigInt(getNext(responseIterator))`) instead of
converting it back from `PRIME`, so any negative value returned by a view
call comes back as `~3.6e75` instead of e.g. `-1n`, silently flipping the
sign of downstream comparisons, balance/P&L computations, and liquidation
checks.

`hdParsingStrategy` already did this conversion correctly — it is what
`CairoIntN.factoryFromApiResponse` itself uses — but required callers to
opt into it explicitly to get correct signed integers. The default is now
`hdParsingStrategy`; `fastParsingStrategy` is unchanged and stays available
for callers who select it explicitly.

This same class of bug is already gone on `beta`/v11: PR #1690
(https://github.com/starknet-io/starknet.js/pull/1690, "run the calldata
codec on the Cairo type classes") independently moved response decoding for
every scalar type onto the Cairo type classes themselves, so the default
path there already builds a `CairoInt8`/…/`CairoInt128` instance from the
response — which performs this exact conversion — rather than reading a raw
felt. This PR brings the same outcome to the current v10 line without
adopting that larger, unrelated refactor.

Two existing `decodeParameters` tests (`contract.test.ts`, `cairo1v2.test.ts`)
fed narrow integer types (`u8`, `u16`, `u64`) values that exceeded their
declared range, purely to check that decoding routes the right felt to the
right field. That was invisible under the old, unvalidated default and is
now correctly rejected by `hdParsingStrategy`; their fixture values were
adjusted to stay within range without changing what each test verifies.

### RPC version (if applicable)

N/A — this is a local response-decoding fix, independent of RPC spec version.

## Usage related changes

- Every `Contract`/`CallData` call decoding a signed integer return value
  (`i8`/`i16`/`i32`/`i64`/`i128`, including inside structs, tuples, and
  arrays) without an explicit `parsingStrategy` now returns the correct
  signed value instead of the raw field element.
- Callers who explicitly pass `parsingStrategy: fastParsingStrategy` are
  unaffected and keep today's (documented trade-off) behavior.
- No API signature change.

## Development related changes

- Added a default-strategy regression test to `parser-0-1.1.0.test.ts` and
  `parser-2.0.0.test.ts`, each decoding a negative `i8`/`i128` response
  without passing a `parsingStrategy`, reproducing GHSA-mv8m-rfr4-jcq8.
- Fixed three pre-existing `decodeParameters` fixture values in
  `contract.test.ts` and `cairo1v2.test.ts` that were out of range for
  their declared type (see above).

## Checklist:

- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] Linked the issues which this PR resolves
- [x] Documented the changes in code (API docs will be generated automatically)
- [x] Updated the tests
- [x] All tests are passing
