### PR TITLE
docs: change keys of algolia search

### DIFF
--- a/www/docusaurus.config.ts
+++ b/www/docusaurus.config.ts
@@ -229,9 +229,9 @@ const config: Config = {
       appId: '86VVNRI64B',
 
       // Public API key: it is safe to commit it
-      apiKey: '6f4db54e4ee0ae77619b41dbe862af7f',
+      apiKey: '1e38429d50835ef8fcae055fba695062',
 
-      indexName: 'starknetjs',
+      indexName: 'starknet-js',
 
       // Algolia "Ask AI" conversational assistant (DocSearch v4).
       // The assistantId is a public value (configured in the Algolia dashboard,


### PR DESCRIPTION
## Motivation and Resolution
Following Algolia cleanup, the keys stored in Docusaurus config are no more the right ones. The search function in the website is no more working.
Keys updated.

### RPC version (if applicable)
N/A

## Usage related changes
Search function is working now.

## Development related changes

## Checklist:

- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] All tests are passing
