### PR TITLE
fix(deps): bump @noble/@scure crypto libs to 2.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,10 @@
       "version": "11.0.0-beta.13",
       "license": "MIT",
       "dependencies": {
-        "@noble/curves": "~2.3.0",
-        "@noble/hashes": "~2.3.0",
-        "@scure/base": "~2.3.0",
-        "@scure/starknet": "2.3.0",
+        "@noble/curves": "~2.4.0",
+        "@noble/hashes": "~2.4.0",
+        "@scure/base": "~2.4.0",
+        "@scure/starknet": "2.4.0",
         "@starknet-io/get-starknet-wallet-standard": "^5.0.0",
         "@starknet-io/get-starknet-wallet-standard-v6": "npm:@starknet-io/get-starknet-wallet-standard@6.0.4",
         "@starknet-io/starknet-types-0101": "npm:@starknet-io/types-js@0.10.2",
@@ -2904,12 +2904,12 @@
       }
     },
     "node_modules/@noble/curves": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.3.0.tgz",
-      "integrity": "sha512-v7cY+4oWYPQszRj6ZFGzTVL7uP2TaLo1xMhWHzYC5wj0ZhOXQ5x+sBre8rF3hi8cAoi0bh1qXoovoOkdFtvqEg==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.4.0.tgz",
+      "integrity": "sha512-P4/62zrgfH33CneE3Dn4WhJVA22YUU0eR51wKIan4NVRvwsA0YnPTwWGpNbpuacSujmSFLvyzpyuR30+fbq2Ew==",
       "license": "MIT",
       "dependencies": {
-        "@noble/hashes": "2.3.0"
+        "@noble/hashes": "2.4.0"
       },
       "engines": {
         "node": ">= 20.19.0"
@@ -2919,9 +2919,9 @@
       }
     },
     "node_modules/@noble/hashes": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.3.0.tgz",
-      "integrity": "sha512-oN+QwyX7VSHotibwubG3kpzbwKrfnyR6OOO+3Nk/53ADL7FmgHHz4TgrbaYKvvOw09u6QTx0oiH1cNCIOuN0CQ==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.4.0.tgz",
+      "integrity": "sha512-X5XaVWZIBCT7HHZGm5I7ZQXDwLG+bGXuSrMQAW+7Zvl87h1kmc1ZB1VSRJcpUfoUrGQp4Fkoxm5kZ+Ms+aW+eA==",
       "license": "MIT",
       "engines": {
         "node": ">= 20.19.0"
@@ -3571,9 +3571,9 @@
       "license": "MIT"
     },
     "node_modules/@scure/base": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.3.0.tgz",
-      "integrity": "sha512-NsG6Y03tY6R5BUis4FdVtHVkur0U6FOzskgs9ZXNl78CUc9fkZ78HmENUle1nSOkCasDmbubmWD9qwB7mm4PZA==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.4.0.tgz",
+      "integrity": "sha512-thZ1TuJwFwBblOhgsjDKvvGirBxNp+wSvY/DR6tJBJOTDhdAAcHJ8Vbr2eFnqaxeca4+t0i9KBf+uHYGWwZORg==",
       "license": "MIT",
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -3664,13 +3664,13 @@
       }
     },
     "node_modules/@scure/starknet": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@scure/starknet/-/starknet-2.3.0.tgz",
-      "integrity": "sha512-UcTTyCkzeh7mWxgwE0xiPbFgY70ri2b+gnkCRH/o3qt7280Mt2Q2XfG1fbwaPD39qPUCv4uCHJW6BRVwhCN8XA==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@scure/starknet/-/starknet-2.4.0.tgz",
+      "integrity": "sha512-ZOtYjLzibTeHUfOgLVQaaUGej+eMV+EnHyUL0+JBSsLWEDKmOggxVYs3ri7G4DybtpeR1/65iK+ihD3K9Sfqbw==",
       "license": "MIT",
       "dependencies": {
-        "@noble/curves": "~2.3.0",
-        "@noble/hashes": "~2.3.0"
+        "@noble/curves": "2.4.0",
+        "@noble/hashes": "2.4.0"
       },
       "engines": {
         "node": ">= 20.19.0"

--- a/package.json
+++ b/package.json
@@ -101,10 +101,10 @@
     "typescript-coverage-report": "npm:@penovicp/typescript-coverage-report@^1.0.0-beta.2"
   },
   "dependencies": {
-    "@noble/curves": "~2.3.0",
-    "@noble/hashes": "~2.3.0",
-    "@scure/base": "~2.3.0",
-    "@scure/starknet": "2.3.0",
+    "@noble/curves": "~2.4.0",
+    "@noble/hashes": "~2.4.0",
+    "@scure/base": "~2.4.0",
+    "@scure/starknet": "2.4.0",
     "@starknet-io/get-starknet-wallet-standard": "^5.0.0",
     "@starknet-io/get-starknet-wallet-standard-v6": "npm:@starknet-io/get-starknet-wallet-standard@6.0.4",
     "@starknet-io/starknet-types-0101": "npm:@starknet-io/types-js@0.10.2",


### PR DESCRIPTION
## Motivation and Resolution

`@noble/curves`, `@noble/hashes`, `@scure/base` and `@scure/starknet` are
bumped from 2.3.0 to 2.4.0. The noble release is a security-hardening
update credited to an external security review: stricter Weierstrass
public-key/infinity handling for ECDH/ECDSA, bounded DER/INTEGER parsing
sizes, and protection of security-sensitive state against mutation
(`@noble/hashes` also improves zeroization). This touches `starkCurve.verify`
in `src/utils/typedData.ts`, the Stark-curve signature verification path used
for SNIP-12 typed data. `@scure/starknet` 2.4.0 itself only re-pins the noble
libs; `@scure/base` is bumped alongside since the four versions move together
in this repo's dependency set.

### RPC version (if applicable)

N/A — dependency-only change, no RPC spec impact.

## Usage related changes

- Consumers get the hardened `@noble/curves`/`@noble/hashes` 2.4.0
  transitively. No change to starknet.js's own public API.

## Development related changes

- `package.json` / `package-lock.json` only.

## Checklist:

- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [x] All tests are passing
