### PR TITLE
Rpc  0.10.4

### DIFF
--- a/__tests__/providerNarrowing.test.ts
+++ b/__tests__/providerNarrowing.test.ts
@@ -1,5 +1,5 @@
 import { RpcProvider, constants } from '../src';
-import { RPCSPEC09, RPCSPEC0103 } from '../src/types/api';
+import { RPCSPEC09, RPCSPEC0104 } from '../src/types/api';
 
 describe('Provider Type Narrowing', () => {
   let provider: RpcProvider;
@@ -10,15 +10,15 @@ describe('Provider Type Narrowing', () => {
   });
 
   describe('getEvents', () => {
-    test('should narrow to RPCSPEC0103.EVENTS_CHUNK when using v0.10.0', async () => {
+    test('should narrow to RPCSPEC0104.EVENTS_CHUNK when using v0.10.0', async () => {
       // Mock the getEvents method to avoid actual API calls
-      const mockEventsChunk: RPCSPEC0103.EVENTS_CHUNK = {
+      const mockEventsChunk: RPCSPEC0104.EVENTS_CHUNK = {
         events: [],
         continuation_token: undefined,
       };
       jest.spyOn(provider, 'getEvents').mockResolvedValueOnce(mockEventsChunk);
 
-      const filter: RPCSPEC0103.EventFilter = {
+      const filter: RPCSPEC0104.EventFilter = {
         from_block: { block_number: 0 },
         to_block: { block_number: 10 },
         chunk_size: 10,
@@ -26,8 +26,8 @@ describe('Provider Type Narrowing', () => {
 
       const result = await provider.getEvents<typeof constants.SupportedRpcVersion.v0_10_0>(filter);
 
-      // Type assertion to verify the type is correctly narrowed to RPCSPEC0103.EVENTS_CHUNK
-      const typeCheck: RPCSPEC0103.EVENTS_CHUNK = result;
+      // Type assertion to verify the type is correctly narrowed to RPCSPEC0104.EVENTS_CHUNK
+      const typeCheck: RPCSPEC0104.EVENTS_CHUNK = result;
       expect(typeCheck).toBeDefined();
       expect('events' in result).toBe(true);
     });
@@ -56,13 +56,13 @@ describe('Provider Type Narrowing', () => {
 
     test('should return union type when no version specified', async () => {
       // Mock the getEvents method to avoid actual API calls
-      const mockEventsChunk: RPCSPEC0103.EVENTS_CHUNK | RPCSPEC09.EVENTS_CHUNK = {
+      const mockEventsChunk: RPCSPEC0104.EVENTS_CHUNK | RPCSPEC09.EVENTS_CHUNK = {
         events: [],
         continuation_token: undefined,
       };
       jest.spyOn(provider, 'getEvents').mockResolvedValueOnce(mockEventsChunk);
 
-      const filter: RPCSPEC0103.EventFilter | RPCSPEC09.EventFilter = {
+      const filter: RPCSPEC0104.EventFilter | RPCSPEC09.EventFilter = {
         from_block: { block_number: 0 },
         to_block: { block_number: 10 },
         chunk_size: 10,
@@ -70,22 +70,22 @@ describe('Provider Type Narrowing', () => {
 
       const result = await provider.getEvents(filter);
 
-      // Type is union: RPCSPEC0103.EVENTS_CHUNK | RPCSPEC09.EVENTS_CHUNK
-      const typeCheck: RPCSPEC0103.EVENTS_CHUNK | RPCSPEC09.EVENTS_CHUNK = result;
+      // Type is union: RPCSPEC0104.EVENTS_CHUNK | RPCSPEC09.EVENTS_CHUNK
+      const typeCheck: RPCSPEC0104.EVENTS_CHUNK | RPCSPEC09.EVENTS_CHUNK = result;
       expect(typeCheck).toBeDefined();
       expect('events' in result).toBe(true);
     });
   });
 
   describe('getTransactionTrace', () => {
-    test('should narrow to RPCSPEC0103.TRANSACTION_TRACE when using v0.10.0', async () => {
+    test('should narrow to RPCSPEC0104.TRANSACTION_TRACE when using v0.10.0', async () => {
       // This test verifies type narrowing at compile time
       type ResultType = Awaited<
         ReturnType<
           typeof provider.getTransactionTrace<typeof constants.SupportedRpcVersion.v0_10_0>
         >
       >;
-      type ExpectedType = RPCSPEC0103.TRANSACTION_TRACE;
+      type ExpectedType = RPCSPEC0104.TRANSACTION_TRACE;
 
       // Type-level assertion
       const typeCheck: ResultType extends ExpectedType ? true : false = true;
@@ -106,7 +106,7 @@ describe('Provider Type Narrowing', () => {
 
     test('should return union type when no version specified', async () => {
       type ResultType = Awaited<ReturnType<typeof provider.getTransactionTrace>>;
-      type ExpectedType = RPCSPEC0103.TRANSACTION_TRACE | RPCSPEC09.TRANSACTION_TRACE;
+      type ExpectedType = RPCSPEC0104.TRANSACTION_TRACE | RPCSPEC09.TRANSACTION_TRACE;
 
       // Type-level assertion - union type should be assignable to both directions
       const typeCheck: ResultType extends ExpectedType ? true : false = true;
@@ -115,11 +115,11 @@ describe('Provider Type Narrowing', () => {
   });
 
   describe('estimateMessageFee', () => {
-    test('should narrow to RPCSPEC0103.FEE_ESTIMATE when using v0.10.0', async () => {
+    test('should narrow to RPCSPEC0104.FEE_ESTIMATE when using v0.10.0', async () => {
       type ResultType = Awaited<
         ReturnType<typeof provider.estimateMessageFee<typeof constants.SupportedRpcVersion.v0_10_0>>
       >;
-      type ExpectedType = RPCSPEC0103.FEE_ESTIMATE;
+      type ExpectedType = RPCSPEC0104.FEE_ESTIMATE;
 
       const typeCheck: ResultType extends ExpectedType ? true : false = true;
       expect(typeCheck).toBe(true);
@@ -137,7 +137,7 @@ describe('Provider Type Narrowing', () => {
 
     test('should return union type when no version specified', async () => {
       type ResultType = Awaited<ReturnType<typeof provider.estimateMessageFee>>;
-      type ExpectedType = RPCSPEC0103.FEE_ESTIMATE | RPCSPEC09.MESSAGE_FEE_ESTIMATE;
+      type ExpectedType = RPCSPEC0104.FEE_ESTIMATE | RPCSPEC09.MESSAGE_FEE_ESTIMATE;
 
       const typeCheck: ResultType extends ExpectedType ? true : false = true;
       expect(typeCheck).toBe(true);
@@ -145,13 +145,13 @@ describe('Provider Type Narrowing', () => {
   });
 
   describe('getL1MessagesStatus', () => {
-    test('should narrow to RPCSPEC0103.L1L2MessagesStatus when using v0.10.0', async () => {
+    test('should narrow to RPCSPEC0104.L1L2MessagesStatus when using v0.10.0', async () => {
       type ResultType = Awaited<
         ReturnType<
           typeof provider.getL1MessagesStatus<typeof constants.SupportedRpcVersion.v0_10_0>
         >
       >;
-      type ExpectedType = RPCSPEC0103.L1L2MessagesStatus;
+      type ExpectedType = RPCSPEC0104.L1L2MessagesStatus;
 
       const typeCheck: ResultType extends ExpectedType ? true : false = true;
       expect(typeCheck).toBe(true);
@@ -169,7 +169,7 @@ describe('Provider Type Narrowing', () => {
 
     test('should return union type when no version specified', async () => {
       type ResultType = Awaited<ReturnType<typeof provider.getL1MessagesStatus>>;
-      type ExpectedType = RPCSPEC0103.L1L2MessagesStatus | RPCSPEC09.L1L2MessagesStatus;
+      type ExpectedType = RPCSPEC0104.L1L2MessagesStatus | RPCSPEC09.L1L2MessagesStatus;
 
       const typeCheck: ResultType extends ExpectedType ? true : false = true;
       expect(typeCheck).toBe(true);
@@ -179,13 +179,13 @@ describe('Provider Type Narrowing', () => {
   describe('Literal string type narrowing', () => {
     test('should work with literal "0.10.0" for getEvents', async () => {
       // Mock the getEvents method to avoid actual API calls
-      const mockEventsChunk: RPCSPEC0103.EVENTS_CHUNK = {
+      const mockEventsChunk: RPCSPEC0104.EVENTS_CHUNK = {
         events: [],
         continuation_token: undefined,
       };
       jest.spyOn(provider, 'getEvents').mockResolvedValueOnce(mockEventsChunk);
 
-      const filter: RPCSPEC0103.EventFilter = {
+      const filter: RPCSPEC0104.EventFilter = {
         from_block: { block_number: 0 },
         to_block: { block_number: 10 },
         chunk_size: 10,
@@ -193,7 +193,7 @@ describe('Provider Type Narrowing', () => {
 
       const result = await provider.getEvents<'0.10.0'>(filter);
 
-      const typeCheck: RPCSPEC0103.EVENTS_CHUNK = result;
+      const typeCheck: RPCSPEC0104.EVENTS_CHUNK = result;
       expect(typeCheck).toBeDefined();
     });
 

--- a/__tests__/specVersionResolution.test.ts
+++ b/__tests__/specVersionResolution.test.ts
@@ -83,5 +83,35 @@ describe('spec version resolution', () => {
         warn.mockRestore();
       }
     });
+
+    test('routes every 0.10 patch version to the same channel, reporting the node version', async () => {
+      // spec versions actually reported by nodes in the wild, plus the newly released one
+      const cases = [
+        { reported: '0.10.2', resolved: '0.10.2' },
+        { reported: '0.10.3-rc.0', resolved: '0.10.3' },
+        { reported: '0.10.4', resolved: '0.10.4' },
+      ];
+
+      const providers = await Promise.all(
+        cases.map(({ reported }) => RpcProvider.create({ nodeUrl, baseFetch: stubNode(reported) }))
+      );
+
+      // the channel is picked per generation, so every patch version must share the same one
+      expect(new Set(providers.map((provider) => provider.channel.id)).size).toBe(1);
+
+      providers.forEach((provider, index) => {
+        expect(provider.readSpecVersion()).toBe(cases[index].resolved);
+      });
+    });
+
+    test('routes a 0.9 node to another channel than a 0.10 node', async () => {
+      const [node09, node010] = await Promise.all([
+        RpcProvider.create({ nodeUrl, baseFetch: stubNode('0.9.0') }),
+        RpcProvider.create({ nodeUrl, baseFetch: stubNode('0.10.4') }),
+      ]);
+
+      expect(node09.channel.id).not.toBe(node010.channel.id);
+      expect(node09.readSpecVersion()).toBe('0.9.0');
+    });
   });
 });

--- a/__tests__/utils/errors.test.ts
+++ b/__tests__/utils/errors.test.ts
@@ -2,7 +2,7 @@ import { RPC, RpcError } from '../../src';
 
 describe('Error utility tests', () => {
   test('RpcError', () => {
-    const baseError: RPC.RPCSPEC0103.UNEXPECTED_ERROR = {
+    const baseError: RPC.RPCSPEC0104.UNEXPECTED_ERROR = {
       code: 63,
       message: 'An unexpected error occurred',
       data: 'data',

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@scure/base": "~1.2.1",
         "@scure/starknet": "1.1.0",
         "@starknet-io/get-starknet-wallet-standard": "^5.0.0",
-        "@starknet-io/get-starknet-wallet-standard-v6": "npm:@starknet-io/get-starknet-wallet-standard@6.0.4",
+        "@starknet-io/get-starknet-wallet-standard-v6": "npm:@starknet-io/get-starknet-wallet-standard@6.0.6",
         "@starknet-io/starknet-types-0101": "npm:@starknet-io/types-js@0.10.2",
         "@starknet-io/starknet-types-0103": "npm:@starknet-io/types-js@0.10.3",
         "@starknet-io/starknet-types-0104": "npm:@starknet-io/types-js@0.10.4",
@@ -2903,6 +2903,18 @@
         "@tybys/wasm-util": "^0.10.0"
       }
     },
+    "node_modules/@noble/ciphers": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-2.4.0.tgz",
+      "integrity": "sha512-AnjFn0Jv92laAkvMrghlFZq4qQCIN/4DxFV/eooqtC2YTjB7kBeLMS2T9KJX4Dn+ZVXLOwK0lSgqDtx9gvxtiw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@noble/curves": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.7.0.tgz",
@@ -2937,6 +2949,62 @@
       "license": "MIT",
       "engines": {
         "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/post-quantum": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@noble/post-quantum/-/post-quantum-0.6.1.tgz",
+      "integrity": "sha512-+pormrDZwjRw05U8ADK4JpHejo87+gBd+muRBB/ozztH5yhDLMDF4jHQWN3NQQAsu1zBNPWTG0ZwVI0CR29H0A==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/ciphers": "~2.2.0",
+        "@noble/curves": "~2.2.0",
+        "@noble/hashes": "~2.2.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/post-quantum/node_modules/@noble/ciphers": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-2.2.0.tgz",
+      "integrity": "sha512-Z6pjIZ/8IJcCGzb2S/0Px5J81yij85xASuk1teLNeg75bfT07MV3a/O2Mtn1I2se43k3lkVEcFaR10N4cgQcZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/post-quantum/node_modules/@noble/curves": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.2.0.tgz",
+      "integrity": "sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "2.2.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/post-quantum/node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -4353,15 +4421,109 @@
     },
     "node_modules/@starknet-io/get-starknet-wallet-standard-v6": {
       "name": "@starknet-io/get-starknet-wallet-standard",
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/@starknet-io/get-starknet-wallet-standard/-/get-starknet-wallet-standard-6.0.4.tgz",
-      "integrity": "sha512-HhJlC7lSqaiFZPcn+nY4j3hNyzprt7KC7UZY6TFi8w1TNRYccGV9dwY2NtJ+bfLl5mv5ZSxt9OigRn9t6WzNLg==",
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/@starknet-io/get-starknet-wallet-standard/-/get-starknet-wallet-standard-6.0.6.tgz",
+      "integrity": "sha512-iBS7zwBP5l7yKxM/1INOBzqB82KSgYqmLPrBlgNs/uYNJyCj+ZL7yTVuUyv1174Y33yztN5Lvwxppsiyxg1+Uw==",
       "license": "MIT",
       "dependencies": {
-        "@starknet-io/types-js": "0.10.4-beta.2",
+        "@starknet-io/types-js": "0.10.4",
         "@wallet-standard/base": "^1.1.1",
         "@wallet-standard/features": "^1.1.1",
-        "ox": "^0.4.4"
+        "ox": "^1.6.2"
+      }
+    },
+    "node_modules/@starknet-io/get-starknet-wallet-standard-v6/node_modules/@noble/curves": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.4.0.tgz",
+      "integrity": "sha512-P4/62zrgfH33CneE3Dn4WhJVA22YUU0eR51wKIan4NVRvwsA0YnPTwWGpNbpuacSujmSFLvyzpyuR30+fbq2Ew==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "2.4.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@starknet-io/get-starknet-wallet-standard-v6/node_modules/@noble/hashes": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.4.0.tgz",
+      "integrity": "sha512-X5XaVWZIBCT7HHZGm5I7ZQXDwLG+bGXuSrMQAW+7Zvl87h1kmc1ZB1VSRJcpUfoUrGQp4Fkoxm5kZ+Ms+aW+eA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@starknet-io/get-starknet-wallet-standard-v6/node_modules/@scure/base": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.4.0.tgz",
+      "integrity": "sha512-thZ1TuJwFwBblOhgsjDKvvGirBxNp+wSvY/DR6tJBJOTDhdAAcHJ8Vbr2eFnqaxeca4+t0i9KBf+uHYGWwZORg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@starknet-io/get-starknet-wallet-standard-v6/node_modules/@scure/bip32": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-2.4.0.tgz",
+      "integrity": "sha512-i3DS0CptAocyvqE4n3SUkpzeQK4vJMFwWLofTwRiiKo2aWojBOfyMCgfKw9HVpO6fSY5AK86sHS/Uzn8kK9Few==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "2.4.0",
+        "@noble/hashes": "2.4.0",
+        "@scure/base": "2.4.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@starknet-io/get-starknet-wallet-standard-v6/node_modules/@scure/bip39": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-2.4.0.tgz",
+      "integrity": "sha512-82dxFbZUYboyOf0AXiydsQrFQ5Q4h9mX+O2UkE91ROYmsc0BKMGZLwDmy96Jpa2+vrtoxomjUhy1RPIgH/r2nA==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "2.4.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@starknet-io/get-starknet-wallet-standard-v6/node_modules/ox": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-1.7.4.tgz",
+      "integrity": "sha512-bpi/fBiftKb8aO4vHbvTq+pMRRTbzAML52ZRa+fH1gdwtLDCNE2VxpyASLeukltrDpXhzXQy69iNX3O0PtBWEw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@adraffy/ens-normalize": "^1.11.0",
+        "@noble/ciphers": "^2.2.0",
+        "@noble/curves": "^2.2.0",
+        "@noble/hashes": "^2.2.0",
+        "@noble/post-quantum": "^0.6.1",
+        "@scure/bip32": "^2.0.0",
+        "@scure/bip39": "^2.0.0",
+        "abitype": "^1.3.0",
+        "eventemitter3": "5.0.1",
+        "zod": "^4.4.3"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/@starknet-io/get-starknet-wallet-standard/node_modules/@starknet-io/types-js": {
@@ -4399,9 +4561,9 @@
       "license": "MIT"
     },
     "node_modules/@starknet-io/types-js": {
-      "version": "0.10.4-beta.2",
-      "resolved": "https://registry.npmjs.org/@starknet-io/types-js/-/types-js-0.10.4-beta.2.tgz",
-      "integrity": "sha512-DHfzg/d6s1NYeQpbBpLwXxYBVgCMhMIW2RjbSS2ukwz8XbPZQCLwj8ArAH4Tx4dmkJpn4J6YVRhZGFgjO26TVQ==",
+      "version": "0.10.4",
+      "resolved": "https://registry.npmjs.org/@starknet-io/types-js/-/types-js-0.10.4.tgz",
+      "integrity": "sha512-uyrgECEHzKpQfUSXgFpM3vPov4qYSoFQzdUNW+UEPHRJtaemzZGWPvIjuerPgjmrxKsh6q8nqzEKdm6BFykRlQ==",
       "license": "MIT"
     },
     "node_modules/@swc/core": {
@@ -5416,16 +5578,16 @@
       }
     },
     "node_modules/abitype": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.0.8.tgz",
-      "integrity": "sha512-ZeiI6h3GnW06uYDLx0etQtX/p8E24UaHHBj57RSjK7YBFe7iuVn07EDpOeP451D06sF27VOz9JJPlIKJmXgkEg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.3.0.tgz",
+      "integrity": "sha512-fk6Te+bojIFrMvMZrnOO+SxCB+RUksTGOzq/60ZRvs1L+BVzvi2bqt9L3W/17ZLdZsyM1FuYf65P5nlmoiH1Bg==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/wevm"
       },
       "peerDependencies": {
         "typescript": ">=5.0.4",
-        "zod": "^3 >=3.22.0"
+        "zod": "^3.22.0 || ^4.0.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -20143,6 +20305,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.6.1.tgz",
+      "integrity": "sha512-341aRWQsve0rvronKNTqZpjmzdbUDlFuzHaI/XLg/Ej82qffDJRRfBTCuv7+9q/rMjB6LSLyEBnW4InJeMtt/Q==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,8 +17,8 @@
         "@starknet-io/get-starknet-wallet-standard-v6": "npm:@starknet-io/get-starknet-wallet-standard@6.0.4",
         "@starknet-io/starknet-types-0101": "npm:@starknet-io/types-js@0.10.2",
         "@starknet-io/starknet-types-0103": "npm:@starknet-io/types-js@0.10.3",
-        "@starknet-io/starknet-types-0104": "npm:@starknet-io/types-js@0.10.4-beta.2",
-        "@starknet-io/starknet-types-09": "npm:@starknet-io/types-js@~0.9.2",
+        "@starknet-io/starknet-types-0104": "npm:@starknet-io/types-js@0.10.4",
+        "@starknet-io/starknet-types-09": "npm:@starknet-io/types-js@0.9.2",
         "abi-wan-kanabi": "2.2.4",
         "lossless-json": "^4.2.0"
       },
@@ -4386,9 +4386,9 @@
     },
     "node_modules/@starknet-io/starknet-types-0104": {
       "name": "@starknet-io/types-js",
-      "version": "0.10.4-beta.2",
-      "resolved": "https://registry.npmjs.org/@starknet-io/types-js/-/types-js-0.10.4-beta.2.tgz",
-      "integrity": "sha512-DHfzg/d6s1NYeQpbBpLwXxYBVgCMhMIW2RjbSS2ukwz8XbPZQCLwj8ArAH4Tx4dmkJpn4J6YVRhZGFgjO26TVQ==",
+      "version": "0.10.4",
+      "resolved": "https://registry.npmjs.org/@starknet-io/types-js/-/types-js-0.10.4.tgz",
+      "integrity": "sha512-uyrgECEHzKpQfUSXgFpM3vPov4qYSoFQzdUNW+UEPHRJtaemzZGWPvIjuerPgjmrxKsh6q8nqzEKdm6BFykRlQ==",
       "license": "MIT"
     },
     "node_modules/@starknet-io/starknet-types-09": {

--- a/package.json
+++ b/package.json
@@ -109,8 +109,8 @@
     "@starknet-io/get-starknet-wallet-standard-v6": "npm:@starknet-io/get-starknet-wallet-standard@6.0.4",
     "@starknet-io/starknet-types-0101": "npm:@starknet-io/types-js@0.10.2",
     "@starknet-io/starknet-types-0103": "npm:@starknet-io/types-js@0.10.3",
-    "@starknet-io/starknet-types-0104": "npm:@starknet-io/types-js@0.10.4-beta.2",
-    "@starknet-io/starknet-types-09": "npm:@starknet-io/types-js@~0.9.2",
+    "@starknet-io/starknet-types-0104": "npm:@starknet-io/types-js@0.10.4",
+    "@starknet-io/starknet-types-09": "npm:@starknet-io/types-js@0.9.2",
     "abi-wan-kanabi": "2.2.4",
     "lossless-json": "^4.2.0"
   },

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "@scure/base": "~1.2.1",
     "@scure/starknet": "1.1.0",
     "@starknet-io/get-starknet-wallet-standard": "^5.0.0",
-    "@starknet-io/get-starknet-wallet-standard-v6": "npm:@starknet-io/get-starknet-wallet-standard@6.0.4",
+    "@starknet-io/get-starknet-wallet-standard-v6": "npm:@starknet-io/get-starknet-wallet-standard@6.0.6",
     "@starknet-io/starknet-types-0101": "npm:@starknet-io/types-js@0.10.2",
     "@starknet-io/starknet-types-0103": "npm:@starknet-io/types-js@0.10.3",
     "@starknet-io/starknet-types-0104": "npm:@starknet-io/types-js@0.10.4",

--- a/src/channel/index.ts
+++ b/src/channel/index.ts
@@ -1,8 +1,9 @@
 export * as RPC09 from './rpc_0_9_0';
 export * as RPC0102 from './rpc_0_10_2';
 export * as RPC0103 from './rpc_0_10_3';
+export * as RPC0104 from './rpc_0_10_4';
 // Default channel
-export * from './rpc_0_10_3';
+export * from './rpc_0_10_4';
 export * from './ws/ws_0_10';
 export * from './ws/subscription';
 export { TimeoutError, WebSocketNotConnectedError } from '../utils/errors';

--- a/src/channel/rpc_0_10_3.ts
+++ b/src/channel/rpc_0_10_3.ts
@@ -2,7 +2,7 @@ import { SupportedRpcVersion } from '../global/constants';
 import { RpcChannel as RpcChannel_0_10_2 } from './rpc_0_10_2';
 
 export class RpcChannel extends RpcChannel_0_10_2 {
-  override readonly id = 'RPC0.10.3';
+  override readonly id: string = 'RPC0.10.3';
 
   override readonly channelSpecVersion: SupportedRpcVersion = SupportedRpcVersion.v0_10_3;
 }

--- a/src/channel/rpc_0_10_4.ts
+++ b/src/channel/rpc_0_10_4.ts
@@ -1,0 +1,8 @@
+import { SupportedRpcVersion } from '../global/constants';
+import { RpcChannel as RpcChannel_0_10_3 } from './rpc_0_10_3';
+
+export class RpcChannel extends RpcChannel_0_10_3 {
+  override readonly id = 'RPC0.10.4';
+
+  override readonly channelSpecVersion: SupportedRpcVersion = SupportedRpcVersion.v0_10_4;
+}

--- a/src/channel/ws/ws_0_10.ts
+++ b/src/channel/ws/ws_0_10.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-underscore-dangle */
 import {
   JRPC,
-  RPCSPEC0103,
+  RPCSPEC0104,
   StarknetEventsEvent,
   NewHeadsEvent,
   TransactionsStatusEvent,
@@ -58,7 +58,7 @@ export interface SubscribeNewTransactionsParams {
   /** Filter by sender addresses */
   senderAddress?: BigNumberish[];
   /** Subscription tags for additional data (RPC 0.10.1+) */
-  tags?: RPCSPEC0103.SUBSCRIPTION_TAG[];
+  tags?: RPCSPEC0104.SUBSCRIPTION_TAG[];
 }
 
 // Subscription Result types

--- a/src/global/constants.ts
+++ b/src/global/constants.ts
@@ -105,10 +105,12 @@ const _SupportedRpcVersion = {
   '0.10.0': '0.10.0',
   '0.10.2': '0.10.2',
   '0.10.3': '0.10.3',
+  '0.10.4': '0.10.4',
   v0_9_0: '0.9.0',
   v0_10_0: '0.10.0',
   v0_10_2: '0.10.2',
   v0_10_3: '0.10.3',
+  v0_10_4: '0.10.4',
 } as const;
 type _SupportedRpcVersion = ValuesType<typeof _SupportedRpcVersion>;
 export { _SupportedRpcVersion as SupportedRpcVersion };
@@ -119,7 +121,8 @@ export { _SupportedRpcVersion as SupportedRpcVersion };
 export type SupportedRpcVersion0_10 =
   | typeof _SupportedRpcVersion.v0_10_0
   | typeof _SupportedRpcVersion.v0_10_2
-  | typeof _SupportedRpcVersion.v0_10_3;
+  | typeof _SupportedRpcVersion.v0_10_3
+  | typeof _SupportedRpcVersion.v0_10_4;
 
 export type SupportedTransactionVersion = typeof ETransactionVersion.V3;
 export type SupportedCairoVersion = '1';

--- a/src/provider/interface.ts
+++ b/src/provider/interface.ts
@@ -1,4 +1,4 @@
-import { RPC09, RPC0102, RPC0103 } from '../channel';
+import { RPC09, RPC0102, RPC0103, RPC0104 } from '../channel';
 import { StarknetChainId } from '../global/constants';
 import type {
   AccountInvocations,
@@ -40,11 +40,15 @@ import type {
   StorageResponse,
 } from '../types';
 import { TipAnalysisOptions, TipEstimate } from './modules/tip';
-import { RPCSPEC09, RPCSPEC0103 } from '../types/api';
+import { RPCSPEC09, RPCSPEC0104 } from '../types/api';
 import { RPCResponseParser } from './modules/responseParser';
 
 export abstract class ProviderInterface {
-  public abstract channel: RPC09.RpcChannel | RPC0102.RpcChannel | RPC0103.RpcChannel;
+  public abstract channel:
+    | RPC09.RpcChannel
+    | RPC0102.RpcChannel
+    | RPC0103.RpcChannel
+    | RPC0104.RpcChannel;
 
   public abstract responseParser: RPCResponseParser;
 
@@ -192,7 +196,7 @@ export abstract class ProviderInterface {
     contractAddress: BigNumberish,
     key: BigNumberish,
     blockIdentifier?: BlockIdentifier,
-    responseFlags?: RPCSPEC0103.STORAGE_RESPONSE_FLAG[]
+    responseFlags?: RPCSPEC0104.STORAGE_RESPONSE_FLAG[]
   ): Promise<StorageResponse>;
 
   /**
@@ -567,7 +571,7 @@ export abstract class ProviderInterface {
    */
   public abstract getTransactionTrace(
     txHash: BigNumberish
-  ): Promise<RPCSPEC0103.TRANSACTION_TRACE | RPCSPEC09.TRANSACTION_TRACE>;
+  ): Promise<RPCSPEC0104.TRANSACTION_TRACE | RPCSPEC09.TRANSACTION_TRACE>;
 
   /**
    * Get the status of a transaction
@@ -625,7 +629,7 @@ export abstract class ProviderInterface {
   public abstract estimateMessageFee(
     message: RPCSPEC09.L1Message,
     blockIdentifier?: BlockIdentifier
-  ): Promise<RPCSPEC0103.FEE_ESTIMATE | RPCSPEC09.MESSAGE_FEE_ESTIMATE>;
+  ): Promise<RPCSPEC0104.FEE_ESTIMATE | RPCSPEC09.MESSAGE_FEE_ESTIMATE>;
 
   /**
    * Get node synchronization status
@@ -639,8 +643,8 @@ export abstract class ProviderInterface {
    * @returns Events and pagination info
    */
   public abstract getEvents(
-    eventFilter: RPCSPEC0103.EventFilter | RPCSPEC09.EventFilter
-  ): Promise<RPCSPEC0103.EVENTS_CHUNK | RPCSPEC09.EVENTS_CHUNK>;
+    eventFilter: RPCSPEC0104.EventFilter | RPCSPEC09.EventFilter
+  ): Promise<RPCSPEC0104.EVENTS_CHUNK | RPCSPEC09.EVENTS_CHUNK>;
 
   /**
    * Verify in Starknet a signature of a TypedData object or of a given hash.
@@ -697,7 +701,7 @@ export abstract class ProviderInterface {
    */
   public abstract getL1MessagesStatus(
     transactionHash: BigNumberish
-  ): Promise<RPC.RPCSPEC0103.L1L2MessagesStatus | RPC.RPCSPEC09.L1L2MessagesStatus>;
+  ): Promise<RPC.RPCSPEC0104.L1L2MessagesStatus | RPC.RPCSPEC09.L1L2MessagesStatus>;
 
   /**
    * Get Merkle paths in state tries

--- a/src/provider/modules/responseParser/rpc.ts
+++ b/src/provider/modules/responseParser/rpc.ts
@@ -13,7 +13,7 @@ import type {
   SimulateTransactionOverheadResponse,
   EstimateFeeResponseBulkOverhead,
 } from '../../types/index.type';
-import { RPCSPEC0103 } from '../../../types/api';
+import { RPCSPEC0104 } from '../../../types/api';
 import { isString } from '../../../utils/typed';
 import { toOverheadOverallFee, toOverheadResourceBounds } from '../../../utils/stark';
 import { ResponseParser } from './interface';
@@ -87,8 +87,8 @@ export class RPCResponseParser implements Omit<
   }
 
   public parseStorageResponse(
-    res: RPCSPEC0103.FELT | RPCSPEC0103.STORAGE_RESULT
-  ): RPCSPEC0103.STORAGE_RESULT {
+    res: RPCSPEC0104.FELT | RPCSPEC0104.STORAGE_RESULT
+  ): RPCSPEC0104.STORAGE_RESULT {
     // Normalize response: wrap FELT (string) in STORAGE_RESULT if needed
     if (typeof res === 'string') {
       return { value: res, last_update_block: 0 };

--- a/src/provider/rpc.ts
+++ b/src/provider/rpc.ts
@@ -1,4 +1,4 @@
-import { RPC09, RPC0102, RPC0103 } from '../channel';
+import { RPC09, RPC0102, RPC0103, RPC0104 } from '../channel';
 import { config } from '../global/config';
 import { SupportedRpcVersion, type SupportedRpcVersion0_10 } from '../global/constants';
 import { logger } from '../global/logger';
@@ -34,7 +34,7 @@ import {
   type TypedData,
   waitForTransactionOptions,
 } from '../types';
-import { ETransactionType, RPCSPEC0103, RPCSPEC09 } from '../types/api';
+import { ETransactionType, RPCSPEC0104, RPCSPEC09 } from '../types/api';
 import assert from '../utils/assert';
 import { getAbiContractVersion } from '../utils/calldata/cairo';
 import { extractContractHashes, isSierra } from '../utils/contract';
@@ -73,7 +73,7 @@ export interface RpcProvider
 export class RpcProvider implements ProviderInterface {
   public responseParser: RPCResponseParser;
 
-  public channel: RPC09.RpcChannel | RPC0102.RpcChannel | RPC0103.RpcChannel;
+  public channel: RPC09.RpcChannel | RPC0102.RpcChannel | RPC0103.RpcChannel | RPC0104.RpcChannel;
 
   /** @internal Plugin management infrastructure */
   public readonly pluginManager: PluginManager;
@@ -101,14 +101,14 @@ export class RpcProvider implements ProviderInterface {
         if (isVersion('0.9', options.specVersion)) {
           this.channel = new RPC09.RpcChannel({ ...options, waitMode: false });
         } else if (isVersion('0.10', options.specVersion)) {
-          this.channel = new RPC0103.RpcChannel({ ...options, waitMode: false });
+          this.channel = new RPC0104.RpcChannel({ ...options, waitMode: false });
         } else throw new Error(`unsupported channel for spec version: ${options.specVersion}`);
       } else if (isVersion('0.9', config.get('rpcVersion'))) {
         // default channel when unspecified
         this.channel = new RPC09.RpcChannel({ ...options, waitMode: false });
       } else if (isVersion('0.10', config.get('rpcVersion'))) {
         // default channel when unspecified
-        this.channel = new RPC0103.RpcChannel({ ...options, waitMode: false });
+        this.channel = new RPC0104.RpcChannel({ ...options, waitMode: false });
       } else throw new Error('unable to define spec version for channel');
 
       this.responseParser = new RPCResponseParser(options?.resourceBoundsOverhead);
@@ -144,13 +144,14 @@ export class RpcProvider implements ProviderInterface {
     if (isVersion('0.9', specVersion)) {
       return new this({
         ...optionsOrProvider,
-        specVersion: SupportedRpcVersion.v0_9_0,
+        specVersion: specVersion as SupportedRpcVersion,
       }) as T;
     }
     if (isVersion('0.10', specVersion)) {
       return new this({
         ...optionsOrProvider,
-        specVersion: SupportedRpcVersion.v0_10_3,
+        // forward the version the node reports, not the newest revision the SDK implements
+        specVersion: specVersion as SupportedRpcVersion,
       }) as T;
     }
 
@@ -396,14 +397,14 @@ export class RpcProvider implements ProviderInterface {
   public async getTransactionTrace<V extends SupportedRpcVersion = SupportedRpcVersion>(
     txHash: BigNumberish
   ): Promise<
-    V extends SupportedRpcVersion0_10 ? RPCSPEC0103.TRANSACTION_TRACE : RPCSPEC09.TRANSACTION_TRACE
+    V extends SupportedRpcVersion0_10 ? RPCSPEC0104.TRANSACTION_TRACE : RPCSPEC09.TRANSACTION_TRACE
   >;
   public async getTransactionTrace(
     txHash: BigNumberish
-  ): Promise<RPCSPEC0103.TRANSACTION_TRACE | RPCSPEC09.TRANSACTION_TRACE>;
+  ): Promise<RPCSPEC0104.TRANSACTION_TRACE | RPCSPEC09.TRANSACTION_TRACE>;
   public async getTransactionTrace(
     txHash: BigNumberish
-  ): Promise<RPCSPEC0103.TRANSACTION_TRACE | RPCSPEC09.TRANSACTION_TRACE> {
+  ): Promise<RPCSPEC0104.TRANSACTION_TRACE | RPCSPEC09.TRANSACTION_TRACE> {
     return this.channel.getTransactionTrace(txHash);
   }
 
@@ -437,7 +438,7 @@ export class RpcProvider implements ProviderInterface {
     contractAddress: BigNumberish,
     key: BigNumberish,
     blockIdentifier?: BlockIdentifier,
-    responseFlags?: RPCSPEC0103.STORAGE_RESPONSE_FLAG[]
+    responseFlags?: RPCSPEC0104.STORAGE_RESPONSE_FLAG[]
   ) {
     const result = await this.channel.getStorageAt(
       contractAddress,
@@ -615,16 +616,16 @@ export class RpcProvider implements ProviderInterface {
     message: RPCSPEC09.L1Message,
     blockIdentifier?: BlockIdentifier
   ): Promise<
-    V extends SupportedRpcVersion0_10 ? RPCSPEC0103.FEE_ESTIMATE : RPCSPEC09.MESSAGE_FEE_ESTIMATE
+    V extends SupportedRpcVersion0_10 ? RPCSPEC0104.FEE_ESTIMATE : RPCSPEC09.MESSAGE_FEE_ESTIMATE
   >;
   public async estimateMessageFee(
     message: RPCSPEC09.L1Message,
     blockIdentifier?: BlockIdentifier
-  ): Promise<RPCSPEC0103.FEE_ESTIMATE | RPCSPEC09.MESSAGE_FEE_ESTIMATE>;
+  ): Promise<RPCSPEC0104.FEE_ESTIMATE | RPCSPEC09.MESSAGE_FEE_ESTIMATE>;
   public async estimateMessageFee(
     message: RPCSPEC09.L1Message, // same as spec08.L1Message
     blockIdentifier?: BlockIdentifier
-  ): Promise<RPCSPEC0103.FEE_ESTIMATE | RPCSPEC09.MESSAGE_FEE_ESTIMATE> {
+  ): Promise<RPCSPEC0104.FEE_ESTIMATE | RPCSPEC09.MESSAGE_FEE_ESTIMATE> {
     return this.channel.estimateMessageFee(message, blockIdentifier);
   }
 
@@ -633,16 +634,16 @@ export class RpcProvider implements ProviderInterface {
   }
 
   public async getEvents<V extends SupportedRpcVersion = SupportedRpcVersion>(
-    eventFilter: V extends SupportedRpcVersion0_10 ? RPCSPEC0103.EventFilter : RPCSPEC09.EventFilter
-  ): Promise<V extends SupportedRpcVersion0_10 ? RPCSPEC0103.EVENTS_CHUNK : RPCSPEC09.EVENTS_CHUNK>;
+    eventFilter: V extends SupportedRpcVersion0_10 ? RPCSPEC0104.EventFilter : RPCSPEC09.EventFilter
+  ): Promise<V extends SupportedRpcVersion0_10 ? RPCSPEC0104.EVENTS_CHUNK : RPCSPEC09.EVENTS_CHUNK>;
   public async getEvents(
-    eventFilter: RPCSPEC0103.EventFilter | RPCSPEC09.EventFilter
-  ): Promise<RPCSPEC0103.EVENTS_CHUNK | RPCSPEC09.EVENTS_CHUNK>;
+    eventFilter: RPCSPEC0104.EventFilter | RPCSPEC09.EventFilter
+  ): Promise<RPCSPEC0104.EVENTS_CHUNK | RPCSPEC09.EVENTS_CHUNK>;
   public async getEvents(
-    eventFilter: RPCSPEC0103.EventFilter | RPCSPEC09.EventFilter
-  ): Promise<RPCSPEC0103.EVENTS_CHUNK | RPCSPEC09.EVENTS_CHUNK> {
+    eventFilter: RPCSPEC0104.EventFilter | RPCSPEC09.EventFilter
+  ): Promise<RPCSPEC0104.EVENTS_CHUNK | RPCSPEC09.EVENTS_CHUNK> {
     if (this.channel instanceof RPC0102.RpcChannel) {
-      return this.channel.getEvents(eventFilter as RPCSPEC0103.EventFilter);
+      return this.channel.getEvents(eventFilter as RPCSPEC0104.EventFilter);
     }
     if (this.channel instanceof RPC09.RpcChannel) {
       return this.channel.getEvents(eventFilter as RPCSPEC09.EventFilter);
@@ -720,15 +721,15 @@ export class RpcProvider implements ProviderInterface {
     transactionHash: BigNumberish
   ): Promise<
     V extends SupportedRpcVersion0_10
-      ? RPC.RPCSPEC0103.L1L2MessagesStatus
+      ? RPC.RPCSPEC0104.L1L2MessagesStatus
       : RPC.RPCSPEC09.L1L2MessagesStatus
   >;
   public async getL1MessagesStatus(
     transactionHash: BigNumberish
-  ): Promise<RPC.RPCSPEC0103.L1L2MessagesStatus | RPC.RPCSPEC09.L1L2MessagesStatus>;
+  ): Promise<RPC.RPCSPEC0104.L1L2MessagesStatus | RPC.RPCSPEC09.L1L2MessagesStatus>;
   public async getL1MessagesStatus(
     transactionHash: BigNumberish
-  ): Promise<RPC.RPCSPEC0103.L1L2MessagesStatus | RPC.RPCSPEC09.L1L2MessagesStatus> {
+  ): Promise<RPC.RPCSPEC0104.L1L2MessagesStatus | RPC.RPCSPEC09.L1L2MessagesStatus> {
     return this.channel.getMessagesStatus(transactionHash);
   }
 

--- a/src/provider/types/response.type.ts
+++ b/src/provider/types/response.type.ts
@@ -9,7 +9,7 @@ import {
   IsSucceeded,
   IsType,
   PRE_CONFIRMED_BLOCK_WITH_TX_HASHES,
-  RPCSPEC0103,
+  RPCSPEC0104,
   TransactionReceipt,
 } from '../../types/api';
 
@@ -62,7 +62,7 @@ export type DeclareContractResponse = DeclaredTransaction;
 
 export type CallContractResponse = string[];
 
-export type StorageResponse = RPCSPEC0103.STORAGE_RESULT;
+export type StorageResponse = RPCSPEC0104.STORAGE_RESULT;
 
 export type Nonce = string;
 

--- a/src/provider/types/spec.type.ts
+++ b/src/provider/types/spec.type.ts
@@ -1,7 +1,7 @@
 // this file aims to unify the RPC specification types used by the common Provider class
 
 import { SimpleOneOf } from '../../types/helpers';
-import { RPCSPEC09, RPCSPEC0103 } from '../../types/api';
+import { RPCSPEC09, RPCSPEC0104 } from '../../types/api';
 
 // taken from type-fest
 export type Simplify<T> = { [K in keyof T]: T[K] } & {};
@@ -62,22 +62,22 @@ export type ETransactionVersion3 = RPCSPEC09.ETransactionVersion3;
 export const { ETransactionVersion3 } = RPCSPEC09;
 
 // MERGES
-export type BLOCK_HASH = Merge<RPCSPEC0103.BLOCK_HASH, RPCSPEC09.BLOCK_HASH>;
-export type BLOCK_NUMBER = Merge<RPCSPEC0103.BLOCK_NUMBER, RPCSPEC09.BLOCK_NUMBER>;
-export type FELT = Merge<RPCSPEC0103.FELT, RPCSPEC09.FELT>;
-export type TXN_HASH = Merge<RPCSPEC0103.TXN_HASH, RPCSPEC09.TXN_HASH>;
+export type BLOCK_HASH = Merge<RPCSPEC0104.BLOCK_HASH, RPCSPEC09.BLOCK_HASH>;
+export type BLOCK_NUMBER = Merge<RPCSPEC0104.BLOCK_NUMBER, RPCSPEC09.BLOCK_NUMBER>;
+export type FELT = Merge<RPCSPEC0104.FELT, RPCSPEC09.FELT>;
+export type TXN_HASH = Merge<RPCSPEC0104.TXN_HASH, RPCSPEC09.TXN_HASH>;
 
-export type PRICE_UNIT = Merge<RPCSPEC0103.PRICE_UNIT, RPCSPEC09.PRICE_UNIT>;
-export type RESOURCE_PRICE = Merge<RPCSPEC0103.RESOURCE_PRICE, RPCSPEC09.RESOURCE_PRICE>;
-export type SIMULATION_FLAG = Merge<RPCSPEC0103.SIMULATION_FLAG, RPCSPEC09.SIMULATION_FLAG>;
+export type PRICE_UNIT = Merge<RPCSPEC0104.PRICE_UNIT, RPCSPEC09.PRICE_UNIT>;
+export type RESOURCE_PRICE = Merge<RPCSPEC0104.RESOURCE_PRICE, RPCSPEC09.RESOURCE_PRICE>;
+export type SIMULATION_FLAG = Merge<RPCSPEC0104.SIMULATION_FLAG, RPCSPEC09.SIMULATION_FLAG>;
 
-export type STATE_UPDATE = Merge<RPCSPEC0103.STATE_UPDATE, RPCSPEC09.STATE_UPDATE>;
+export type STATE_UPDATE = Merge<RPCSPEC0104.STATE_UPDATE, RPCSPEC09.STATE_UPDATE>;
 /* export type PENDING_STATE_UPDATE = Merge<
-  RPCSPEC0103.PENDING_STATE_UPDATE,
+  RPCSPEC0104.PENDING_STATE_UPDATE,
   RPCSPEC09.PRE_CONFIRMED_STATE_UPDATE
 >; */
 export type PRE_CONFIRMED_STATE_UPDATE = Merge<
-  RPCSPEC0103.PRE_CONFIRMED_STATE_UPDATE,
+  RPCSPEC0104.PRE_CONFIRMED_STATE_UPDATE,
   RPCSPEC09.PRE_CONFIRMED_STATE_UPDATE
 >;
 // TODO: Can we remove all of this ?
@@ -102,47 +102,47 @@ export type PENDING_L1_HANDLER_TXN_RECEIPT = RPCSPEC08.IsPending<
 >; */
 //
 
-export type BlockWithTxHashes = Merge<RPCSPEC0103.BlockWithTxHashes, RPCSPEC09.BlockWithTxHashes>;
-export type ContractClassPayload = Merge<RPCSPEC0103.ContractClass, RPCSPEC09.ContractClass>;
+export type BlockWithTxHashes = Merge<RPCSPEC0104.BlockWithTxHashes, RPCSPEC09.BlockWithTxHashes>;
+export type ContractClassPayload = Merge<RPCSPEC0104.ContractClass, RPCSPEC09.ContractClass>;
 export type DeclaredTransaction = Merge<
-  RPCSPEC0103.DeclaredTransaction,
+  RPCSPEC0104.DeclaredTransaction,
   RPCSPEC09.DeclaredTransaction
 >;
 export type InvokedTransaction = Merge<
-  RPCSPEC0103.InvokedTransaction,
+  RPCSPEC0104.InvokedTransaction,
   RPCSPEC09.InvokedTransaction
 >;
 export type DeployedAccountTransaction = Merge<
-  RPCSPEC0103.DeployedAccountTransaction,
+  RPCSPEC0104.DeployedAccountTransaction,
   RPCSPEC09.DeployedAccountTransaction
 >;
 
-export type L1_HANDLER_TXN = RPCSPEC0103.L1_HANDLER_TXN;
-export type EDataAvailabilityMode = RPCSPEC0103.EDataAvailabilityMode;
-export const { EDataAvailabilityMode } = RPCSPEC0103;
-export type EDAMode = RPCSPEC0103.EDAMode;
-export const { EDAMode } = RPCSPEC0103;
-export type EmittedEvent = Merge<RPCSPEC0103.EmittedEvent, RPCSPEC09.EmittedEvent>;
-export type Event = Merge<RPCSPEC0103.Event, RPCSPEC09.Event>;
+export type L1_HANDLER_TXN = RPCSPEC0104.L1_HANDLER_TXN;
+export type EDataAvailabilityMode = RPCSPEC0104.EDataAvailabilityMode;
+export const { EDataAvailabilityMode } = RPCSPEC0104;
+export type EDAMode = RPCSPEC0104.EDAMode;
+export const { EDAMode } = RPCSPEC0104;
+export type EmittedEvent = Merge<RPCSPEC0104.EmittedEvent, RPCSPEC09.EmittedEvent>;
+export type Event = Merge<RPCSPEC0104.Event, RPCSPEC09.Event>;
 
 /* export type PendingReceipt = Merge<
-  RPCSPEC0103.TransactionReceiptPendingBlock,
+  RPCSPEC0104.TransactionReceiptPendingBlock,
   RPCSPEC09.TransactionReceiptPreConfirmedBlock
 >; */
 export type Receipt = Merge<
-  RPCSPEC0103.TransactionReceiptProductionBlock,
+  RPCSPEC0104.TransactionReceiptProductionBlock,
   RPCSPEC09.TransactionReceiptProductionBlock
 >;
 
 /**
  * original response from estimate fee without parsing
  */
-export type FeeEstimate = Merge<RPCSPEC0103.FEE_ESTIMATE, RPCSPEC09.FEE_ESTIMATE>;
+export type FeeEstimate = Merge<RPCSPEC0104.FEE_ESTIMATE, RPCSPEC09.FEE_ESTIMATE>;
 export type ApiEstimateFeeResponse = FeeEstimate[]; // 0.8 and 0.9
 
 export function isRPC08Plus_ResourceBounds(
   entry: ResourceBounds
-): entry is RPCSPEC0103.ResourceBounds {
+): entry is RPCSPEC0104.ResourceBounds {
   return 'l1_data_gas' in entry;
 }
 
@@ -150,7 +150,7 @@ export function isRPC08Plus_ResourceBoundsBN(entry: ResourceBoundsBN): entry is 
   return 'l1_data_gas' in entry;
 }
 
-export type ResourceBounds = Merge<RPCSPEC0103.ResourceBounds, RPCSPEC09.ResourceBounds>; // same sa rpc0.8
+export type ResourceBounds = Merge<RPCSPEC0104.ResourceBounds, RPCSPEC09.ResourceBounds>; // same sa rpc0.8
 
 export type EventFilter = RPCSPEC09.EventFilter;
 
@@ -179,60 +179,60 @@ export type ResourceBoundsBN = {
 
 export type SimulateTransaction = SimpleOneOf<
   RPCSPEC09.SimulateTransaction,
-  RPCSPEC0103.SimulateTransaction
+  RPCSPEC0104.SimulateTransaction
 >;
 export type SimulateTransactionResponse =
   | RPCSPEC09.SimulateTransactionResponse
-  | RPCSPEC0103.SimulateTransactionResponse;
+  | RPCSPEC0104.SimulateTransactionResponse;
 
-export type INITIAL_READS = RPCSPEC0103.INITIAL_READS;
+export type INITIAL_READS = RPCSPEC0104.INITIAL_READS;
 
 /** Flags to request additional fields in transaction responses (RPC 0.10.1+) */
-export type ETxnResponseFlag = RPCSPEC0103.ETxnResponseFlag;
-export const { ETxnResponseFlag } = RPCSPEC0103;
+export type ETxnResponseFlag = RPCSPEC0104.ETxnResponseFlag;
+export const { ETxnResponseFlag } = RPCSPEC0104;
 
 /** Flags to request additional fields in trace responses (RPC 0.10.1+) */
-export type ETraceFlag = RPCSPEC0103.ETraceFlag;
-export const { ETraceFlag } = RPCSPEC0103;
+export type ETraceFlag = RPCSPEC0104.ETraceFlag;
+export const { ETraceFlag } = RPCSPEC0104;
 
 /** Tags for WebSocket transaction subscriptions (RPC 0.10.1+) */
-export type ESubscriptionTag = RPCSPEC0103.ESubscriptionTag;
-export const { ESubscriptionTag } = RPCSPEC0103;
+export type ESubscriptionTag = RPCSPEC0104.ESubscriptionTag;
+export const { ESubscriptionTag } = RPCSPEC0104;
 
 /** A single transaction trace within a block */
-export type BlockTransactionTrace = RPCSPEC0103.BlockTransactionTrace;
+export type BlockTransactionTrace = RPCSPEC0104.BlockTransactionTrace;
 /** Block transaction traces with optional initial storage reads (RPC 0.10.1+) */
 export type BlockTransactionsTracesWithInitialReads =
-  RPCSPEC0103.BlockTransactionsTracesWithInitialReads;
+  RPCSPEC0104.BlockTransactionsTracesWithInitialReads;
 
 export type TransactionTrace = SimpleOneOf<
   RPCSPEC09.TRANSACTION_TRACE,
-  RPCSPEC0103.TRANSACTION_TRACE
+  RPCSPEC0104.TRANSACTION_TRACE
 >;
 
 export type TransactionWithHash = Merge<
-  RPCSPEC0103.TransactionWithHash,
+  RPCSPEC0104.TransactionWithHash,
   RPCSPEC09.TransactionWithHash
 >;
 
 export type TransactionReceipt = Merge<
-  RPCSPEC0103.TransactionReceipt,
+  RPCSPEC0104.TransactionReceipt,
   RPCSPEC09.TransactionReceipt
 >;
-export type Methods = RPCSPEC0103.Methods;
-export type TXN_STATUS = Merge<RPCSPEC0103.TXN_STATUS, RPCSPEC09.TXN_STATUS>;
+export type Methods = RPCSPEC0104.Methods;
+export type TXN_STATUS = Merge<RPCSPEC0104.TXN_STATUS, RPCSPEC09.TXN_STATUS>;
 export type TXN_EXECUTION_STATUS = Merge<
-  RPCSPEC0103.TXN_EXECUTION_STATUS,
+  RPCSPEC0104.TXN_EXECUTION_STATUS,
   RPCSPEC09.TXN_EXECUTION_STATUS
 >;
-export type TransactionStatus = Merge<RPCSPEC0103.TransactionStatus, RPCSPEC09.TransactionStatus>;
-export type ETransactionStatus = RPCSPEC0103.ETransactionStatus;
-export const { ETransactionStatus } = RPCSPEC0103;
-export type ETransactionExecutionStatus = RPCSPEC0103.ETransactionExecutionStatus;
-export const { ETransactionExecutionStatus } = RPCSPEC0103;
+export type TransactionStatus = Merge<RPCSPEC0104.TransactionStatus, RPCSPEC09.TransactionStatus>;
+export type ETransactionStatus = RPCSPEC0104.ETransactionStatus;
+export const { ETransactionStatus } = RPCSPEC0104;
+export type ETransactionExecutionStatus = RPCSPEC0104.ETransactionExecutionStatus;
+export const { ETransactionExecutionStatus } = RPCSPEC0104;
 // export type TRANSACTION_TRACE = Merge<RPCSPEC08.TRANSACTION_TRACE, RPCSPEC09.TRANSACTION_TRACE>;
-export type FEE_ESTIMATE = Merge<RPCSPEC0103.FEE_ESTIMATE, RPCSPEC09.FEE_ESTIMATE>;
-export type EVENTS_CHUNK = Merge<RPCSPEC0103.EVENTS_CHUNK, RPCSPEC09.EVENTS_CHUNK>;
+export type FEE_ESTIMATE = Merge<RPCSPEC0104.FEE_ESTIMATE, RPCSPEC09.FEE_ESTIMATE>;
+export type EVENTS_CHUNK = Merge<RPCSPEC0104.EVENTS_CHUNK, RPCSPEC09.EVENTS_CHUNK>;
 
 export type TransactionType = RPCSPEC09.ETransactionType;
 export const { ETransactionType: TransactionType } = RPCSPEC09;

--- a/src/types/api/index.ts
+++ b/src/types/api/index.ts
@@ -1,12 +1,12 @@
 export * as JRPC from './jsonrpc';
 
 export * as RPCSPEC09 from '@starknet-io/starknet-types-09';
-export * as RPCSPEC0103 from '@starknet-io/starknet-types-0103';
+export * as RPCSPEC0104 from '@starknet-io/starknet-types-0104';
 
-export { PAYMASTER_API } from '@starknet-io/starknet-types-0103';
+export { PAYMASTER_API } from '@starknet-io/starknet-types-0104';
 
 // Default export
-// alias for "export * from '@starknet-io/starknet-types-09';" which is done within ./rpc.ts
+// alias for "export * from '@starknet-io/starknet-types-0104';" which is done within ./rpc.ts
 // the extra level avoids a rollup issue that injects namespace merger JS code into the published .d.ts file
 //
 // eslint-disable-next-line

--- a/src/types/api/rpc.ts
+++ b/src/types/api/rpc.ts
@@ -1,2 +1,2 @@
 // see explanation in ./index.ts
-export * from '@starknet-io/starknet-types-0103';
+export * from '@starknet-io/starknet-types-0104';

--- a/www/docs/guides/configuration.md
+++ b/www/docs/guides/configuration.md
@@ -65,7 +65,7 @@ Here are all the available configuration properties:
 
 ```ts
 {
-  // RPC version to use when communicating with nodes ('0.9.0', '0.10.0', '0.10.2', '0.10.3')
+  // RPC version to use when communicating with nodes ('0.9.0', '0.10.0', '0.10.2', '0.10.3', '0.10.4')
   rpcVersion: '0.10.0',
 
   // Transaction version to use (only V3 is supported in v8)

--- a/www/docs/guides/migrate.md
+++ b/www/docs/guides/migrate.md
@@ -24,7 +24,7 @@ If you encounter any missing changes, please let us know and we will update this
 10. **fastExecute Moved to a Plugin** - `account.fastExecute()` and `provider.fastWaitForTransaction()` now come from the `fastExecute` plugin
 11. **Paymaster Option Renamed** - `PaymasterRpcOptions.default` → `mute`
 12. **felt252 Validation** - `CairoFelt()` now throws on out-of-range values, and `CairoFelt252.toApiRequest()` returns decimal
-13. **RPC Namespace Renames** - `RPCSPEC010` → `RPCSPEC0103`, `RPC010` → `RPC0102` / `RPC0103`
+13. **RPC Namespace Renames** - `RPCSPEC010` → `RPCSPEC0104`, `RPC010` → `RPC0102` / `RPC0103` / `RPC0104`
 
 ### Breaking Changes Summary
 
@@ -661,9 +661,9 @@ strings, or that relied on out-of-range values not throwing.
 
 Two public exports were renamed to track the new default RPC spec version. These only affect advanced usage (raw RPC spec types and direct channel imports).
 
-### `RPCSPEC010` → `RPCSPEC0103`
+### `RPCSPEC010` → `RPCSPEC0104`
 
-The namespace re-exporting the 0.10.x RPC spec types was renamed.
+The namespace re-exporting the 0.10.x RPC spec types was renamed. It always tracks the newest supported spec revision, so it moves again whenever one is added: `RPCSPEC0101`, then `RPCSPEC0103`, and `RPCSPEC0104` since v10.8.0.
 
 **❌ v9:**
 
@@ -676,14 +676,14 @@ type MyBlock = RPCSPEC010.BLOCK_WITH_TXS;
 **✅ v10:**
 
 ```typescript
-import { RPCSPEC0103 } from 'starknet';
+import { RPCSPEC0104 } from 'starknet';
 
-type MyBlock = RPCSPEC0103.BLOCK_WITH_TXS;
+type MyBlock = RPCSPEC0104.BLOCK_WITH_TXS;
 ```
 
-### `RPC010` → `RPC0102` / `RPC0103`
+### `RPC010` → `RPC0102` / `RPC0103` / `RPC0104`
 
-The channel namespace for the 0.10.x RPC implementation was renamed. v10 exposes two channel variants: `RPC0102` (spec 0.10.2) and `RPC0103` (spec 0.10.3, the default).
+The channel namespace for the 0.10.x RPC implementation was renamed. v10 exposes one variant per spec revision, the newest being the default; earlier ones remain available.
 
 **❌ v9:**
 
@@ -694,7 +694,8 @@ import { RPC010 } from 'starknet';
 **✅ v10:**
 
 ```typescript
-import { RPC0103 } from 'starknet'; // spec 0.10.3 (default)
+import { RPC0104 } from 'starknet'; // spec 0.10.4 (default)
+import { RPC0103 } from 'starknet'; // spec 0.10.3
 import { RPC0102 } from 'starknet'; // spec 0.10.2 (legacy)
 ```
 
@@ -820,8 +821,9 @@ your use case requires SNIP-36 fact commitment — see the [Proofs (SNIP-36) gui
 None of the following requires any migration work, but they are worth knowing about once you are on
 v10:
 
-- **RPC 0.10.3 support.** Two channels ship side by side, `RPC0102` (spec 0.10.2) and `RPC0103`
-  (spec 0.10.3, the default). `RpcProvider.create()` picks the right one from the node.
+- **RPC 0.10.4 support.** Three channels ship side by side, `RPC0102` (spec 0.10.2), `RPC0103`
+  (spec 0.10.3) and `RPC0104` (spec 0.10.4, the default). `RpcProvider.create()` reads the node
+  spec version and connects through the channel of its generation.
 - **Runtime plugin installation** with `provider.use(plugin)`, fully typed — see the
   [Plugin System Guide](./plugins.md).
 - **`contract.compile(method, args)`** returns the compiled `Calldata` alone, without the

--- a/www/docs/guides/provider_instance.md
+++ b/www/docs/guides/provider_instance.md
@@ -39,11 +39,12 @@ The Starknet.js version must align with the RPC version supported by the chosen 
 | :---------------------------: | ------------------------------------- |
 |            v0.7.x             | Starknet.js v6.24.1 or v7.6.4         |
 |            v0.8.x             | Starknet.js v7.6.4 or v8.9.2          |
-|            v0.9.x             | Starknet.js v8.9.2, v9.4.2 or v10.4.0 |
-|            v0.10.0            | Starknet.js v9.4.2 or v10.4.0         |
+|            v0.9.x             | Starknet.js v8.9.2, v9.4.2 or v10.8.0 |
+|            v0.10.0            | Starknet.js v9.4.2 or v10.8.0         |
 |            v0.10.1            | Not supported                         |
-|            v0.10.2            | Starknet.js v10.4.0                   |
-|            v0.10.3            | Starknet.js v10.4.0                   |
+|            v0.10.2            | Starknet.js v10.8.0                   |
+|            v0.10.3            | Starknet.js v10.8.0                   |
+|            v0.10.4            | Starknet.js v10.8.0                   |
 
 :::note
 
@@ -86,12 +87,12 @@ import { RpcProvider } from 'starknet';
 
 **Local Starknet Devnet network:**
 
-|                   Node | with public url | with API key |
-| ---------------------: | :-------------: | :----------: |
-| starknet-devnet v0.2.4 |      v0_7       |     N/A      |
-| starknet-devnet v0.4.3 |      v0_8       |     N/A      |
-| starknet-devnet v0.6.1 |      v0_9       |     N/A      |
-| starknet-devnet v0.9.0 |      v0_10      |     N/A      |
+|                    Node | with public url | with API key |
+| ----------------------: | :-------------: | :----------: |
+|  starknet-devnet v0.2.4 |      v0_7       |     N/A      |
+|  starknet-devnet v0.4.3 |      v0_8       |     N/A      |
+|  starknet-devnet v0.6.1 |      v0_9       |     N/A      |
+| starknet-devnet v0.10.0 |      v0_10      |     N/A      |
 
 :::note
 
@@ -223,7 +224,7 @@ Example of a connection to a local development node, with starknet-devnet:
 // For RPC 0.10.x (starknet-devnet v0.8.2)
 const myProvider = new RpcProvider({ nodeUrl: 'http://127.0.0.1:5050/rpc' });
 
-// For RPC 0.9.1 (starknet-devnet v0.6.1)
+// For RPC 0.9.0 (starknet-devnet v0.6.1)
 const myProvider = new RpcProvider({ nodeUrl: 'http://127.0.0.1:5050/rpc' });
 ```
 


### PR DESCRIPTION
## Motivation and Resolution

Starknet RPC spec 0.10.4 was released, along with `@starknet-io/types-js` 0.10.4
and `@starknet-io/get-starknet-wallet-standard` 6.0.6. This adds 0.10.4 as the
newest supported spec revision, without dropping any earlier one.

It follows the pattern already used for 0.10.3: `rpc_0_10_4.ts` is a thin
subclass overriding only the spec revision it announces, and becomes the head of
the 0.10 generation. `RPC0103` and `RPC0102` stay exported for callers pinning an
earlier revision.

Moving that head surfaced a latent bug in `RpcProvider.create()`. It read the
spec version reported by the node, used it for the compatibility warning, then
handed the channel the newest revision the SDK implements instead. The
substitution was invisible while the head happened to equal the value most nodes
report. `create()` now forwards the version the node actually announced.

### RPC version (if applicable)

Adds spec 0.10.4. Spec 0.9.0, 0.10.0, 0.10.2 and 0.10.3 remain supported.

## Usage related changes

- `RPC0104` channel namespace added, used by default for any 0.10.x node.
  `RPC0103` and `RPC0102` remain exported.
- `RPCSPEC0103` is renamed `RPCSPEC0104`, tracking the head as `RPCSPEC0101` ->
  `RPCSPEC0103` did before. This only affects advanced usage (raw RPC spec
  types); the migration guide is updated.
- `readSpecVersion()` now returns the spec version reported by the node instead
  of the newest revision the SDK implements. A node running 0.10.2 reports
  `0.10.2` where it previously reported `0.10.3`.
- `@starknet-io/types-js` moves to the final 0.10.4, and the wallet-standard
  package to 6.0.6, which pins that same release. The `0.10.4-beta.2` copy no
  longer coexists in the dependency tree.
- 6.0.6 carries the `ox` 0.4.4 -> 1.6.2 jump, pulling the `@noble` and `@scure`
  v2 stack, `zod` and `@noble/post-quantum` in as transitive dependencies. None
  of it reaches the bundles: every import of the wallet-standard package under
  `src/wallet/` is type-only and erased at compile time.
- Both `types-js` aliases are now pinned exactly, the 0.9 one included.

## Development related changes

- Two tests added to `specVersionResolution.test.ts`: every 0.10 patch version
  routes to the same channel while reporting its own version, and a 0.9 node
  lands on a different channel than a 0.10 one. Neither hardcodes a channel id,
  so a future head move will not break them.
- `rpc_0_10_3.ts` annotates `id` as `string`. It was inferred as a literal type,
  which prevented any later revision from inheriting from it.
- Guides updated: migration guide for the namespace rename, provider guide for
  the version table and the devnet RPC version, configuration guide for the
  accepted `rpcVersion` values.

## Checklist:

- [x] Performed a self-review of the code
- [x] Documented the changes in code (API docs will be generated automatically)
- [x] Updated the tests
- [x] All tests are passing
