### PR TITLE
docs: make 10.x the default docs version and flag 6.x-9.x snapshots as unmaintained

### DIFF
--- a/www/docs/guides/websocket_channel.md
+++ b/www/docs/guides/websocket_channel.md
@@ -365,5 +365,5 @@ main();
 ```
 
 All the types (`WebSocketOptions`, `Subscription`, the `Subscribe…Params` interfaces, …) are exported
-from `starknet`; see the [API documentation](/docs/next/API/classes/WebSocketChannel) for the full
+from `starknet`; see the [API documentation](../API/classes/WebSocketChannel) for the full
 list.

--- a/www/docusaurus.config.ts
+++ b/www/docusaurus.config.ts
@@ -356,6 +356,20 @@ const config: Config = {
 
   plugins: [
     [
+      '@docusaurus/plugin-client-redirects',
+      {
+        // Until 10.x became the default version, the current docs were served under
+        // /docs/next/. Keep those links alive by redirecting every /docs/next/* page to
+        // its /docs/* counterpart. Paths here are relative to `baseUrl`. Versioned
+        // snapshots (/docs/9.2.1/...) never lived under /docs/next/ and are skipped.
+        createRedirects(existingPath: string) {
+          const match = existingPath.match(/^\/docs\/(.+)$/);
+          if (!match || /^\d/.test(match[1])) return undefined;
+          return [`/docs/next/${match[1]}`];
+        },
+      },
+    ],
+    [
       'docusaurus-plugin-typedoc',
       {
         entryPoints: ['../src/index.ts'],

--- a/www/docusaurus.config.ts
+++ b/www/docusaurus.config.ts
@@ -205,6 +205,19 @@ const config: Config = {
       {
         docs: {
           sidebarPath: './sidebars.js',
+          // `www/docs` tracks the supported 10.x line, so it is the default version and
+          // served at /docs/. The frozen snapshots in `versions.json` are unsupported
+          // lines and are flagged as unmaintained. Update `current.label` when the next
+          // major becomes the development line, and set an explicit `banner` for every
+          // new snapshot added by the "[Manual] Documentation Version PR" workflow.
+          lastVersion: 'current',
+          versions: {
+            current: { label: '10.x', banner: 'none' },
+            '9.2.1': { banner: 'unmaintained' },
+            '8.6.0': { banner: 'unmaintained' },
+            '7.6.4': { banner: 'unmaintained' },
+            '6.24.1': { banner: 'unmaintained' },
+          },
           async sidebarItemsGenerator(args) {
             const sidebarItems = await args.defaultSidebarItemsGenerator(args);
 

--- a/www/package-lock.json
+++ b/www/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@docsearch/react": "^4.6.3",
         "@docusaurus/core": "3.10.1",
+        "@docusaurus/plugin-client-redirects": "3.10.1",
         "@docusaurus/plugin-content-docs": "3.10.1",
         "@docusaurus/preset-classic": "3.10.1",
         "@docusaurus/types": "3.10.1",
@@ -3627,6 +3628,30 @@
       "peerDependencies": {
         "react": "*",
         "react-dom": "*"
+      }
+    },
+    "node_modules/@docusaurus/plugin-client-redirects": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-client-redirects/-/plugin-client-redirects-3.10.1.tgz",
+      "integrity": "sha512-LHgd+YDvkhfOHMAE6XtUng3DQNzVM765RqVRrMJgHtzAvfopQhY6ieprqjxDVBdv21cLma6I0jHr+YCZH8fL9A==",
+      "license": "MIT",
+      "dependencies": {
+        "@docusaurus/core": "3.10.1",
+        "@docusaurus/logger": "3.10.1",
+        "@docusaurus/utils": "3.10.1",
+        "@docusaurus/utils-common": "3.10.1",
+        "@docusaurus/utils-validation": "3.10.1",
+        "eta": "^2.2.0",
+        "fs-extra": "^11.1.1",
+        "lodash": "^4.17.21",
+        "tslib": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@docusaurus/plugin-content-blog": {

--- a/www/package.json
+++ b/www/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@docsearch/react": "^4.6.3",
     "@docusaurus/core": "3.10.1",
+    "@docusaurus/plugin-client-redirects": "3.10.1",
     "@docusaurus/plugin-content-docs": "3.10.1",
     "@docusaurus/preset-classic": "3.10.1",
     "@docusaurus/types": "3.10.1",

--- a/www/versioned_docs/version-7.6.4/guides/websocket_channel.md
+++ b/www/versioned_docs/version-7.6.4/guides/websocket_channel.md
@@ -137,4 +137,4 @@ Each of these methods returns a `Promise<Subscription>`.
 - `subscribeTransactionStatus`
 - `subscribePendingTransaction`
 
-For more details, see the complete [API documentation](/docs/next/API/classes/WebSocketChannel).
+For more details, see the complete [API documentation](../API/classes/WebSocketChannel).

--- a/www/versioned_docs/version-8.6.0/guides/websocket_channel.md
+++ b/www/versioned_docs/version-8.6.0/guides/websocket_channel.md
@@ -385,4 +385,4 @@ async function main() {
 main().catch(console.error);
 ```
 
-For more details, see the complete [API documentation](/docs/next/API/classes/WebSocketChannel).
+For more details, see the complete [API documentation](../API/classes/WebSocketChannel).

--- a/www/versioned_docs/version-9.2.1/guides/websocket_channel.md
+++ b/www/versioned_docs/version-9.2.1/guides/websocket_channel.md
@@ -385,4 +385,4 @@ async function main() {
 main().catch(console.error);
 ```
 
-For more details, see the complete [API documentation](/docs/next/API/classes/WebSocketChannel).
+For more details, see the complete [API documentation](../API/classes/WebSocketChannel).


### PR DESCRIPTION
## Motivation and Resolution

On starknet-js.com the default docs version is 9.2.1, shown with no banner as if it were the maintained line, while the 10.x docs are labelled **Next** and carry an "unreleased documentation" banner. That is the reverse of the release state: 10.x is the supported line and 7.x, 8.x and 9.x are end-of-life (see #1702).

The cause is that the docs preset sets no `lastVersion`, so Docusaurus falls back to the first entry in `versions.json` (9.2.1) and treats the working docs as unreleased.

This PR:

- sets `lastVersion: 'current'` so `www/docs` (the 10.x line) becomes the default version at `/docs/`, labelled **10.x** in the version dropdown, with no banner;
- marks the 9.2.1, 8.6.0, 7.6.4 and 6.24.1 snapshots explicitly as `unmaintained`, so each page shows "This is documentation for Starknet.js X, which is no longer actively maintained" with a link to the 10.x docs. 6.x to 8.x already showed this by default; 9.2.1 did not;
- replaces the hard-coded `/docs/next/API/classes/WebSocketChannel` link in the WebSocket guide (current docs and the 7.6.4, 8.6.0 and 9.2.1 snapshots) with a relative link to the same version's own API page. The `next` path no longer exists after this change, so the absolute links would fail the `onBrokenLinks: 'throw'` check; the relative form matches how the other guides link into the API.
- adds `@docusaurus/plugin-client-redirects` (pinned to 3.10.1 like the other Docusaurus packages) with a `createRedirects` rule that emits a `/docs/next/*` redirect page for every current-docs route, so existing links to the old `next` URLs keep working. Versioned snapshot routes are skipped since they never lived under `/docs/next/`.

Verified with a local `npm run docs:build` using the production `DOCS_URL` and `DOCS_BASE_URL`.

### RPC version (if applicable)

N/A

## Usage related changes

- `/docs/...` now serves the 10.x documentation. 9.2.1 moves to `/docs/9.2.1/...`. Existing links to `/docs/next/...` redirect to the matching `/docs/...` page; links to `/docs/...` now land on the supported line, which is what the README, the announcement bar and the security policy point at.
- Readers of any 6.x to 9.x page see an unmaintained banner pointing to the 10.x docs.
- The version dropdown reads 10.x, 9.2.1, 8.6.0, 7.6.4, 6.24.1.

## Development related changes

- When the next major becomes the development line, update `versions.current.label` in `www/docusaurus.config.ts`. The `/docs/next/*` redirect rule should be dropped at the same time if `next` is reintroduced as a real path for the pre-release docs.
- When the "[Manual] Documentation Version PR" workflow adds a snapshot, add an explicit `banner` entry for it in the same `versions` block. Without one, Docusaurus infers `unmaintained` for anything older than `lastVersion`, so the default is safe, but explicit is clearer.
- Suggested follow-ups, not in this PR: the footer link labelled "Migrate to v9" is stale, and the 7.6.4 migration guide still carries absolute links to `starknetjs.com`, which now redirects to a third-party site.

## Checklist:

- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
- [ ] Linked the issues which this PR resolves (none; related to #1702)
- [x] Documented the changes in code (API docs will be generated automatically)
- [ ] Updated the tests: N/A, documentation site configuration only
- [x] All tests are passing (docs build passes locally; no library code changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
