### PR TITLE
docs(skill): update starknet.js skill for 10.8.0

### DIFF
--- a/skills/starknet-js/SKILL.md
+++ b/skills/starknet-js/SKILL.md
@@ -5,18 +5,18 @@ description: Use when writing or debugging JavaScript/TypeScript that interacts 
 
 # starknet.js
 
-Official JS/TS SDK for Starknet. This skill targets **starknet.js v10** (API valid for v9, mostly for v8).
+Official JS/TS SDK for Starknet. Skill verified against **starknet.js 10.8.0**.
 
-**Do not trust training-data memory of starknet.js**: it is typically v5/v6-era and wrong. Constructors now take option objects, only V3 transactions exist (STRK fees, no `maxFee`), and calldata helpers changed. When this skill and memory disagree, the skill wins.
+**Do not trust training-data memory of starknet.js**: it is typically outdated and wrong. Constructors take option objects, only V3 transactions exist (STRK fees, no `maxFee`). When this skill and memory disagree, the skill wins.
 
 Layer model: `Account` (signs & submits) wraps `RpcProvider` (parses, retries) wraps `RpcChannel` (raw JSON-RPC).
 
 ## Reference files
 
-- **[calldata.md](calldata.md)** — REQUIRED reading before encoding or decoding anything: Call/calldata construction, wire format of every Cairo type, enums (Option/Result/custom), ByteArray, string auto-detection traps, response parsing, `decodeParameters`. All examples verified against v10.4.0.
+- **[calldata.md](calldata.md)** — REQUIRED reading before encoding or decoding anything: Call/calldata construction, wire format of every Cairo type, enums (Option/Result/custom), ByteArray, string auto-detection traps, response parsing, `decodeParameters`.
 - **[interacting.md](interacting.md)** — providers, accounts, contracts, multicall, fees/tips, declare/deploy, receipts, events, RPC-version compatibility.
 
-## Non-negotiable v8+ rules
+## Non-negotiable rules
 
 - Only **V3** transactions (INVOKE/DECLARE/DEPLOY_ACCOUNT); fees paid in STRK via `resourceBounds` + `tip`. Never suggest `maxFee` or V1/V2.
 - Constructors take an options object: `new Account({ provider, address, signer })`, `new Contract({ abi, address, providerOrAccount })`, `new RpcProvider({ nodeUrl })`.

--- a/skills/starknet-js/calldata.md
+++ b/skills/starknet-js/calldata.md
@@ -1,6 +1,6 @@
 # Encoding & decoding Cairo values (Call / calldata)
 
-Every concrete output in this file was executed and verified against starknet.js v10.4.0.
+Every concrete output in this file was executed against starknet.js 10.8.0, not written from memory.
 
 ## Wire format
 
@@ -185,7 +185,7 @@ CallData.compile([new CairoOption(CairoOptionVariant.Some, 8)]); // ['0', '8']
 ```
 
 - **Property order matters** (no ABI to reorder objects). `{ low, high }` for u256, in that order.
-- **Custom enums: list ALL variants** (`undefined` for inactive ones) so the variant index can be derived from position, and **wrap the enum in an array** — `CallData.compile(myEnum)` passed directly (not `[myEnum]`) throws `undefined can't be computed by felt()` in v10:
+- **Custom enums: list ALL variants** (`undefined` for inactive ones) so the variant index can be derived from position, and **wrap the enum in an array** — `CallData.compile(myEnum)` passed directly (not `[myEnum]`) throws `undefined can't be computed by felt()`:
   ```ts
   const en = new CairoCustomEnum({
     Response: undefined,
@@ -218,6 +218,24 @@ CallData.compile([new CairoOption(CairoOptionVariant.Some, 8)]); // ['0', '8']
 - `felt252` returns a `bigint` even when it holds text. Decode text manually: `shortString.decodeShortString(num.toHex(value))`.
 - A Cairo 1 function returning several values returns a tuple → object with `'0'`, `'1'`… keys.
 - Cairo 0 contracts return objects keyed by output names (e.g. `res.balance`).
+
+### Signed integers: `parsingStrategy`
+
+`i8…i128` decode to a **negative `bigint`**, converted back from `P` — that is what the default
+strategy does. The alternative strategy returns the raw felt instead, silently flipping the sign of
+every downstream comparison, balance or P&L computation. A view function returning `-5`:
+
+```ts
+const wire = (P - 5n).toString(); // how -5 travels on the wire
+new CallData(abi).decodeParameters('core::integer::i32', [wire]); // -5n  ← default
+new CallData(abi, hdParsingStrategy).decodeParameters('core::integer::i32', [wire]); // -5n
+new CallData(abi, fastParsingStrategy).decodeParameters('core::integer::i32', [wire]);
+// 3618502788666131213697322783095070105623107215331596699973092056135872020476n  ← raw felt
+```
+
+- `parsingStrategy` is accepted by `new CallData(abi, strategy)` and `new Contract({ …, parsingStrategy })`.
+- The default is `hdParsingStrategy`. Never select `fastParsingStrategy` for a contract exposing
+  signed integers.
 
 ### Decode arbitrary felts: `decodeParameters`
 
@@ -308,7 +326,7 @@ uint256.uint256ToBN({ low, high }); // bigint
 | Prepending `array_len` before an array                   | The library adds length prefixes; a stray `_len` property is ignored/rejected                      |
 | Plain bigint for u256 in static `CallData.compile`       | Encodes 1 felt; use `cairo.uint256()` or `{ low, high }`                                           |
 | `new CairoCustomEnum({ Active: v })` in static compile   | Variant index unknowable without ABI — list all variants; with ABI the single-variant form is fine |
-| `CallData.compile(myEnum)` un-wrapped                    | Throws in v10 — wrap: `CallData.compile([myEnum])`                                                 |
+| `CallData.compile(myEnum)` un-wrapped                    | Throws — wrap: `CallData.compile([myEnum])`                                                        |
 | Passing `'123'` expecting text                           | Numeric-looking strings become numbers; use `encodeShortString`                                    |
 | JS array for `[T; N]` in static compile                  | Gets a length prefix; use `CairoFixedArray.compile([...])`                                         |
 | Expecting `string` from a `felt252` return               | You get `bigint`; decode with `shortString.decodeShortString(num.toHex(v))`                        |

--- a/skills/starknet-js/interacting.md
+++ b/skills/starknet-js/interacting.md
@@ -1,11 +1,11 @@
-# Providers, accounts, contracts, transactions (starknet.js v10)
+# Providers, accounts, contracts, transactions
 
 ## RpcProvider
 
 ```ts
 import { RpcProvider, constants, BlockTag } from 'starknet';
 
-const provider = new RpcProvider({ nodeUrl: 'https://…/rpc/v0_10' }); // default channel: RPC 0.10
+const provider = new RpcProvider({ nodeUrl: 'https://…/rpc/v0_10' }); // default channel: RPC 0.10.4
 const provider09 = new RpcProvider({ nodeUrl: '…/rpc/v0_9', specVersion: '0.9.0' });
 const auto = await RpcProvider.create({ nodeUrl }); // queries the node, picks the right channel
 const sepolia = new RpcProvider(); // random public Sepolia node
@@ -13,7 +13,7 @@ const mainnet = new RpcProvider({ nodeUrl: constants.NetworkName.SN_MAIN });
 ```
 
 - The constructor does NOT read the RPC version from the URL: pass `specVersion` or use `RpcProvider.create()`.
-- v10 talks RPC spec **0.9 and 0.10** (v8: 0.8/0.9; v7: 0.7/0.8). Devnet: `http://127.0.0.1:5050/rpc`.
+- Supported RPC specs: **0.9.0, 0.10.0, 0.10.2, 0.10.3, 0.10.4**. Devnet: `http://127.0.0.1:5050/rpc`.
 - Useful: `getSpecVersion()`, `getBlock('latest')`, `getClassAt(addr)` (→ `{ abi }`), `getNonceForAddress`, `getEvents`, `waitForTransaction`.
 - Batching: `new RpcProvider({ batch: 0 })` merges concurrent requests into one HTTP call.
 - Errors: `catch (e) { if (e instanceof RpcError && e.isType('CONTRACT_NOT_FOUND')) … }`.
@@ -65,7 +65,7 @@ const myContract = new Contract({
 - Write: `const { transaction_hash } = await myContract.transfer(to, amount);` then `waitForTransaction`.
 - `myContract.withOptions({ blockIdentifier, tip, resourceBounds, parseRequest, parseResponse, formatResponse, waitForTransaction }).fn(args)` — applies to the **next call only**. With `waitForTransaction: true`, `invoke` waits and returns the successful receipt (throws on failure).
 - `myContract.estimateFee.transfer(to, amount)` → `{ resourceBounds, … }`.
-- `myContract.populate('fn', args)` → `Call` for multicall; `myContract.compile('fn', args)` → `Calldata` (v10).
+- `myContract.populate('fn', args)` → `Call` for multicall; `myContract.compile('fn', args)` → `Calldata`.
 - Dynamic name: `await myContract[fnName](...args)`. Check deployment: `await myContract.isDeployed()`.
 - Typed ABI (autocompletion): `const typed = myContract.typedv2(myAbiAsConst);` (abi-wan-kanabi).
 
@@ -147,11 +147,14 @@ shortString / byteArray / cairo / uint256; // see calldata.md
 
 ## Version compatibility (node RPC spec ↔ starknet.js)
 
-| RPC spec | starknet.js       |
-| -------- | ----------------- |
-| 0.7.x    | v6 / v7           |
-| 0.8.x    | v7 / v8           |
-| 0.9.x    | v8 / v9 / v10     |
-| 0.10.x   | v9 (0.10.0) / v10 |
+| RPC spec | starknet.js    |
+| -------- | -------------- |
+| 0.7.x    | v6 / v7        |
+| 0.8.x    | v7 / v8        |
+| 0.9.x    | v8 / v9 / v10  |
+| 0.10.0   | v9 / v10       |
+| 0.10.2   | v10 (≥ 10.0.0) |
+| 0.10.3   | v10 (≥ 10.1.0) |
+| 0.10.4   | v10 (≥ 10.8.0) |
 
-Starknet ≥ 0.14 (v8+): V3-only transactions, pre-confirmed block state, mandatory tips.
+Starknet ≥ 0.14: V3-only transactions, pre-confirmed block state, mandatory tips.


### PR DESCRIPTION
## Motivation and Resolution

`skills/starknet-js/` had not been touched since the commit that added it (2026-07-12), when the library was at 10.5.0. Because `npx skills add starknet-io/starknet.js` resolves to the repository's default branch, every install since then has been shipping content frozen three minor versions behind.

This PR realigns the skill with 10.8.0 and settles how it should be versioned.

Two decisions shape the diff:

- **The skill describes a single state — the tip of `develop` — never the library's history.** Markers such as "targets v10", "throws in v10", "Non-negotiable v8+ rules" and "Constructors now take option objects" are removed: a document that always tracks the newest commit cannot also narrate what changed and when. The deliberate exception is the RPC spec ↔ starknet.js compatibility table, which describes the *node* — third-party software the user does not control — and therefore still needs a matrix.
- **A hand-written version stamp is kept**, worded "verified against starknet.js 10.8.0". It records a past act instead of promising a present state, so it does not silently become false at the next release. The previous stamp claimed v10.4.0 while the files were in fact published at 10.5.0 — it was already wrong the day it shipped.

One substantive gap was found and filled: **signed integers**. The skill documented `i8…i128` as decoding to `bigint` but never mentioned `parsingStrategy`, even though selecting `fastParsingStrategy` returns the raw felt for a negative value (`3618502788…020476n` instead of `-5n`), silently flipping the sign of any downstream comparison or balance computation. This is the surface behind GHSA-mv8m-rfr4-jcq8, whose default was corrected in 10.7.5; the skill now states the current behaviour and warns against the alternative strategy.

### RPC version (if applicable)

The skill now reflects the RPC support actually present in `src/`: supported specs are **0.9.0, 0.10.0, 0.10.2, 0.10.3 and 0.10.4**, and the default channel is **0.10.4** (the provider only ever instantiates `RPC09` or `RPC0104`). The compatibility table's single `0.10.x` row is split into one row per revision, with the release that introduced each: 0.10.2 → 10.0.0, 0.10.3 → 10.1.0, 0.10.4 → 10.8.0.

## Usage related changes

- No library code is touched; this PR changes only the published agent skill.
- Agents installing the skill now get correct RPC spec and default-channel information instead of a coarse "RPC 0.9 and 0.10".
- Agents are now warned about `parsingStrategy` and will no longer suggest `fastParsingStrategy` for contracts exposing signed integers.
- The skill no longer carries version archaeology, so it stops contradicting itself as the library moves.

## Development related changes

- `AGENTS.md` already requires contributors to check the skill when the public API surface changes; this PR is the overdue application of that rule, not a change to it.
- Verification performed: the skill's offline self-test (`verify.mts`, which asserts every concrete encoding/decoding output in `calldata.md`) was re-run against the 10.8.0 build — **all checks passed**, confirming no drift in the existing examples. The three signed-integer outputs added to `calldata.md` were executed, not estimated. `prettier --check` passes on all three files.
- `npm test` was not run: this change touches documentation only and no test file.

## Checklist:

- [x] Performed a self-review of the code
- [x] Rebased to the last commit of the target branch (or merged it into my branch)
