### PR TITLE
feat(provider): support nodeName option in RpcProvider and RpcChannel

### DIFF
--- a/__tests__/utils/provider.test.ts
+++ b/__tests__/utils/provider.test.ts
@@ -1,0 +1,33 @@
+import { constants, RPC09, RPC0104, RpcProvider } from '../../src';
+
+describe('RpcProvider & RpcChannel nodeName / nodeUrl configuration', () => {
+  test('resolves nodeUrl from nodeName using NetworkName', () => {
+    const provider = new RpcProvider({ nodeName: constants.NetworkName.SN_MAIN });
+    expect(provider.channel.nodeUrl).toContain('mainnet');
+
+    const channel09 = new RPC09.RpcChannel({ nodeName: constants.NetworkName.SN_SEPOLIA });
+    expect(channel09.nodeUrl).toContain('sepolia');
+
+    const channel010 = new RPC0104.RpcChannel({ nodeName: constants.NetworkName.SN_MAIN });
+    expect(channel010.nodeUrl).toContain('mainnet');
+  });
+
+  test('prioritizes explicit nodeName when both nodeName and nodeUrl are provided', () => {
+    const channel = new RPC09.RpcChannel({
+      nodeName: constants.NetworkName.SN_SEPOLIA,
+      nodeUrl: 'https://custom.rpc.node',
+    });
+    expect(channel.nodeUrl).toContain('sepolia');
+  });
+
+  test('preserves backwards compatibility with NetworkName passed as nodeUrl', () => {
+    const provider = new RpcProvider({ nodeUrl: constants.NetworkName.SN_MAIN });
+    expect(provider.channel.nodeUrl).toContain('mainnet');
+  });
+
+  test('uses explicit URL string passed as nodeUrl', () => {
+    const customUrl = 'https://my-custom-rpc-node.example.com/rpc/v0_9';
+    const provider = new RpcProvider({ nodeUrl: customUrl });
+    expect(provider.channel.nodeUrl).toBe(customUrl);
+  });
+});

--- a/src/channel/rpc_0_10_2.ts
+++ b/src/channel/rpc_0_10_2.ts
@@ -91,13 +91,16 @@ export class RpcChannel {
       blockIdentifier,
       chainId,
       headers,
+      nodeName,
       nodeUrl,
       retries,
       specVersion,
       transactionRetryIntervalFallback,
       waitMode,
     } = optionsOrProvider || {};
-    if (Object.values(NetworkName).includes(nodeUrl as NetworkName)) {
+    if (nodeName && Object.values(NetworkName).includes(nodeName)) {
+      this.nodeUrl = getDefaultNodeUrl(nodeName, this.channelSpecVersion);
+    } else if (Object.values(NetworkName).includes(nodeUrl as NetworkName)) {
       this.nodeUrl = getDefaultNodeUrl(nodeUrl as NetworkName, this.channelSpecVersion);
     } else if (nodeUrl) {
       this.nodeUrl = nodeUrl;

--- a/src/channel/rpc_0_9_0.ts
+++ b/src/channel/rpc_0_9_0.ts
@@ -91,13 +91,16 @@ export class RpcChannel {
       blockIdentifier,
       chainId,
       headers,
+      nodeName,
       nodeUrl,
       retries,
       specVersion,
       transactionRetryIntervalFallback,
       waitMode,
     } = optionsOrProvider || {};
-    if (Object.values(NetworkName).includes(nodeUrl as NetworkName)) {
+    if (nodeName && Object.values(NetworkName).includes(nodeName)) {
+      this.nodeUrl = getDefaultNodeUrl(nodeName, this.channelSpecVersion);
+    } else if (Object.values(NetworkName).includes(nodeUrl as NetworkName)) {
       this.nodeUrl = getDefaultNodeUrl(nodeUrl as NetworkName, this.channelSpecVersion);
     } else if (nodeUrl) {
       this.nodeUrl = nodeUrl;

--- a/src/provider/types/configuration.type.ts
+++ b/src/provider/types/configuration.type.ts
@@ -8,6 +8,10 @@ export interface ProviderOptions extends RpcProviderOptions {}
 export type RpcProviderOptions = {
   nodeUrl?: string | NetworkName;
   /**
+   * Specify network name to resolve default node URL (e.g. SN_MAIN, SN_SEPOLIA)
+   */
+  nodeName?: NetworkName;
+  /**
    * Define the number of retries for waitForTransaction
    */
   retries?: waitForTransactionOptions['retries'];


### PR DESCRIPTION
Fixes #1303

## Problem
`RpcProvider` and `RpcChannel` accepted network names (e.g. `constants.NetworkName.SN_MAIN`) passed via the `nodeUrl` option. While convenient, the prop name `nodeUrl` implies an HTTP(S) URL, creating a semantic mismatch when passing a network identifier instead of an actual URL endpoint.

## Solution
- Added `nodeName?: NetworkName` to `RpcProviderOptions`.
- Updated `RpcChannel` (both v0.9 and v0.10 implementations) to check `nodeName` first and resolve it to the default RPC URL via `getDefaultNodeUrl`.
- Retained full backwards compatibility for callers passing `NetworkName` via `nodeUrl`.

## Testing
Added unit test suite in `__tests__/utils/provider.test.ts` asserting:
1. `nodeName` correctly resolves to the expected network URL on both `RpcProvider` and `RpcChannel`.
2. Explicit `nodeName` takes precedence when provided.
3. Passing `NetworkName` as `nodeUrl` continues to resolve as before.
4. Custom string URLs in `nodeUrl` continue to work unchanged.